### PR TITLE
Check reserved identifiers in function params

### DIFF
--- a/crates/stc_ts_errors/src/lib.rs
+++ b/crates/stc_ts_errors/src/lib.rs
@@ -1088,6 +1088,11 @@ pub enum Error {
         span: Span,
     },
 
+    /// TS1359
+    ExpectedIdentifierReservedKeyword {
+        span: Span,
+    },
+
     TS1166 {
         span: Span,
     },
@@ -1517,6 +1522,7 @@ impl Error {
             Error::TS2370 { .. } => 2370,
             Error::WrongOverloadSignature { .. } => 2394,
             Error::TS1166 { .. } => 1166,
+            Error::ExpectedIdentifierReservedKeyword { .. } => 1359,
             Error::TS1345 { .. } => 1345,
             Error::TS2353 { .. } => 2353,
             Error::ConstructorImplMissingOrNotFollowedByDecl { .. } => 2390,

--- a/crates/stc_ts_type_checker/tests/conformance.pass.txt
+++ b/crates/stc_ts_type_checker/tests/conformance.pass.txt
@@ -52,6 +52,7 @@ async/es2017/functionDeclarations/asyncFunctionDeclaration1_es2017.ts
 async/es2017/functionDeclarations/asyncFunctionDeclaration2_es2017.ts
 async/es2017/functionDeclarations/asyncFunctionDeclaration3_es2017.ts
 async/es2017/functionDeclarations/asyncFunctionDeclaration4_es2017.ts
+async/es2017/functionDeclarations/asyncFunctionDeclaration5_es2017.ts
 async/es2017/functionDeclarations/asyncFunctionDeclaration8_es2017.ts
 async/es5/asyncArrowFunction/arrowFunctionWithParameterNameAsync_es5.ts
 async/es5/asyncArrowFunction/asyncArrowFunction10_es5.ts

--- a/crates/stc_ts_type_checker/tests/tsc.rs
+++ b/crates/stc_ts_type_checker/tests/tsc.rs
@@ -216,6 +216,11 @@ fn create_test(path: PathBuf) -> Option<Box<dyn FnOnce() + Send + Sync>> {
 
     if let Ok(errors) = load_expected_errors(&path) {
         for err in errors {
+            // Don't ignore certain TS1 tests
+            if err.code == "TS1359" {
+                continue;
+            }
+
             if err.code.starts_with("TS1") && err.code.len() == 6 {
                 return None;
             }


### PR DESCRIPTION
Adds TS1359 validation for function parameter identifiers.

```
error[TS1359]: ExpectedIdentifierReservedKeyword {
    span: Span {
        lo: BytePos(
            21,
        ),
        hi: BytePos(
            26,
        ),
        ctxt: #0,
    },
}
 --> a.ts:1:20
  |
1 | async function foo(await): Promise<void> {
  |                    ^^^^^
```

New passing conforming tests:
```
async/es2017/functionDeclarations/asyncFunctionDeclaration5_es2017.ts
```
