### PR TITLE
feat(ts/analyzer): Context aware reserved keyword handling

### DIFF
--- a/a.ts
+++ b/a.ts
@@ -1,0 +1,5 @@
+
+
+function yieldString() {
+    yield;
+}

--- a/crates/stc_ts_errors/src/lib.rs
+++ b/crates/stc_ts_errors/src/lib.rs
@@ -1092,6 +1092,10 @@ pub enum Error {
         span: Span,
     },
 
+    TS1212 {
+        span: Span,
+    },
+
     TS1345 {
         span: Span,
     },

--- a/crates/stc_ts_file_analyzer/src/analyzer/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/mod.rs
@@ -844,6 +844,8 @@ impl Analyzer<'_, '_> {
                 self.report_error_for_wrong_top_level_ambient_fns(&m.body);
             }
 
+            self.report_error_for_wrong_yield(&m.body);
+
             if self.is_builtin {
                 m.body.visit_children_with(self);
             } else {

--- a/crates/stc_ts_file_analyzer/src/analyzer/stmt/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/stmt/mod.rs
@@ -23,6 +23,7 @@ mod loops;
 pub(crate) mod return_type;
 mod try_catch;
 mod var_decl;
+mod r#yield;
 
 #[validator]
 impl Analyzer<'_, '_> {

--- a/crates/stc_ts_file_analyzer/src/analyzer/stmt/return_type.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/stmt/return_type.rs
@@ -5,7 +5,7 @@ use stc_ts_ast_rnode::{
     RBreakStmt, RIdent, RReturnStmt, RStmt, RStr, RThrowStmt, RTsEntityName, RTsLit, RYieldExpr,
 };
 use stc_ts_errors::{DebugExt, Error};
-use stc_ts_simple_ast_validations::yield_check::YieldValueUsageFinder;
+use stc_ts_simple_ast_validations::yield_finder::YieldValueUsageFinder;
 use stc_ts_types::{
     CommonTypeMetadata, IndexedAccessType, Key, KeywordType, KeywordTypeMetadata, LitType,
     MethodSignature, ModuleId, Operator, PropertySignature, Ref, RefMetadata, TypeElement,

--- a/crates/stc_ts_file_analyzer/src/analyzer/stmt/yield.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/stmt/yield.rs
@@ -1,0 +1,20 @@
+use rnode::VisitWith;
+use stc_ts_ast_rnode::RModuleItem;
+use stc_ts_simple_ast_validations::yield_check::YieldCheck;
+
+use crate::analyzer::Analyzer;
+
+impl Analyzer<'_, '_> {
+    pub(crate) fn report_error_for_wrong_yield(&mut self, nodes: &[RModuleItem]) {
+        if self.is_builtin {
+            return;
+        }
+
+        let mut visitor = YieldCheck {
+            in_generator: self.ctx.in_generator,
+            errors: &mut self.storage,
+        };
+
+        nodes.visit_with(&mut visitor);
+    }
+}

--- a/crates/stc_ts_simple_ast_validations/src/lib.rs
+++ b/crates/stc_ts_simple_ast_validations/src/lib.rs
@@ -9,4 +9,5 @@
 
 pub mod ambient_fn;
 pub mod consturctor;
+pub mod yield_finder;
 pub mod yield_check;

--- a/crates/stc_ts_simple_ast_validations/src/yield_finder.rs
+++ b/crates/stc_ts_simple_ast_validations/src/yield_finder.rs
@@ -1,0 +1,43 @@
+use rnode::{Visit, VisitWith};
+use stc_ts_ast_rnode::{RArrowExpr, RAssignExpr, RExpr, RFunction, RVarDeclarator};
+
+#[derive(Default)]
+pub struct YieldValueUsageFinder {
+    pub found: bool,
+}
+
+impl Visit<RAssignExpr> for YieldValueUsageFinder {
+    fn visit(&mut self, e: &RAssignExpr) {
+        e.visit_children_with(self);
+
+        match &*e.right {
+            RExpr::Yield(..) => {
+                self.found = true;
+            }
+            _ => {}
+        }
+    }
+}
+
+impl Visit<RVarDeclarator> for YieldValueUsageFinder {
+    fn visit(&mut self, v: &RVarDeclarator) {
+        v.visit_children_with(self);
+
+        match v.init.as_deref() {
+            Some(RExpr::Yield(..)) => {
+                self.found = true;
+            }
+            _ => {}
+        }
+    }
+}
+
+/// noop
+impl Visit<RArrowExpr> for YieldValueUsageFinder {
+    fn visit(&mut self, _: &RArrowExpr) {}
+}
+
+/// noop
+impl Visit<RFunction> for YieldValueUsageFinder {
+    fn visit(&mut self, _: &RFunction) {}
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -126,7 +126,7 @@ fn main() -> Result<(), Error> {
             let mut errors = vec![];
 
             let start = Instant::now();
-            for _ in 0..1000 {
+            for _ in 0..1 {
                 let mut checker = Checker::new(
                     cm.clone(),
                     handler.clone(),


### PR DESCRIPTION
Implements AST validation for `yield` and `await` based on context (TS1212)

```
error[TS0]: TS1212 {
    span: Span {
        lo: BytePos(
            33,
        ),
        hi: BytePos(
            38,
        ),
        ctxt: #1,
    },
}
 --> a.ts:4:5
  |
4 |     yield;
  |     ^^^^^

error[TS2304]: NoSuchVar {
    span: Span {
        lo: BytePos(
            33,
        ),
        hi: BytePos(
            38,
        ),
        ctxt: #0,
    },
    name: yield#1,
}
 --> a.ts:4:5
  |
4 |     yield;
  |     ^^^^^
``` 