### PR TITLE
Validate object in `obj.toString()` case

### DIFF
--- a/crates/stc_ts_file_analyzer/src/analyzer/expr/call_new.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/expr/call_new.rs
@@ -363,6 +363,9 @@ impl Analyzer<'_, '_> {
                 ..
             }) => {
                 let prop = self.validate_key(prop, computed)?;
+
+                // Validate object
+                let mut obj_type = obj.validate_with_default(self)?.generalize_lit();
                 {
                     // Handle toString()
 
@@ -376,7 +379,6 @@ impl Analyzer<'_, '_> {
                 }
 
                 // Handle member expression
-                let mut obj_type = obj.validate_with_default(self)?.generalize_lit();
                 obj_type.make_clone_cheap();
 
                 let obj_type = match *obj_type.normalize() {

--- a/crates/stc_ts_file_analyzer/tests/pass/class/inheritance/methods-from-object-1.swc-stderr
+++ b/crates/stc_ts_file_analyzer/tests/pass/class/inheritance/methods-from-object-1.swc-stderr
@@ -2,6 +2,14 @@ warning: Type
  --> $DIR/tests/pass/class/inheritance/methods-from-object-1.ts:4:16
   |
 4 | export var r = c.toString();
+  |                ^
+  |
+  = note: C
+
+warning: Type
+ --> $DIR/tests/pass/class/inheritance/methods-from-object-1.ts:4:16
+  |
+4 | export var r = c.toString();
   |                ^^^^^^^^^^^^
   |
   = note: string

--- a/crates/stc_ts_file_analyzer/tests/pass/fn/args/contextuallyTypedBindingInitializer-1.swc-stderr
+++ b/crates/stc_ts_file_analyzer/tests/pass/fn/args/contextuallyTypedBindingInitializer-1.swc-stderr
@@ -2,6 +2,14 @@ warning: Type
  --> $DIR/tests/pass/fn/args/contextuallyTypedBindingInitializer-1.ts:5:33
   |
 5 | export function f({ show = v => v.toString() }: Show) { }
+  |                                 ^
+  |
+  = note: number
+
+warning: Type
+ --> $DIR/tests/pass/fn/args/contextuallyTypedBindingInitializer-1.ts:5:33
+  |
+5 | export function f({ show = v => v.toString() }: Show) { }
   |                                 ^^^^^^^^^^^^
   |
   = note: string


### PR DESCRIPTION
Correctly type check expressions like:
```ts
let a: string = notDefined.toString();
```
```
error[TS2304]: NoSuchVar {
    span: Span {
        lo: BytePos(
            18,
        ),
        hi: BytePos(
            28,
        ),
        ctxt: #0,
    },
    name: notDefined#1,
}
 --> a.ts:1:17
  |
1 | let a: string = notDefined.toString();
```



This is one of the false positive I'm hitting to get `tests/conformance/controlFlowNullishCoalesce.ts` to work.