### PR TITLE
feat(ts/analyzer): delete operand must be optional

### DIFF
--- a/crates/stc_ts_file_analyzer/src/analyzer/expr/unary.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/expr/unary.rs
@@ -214,7 +214,15 @@ impl Analyzer<'_, '_> {
                 ..
             }) => Err(Error::CannotDeletePrivateProperty { span }),
 
-            RExpr::Member(..) => return Ok(()),
+            RExpr::Member(me) => {
+                if self.rule().strict_null_checks {
+                    let ty = self.type_of_member_expr(me, TypeOfMode::RValue)?;
+                    if !self.can_be_undefined(span, &ty)? {
+                        return Err(Error::DeleteOperandMustBeOptional { span });
+                    }
+                }
+                return Ok(());
+            }
 
             RExpr::Await(..) => Err(Error::InvalidDeleteOperand { span }),
 

--- a/crates/stc_ts_type_checker/tests/conformance.pass.txt
+++ b/crates/stc_ts_type_checker/tests/conformance.pass.txt
@@ -278,6 +278,7 @@ controlFlow/controlFlowBinaryAndExpression.ts
 controlFlow/controlFlowBindingPatternOrder.ts
 controlFlow/controlFlowCommaOperator.ts
 controlFlow/controlFlowConditionalExpression.ts
+controlFlow/controlFlowDeleteOperator.ts
 controlFlow/controlFlowDestructuringDeclaration.ts
 controlFlow/controlFlowDoWhileStatement.ts
 controlFlow/controlFlowElementAccess.ts

--- a/crates/stc_ts_type_checker/tests/tsc-stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/tsc-stats.rust-debug
@@ -1,5 +1,5 @@
 Stats {
-    required_error: 4159,
-    matched_error: 5536,
-    extra_error: 1024,
+    required_error: 4158,
+    matched_error: 5537,
+    extra_error: 1015,
 }


### PR DESCRIPTION
```ts
let x: { a?: number | string, b: number | string } = { b: 1 };
delete x.a;
delete x.b;
```

```
error[TS2790]: DeleteOperandMustBeOptional {
    span: Span {
        lo: BytePos(
            85,
        ),
        hi: BytePos(
            88,
        ),
        ctxt: #0,
    },
}
 --> a.ts:4:8
  |
4 | delete x.b;
  |        ^^^
```

See https://github.com/microsoft/TypeScript/pull/37921