### PR TITLE
fix(ts/analyzer): Fix assignment of function paramters

### DIFF
--- a/crates/stc_ts_file_analyzer/src/analyzer/assign/function.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/assign/function.rs
@@ -380,7 +380,7 @@ impl Analyzer<'_, '_> {
 
         // TypeScript functions are bivariant if strict_function_types is false.
         if !self.env.rule().strict_function_types {
-            if self.assign_params(data, opts, &l_params, &r_params).is_ok() {
+            if self.assign_params(data, opts, &r_params, &l_params).is_ok() {
                 return Ok(());
             }
         }

--- a/crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs
@@ -58,7 +58,7 @@ pub(crate) struct AssignOpts {
     /// ```
     pub allow_unknown_type: bool,
 
-    /// Allow assignmnet to [Type::Param].
+    /// Allow assignment to [Type::Param].
     pub allow_assignment_to_param: bool,
 
     pub allow_assignment_of_param: bool,

--- a/crates/stc_ts_file_analyzer/src/analyzer/assign/tests.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/assign/tests.rs
@@ -39,6 +39,7 @@ fn type_lit_1() {
 }
 
 #[test]
+#[ignore = "Predicate validation is not implemented yet"]
 fn array_filter_1() {
     test_assign(
         "(value: string, index: number, array: string[]) => value is string",

--- a/crates/stc_ts_file_analyzer/src/analyzer/assign/tests.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/assign/tests.rs
@@ -37,3 +37,36 @@ fn type_lit_1() {
         Default::default(),
     );
 }
+
+#[test]
+fn array_filter_1() {
+    test_assign(
+        "(value: string, index: number, array: string[]) => value is string",
+        "(x: string) => boolean;",
+        false,
+        Default::default(),
+    );
+    test_assign(
+        "(x: string) => boolean;",
+        "(value: string, index: number, array: string[]) => value is string",
+        false,
+        Default::default(),
+    );
+}
+
+/// Without type predicate
+#[test]
+fn array_filter_2() {
+    test_assign(
+        "(value: string, index: number, array: string[]) => boolean",
+        "(x: string) => boolean;",
+        true,
+        Default::default(),
+    );
+    test_assign(
+        "(x: string) => boolean;",
+        "(value: string, index: number, array: string[]) => boolean",
+        false,
+        Default::default(),
+    );
+}

--- a/crates/stc_ts_file_analyzer/tests/base.rs
+++ b/crates/stc_ts_file_analyzer/tests/base.rs
@@ -386,9 +386,9 @@ fn run_test(file_name: PathBuf, for_error: bool) -> Option<NormalizedOutput> {
                 if !line.starts_with("//@") {
                     continue;
                 }
-                let line = &line["//@".len()..];
+                let line = &line["//@".len()..].trim();
                 if line.starts_with("strict:") {
-                    let value = line["strict:".len()..].parse::<bool>().unwrap();
+                    let value = line["strict:".len()..].trim().parse::<bool>().unwrap();
                     rule.strict_function_types = value;
                     rule.strict_null_checks = value;
                     continue;

--- a/crates/stc_ts_file_analyzer/tests/pass/types/inference/genericContextualTypes1/1.swc-stderr
+++ b/crates/stc_ts_file_analyzer/tests/pass/types/inference/genericContextualTypes1/1.swc-stderr
@@ -1,0 +1,40 @@
+warning: Type
+ --> $DIR/tests/pass/types/inference/genericContextualTypes1/1.ts:3:69
+  |
+3 | export const arrayMap = <T, U>(f: (x: T) => U) => (a: T[]) => a.map(f);
+  |                                                                     ^
+  |
+  = note: (x: T) => U
+
+warning: Type
+ --> $DIR/tests/pass/types/inference/genericContextualTypes1/1.ts:3:63
+  |
+3 | export const arrayMap = <T, U>(f: (x: T) => U) => (a: T[]) => a.map(f);
+  |                                                               ^
+  |
+  = note: T[]
+
+warning: Type
+ --> $DIR/tests/pass/types/inference/genericContextualTypes1/1.ts:3:63
+  |
+3 | export const arrayMap = <T, U>(f: (x: T) => U) => (a: T[]) => a.map(f);
+  |                                                               ^^^^^^^^
+  |
+  = note: U[]
+
+warning: Type
+ --> $DIR/tests/pass/types/inference/genericContextualTypes1/1.ts:3:51
+  |
+3 | export const arrayMap = <T, U>(f: (x: T) => U) => (a: T[]) => a.map(f);
+  |                                                   ^^^^^^^^^^^^^^^^^^^^
+  |
+  = note: (a: T[]) => U[]
+
+warning: Type
+ --> $DIR/tests/pass/types/inference/genericContextualTypes1/1.ts:3:25
+  |
+3 | export const arrayMap = <T, U>(f: (x: T) => U) => (a: T[]) => a.map(f);
+  |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |
+  = note: <T, U>(f: (x: T) => U) => (a: T[]) => U[]
+

--- a/crates/stc_ts_file_analyzer/tests/pass/types/inference/genericContextualTypes1/1.ts
+++ b/crates/stc_ts_file_analyzer/tests/pass/types/inference/genericContextualTypes1/1.ts
@@ -1,4 +1,3 @@
-// @strict: true
-// @declaration: true
+//@strict: true
 
 export const arrayMap = <T, U>(f: (x: T) => U) => (a: T[]) => a.map(f);

--- a/crates/stc_ts_file_analyzer/tests/pass/types/inference/genericContextualTypes1/1.ts
+++ b/crates/stc_ts_file_analyzer/tests/pass/types/inference/genericContextualTypes1/1.ts
@@ -1,0 +1,4 @@
+// @strict: true
+// @declaration: true
+
+export const arrayMap = <T, U>(f: (x: T) => U) => (a: T[]) => a.map(f);

--- a/crates/stc_ts_file_analyzer/tests/pass/types/inference/genericContextualTypes1/2.swc-stderr
+++ b/crates/stc_ts_file_analyzer/tests/pass/types/inference/genericContextualTypes1/2.swc-stderr
@@ -1,0 +1,40 @@
+warning: Type
+ --> $DIR/tests/pass/types/inference/genericContextualTypes1/2.ts:3:78
+  |
+3 | export const arrayFilter = <T>(f: (x: T) => boolean) => (a: T[]) => a.filter(f);
+  |                                                                              ^
+  |
+  = note: (x: T) => boolean
+
+warning: Type
+ --> $DIR/tests/pass/types/inference/genericContextualTypes1/2.ts:3:69
+  |
+3 | export const arrayFilter = <T>(f: (x: T) => boolean) => (a: T[]) => a.filter(f);
+  |                                                                     ^
+  |
+  = note: T[]
+
+warning: Type
+ --> $DIR/tests/pass/types/inference/genericContextualTypes1/2.ts:3:69
+  |
+3 | export const arrayFilter = <T>(f: (x: T) => boolean) => (a: T[]) => a.filter(f);
+  |                                                                     ^^^^^^^^^^^
+  |
+  = note: T[]
+
+warning: Type
+ --> $DIR/tests/pass/types/inference/genericContextualTypes1/2.ts:3:57
+  |
+3 | export const arrayFilter = <T>(f: (x: T) => boolean) => (a: T[]) => a.filter(f);
+  |                                                         ^^^^^^^^^^^^^^^^^^^^^^^
+  |
+  = note: (a: T[]) => T[]
+
+warning: Type
+ --> $DIR/tests/pass/types/inference/genericContextualTypes1/2.ts:3:28
+  |
+3 | export const arrayFilter = <T>(f: (x: T) => boolean) => (a: T[]) => a.filter(f);
+  |                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |
+  = note: <T>(f: (x: T) => boolean) => (a: T[]) => T[]
+

--- a/crates/stc_ts_file_analyzer/tests/pass/types/inference/genericContextualTypes1/2.ts
+++ b/crates/stc_ts_file_analyzer/tests/pass/types/inference/genericContextualTypes1/2.ts
@@ -1,5 +1,4 @@
-// @strict: true
-// @declaration: true
+//@strict: true
 
 export const arrayFilter = <T>(f: (x: T) => boolean) => (a: T[]) => a.filter(f);
 

--- a/crates/stc_ts_file_analyzer/tests/pass/types/inference/genericContextualTypes1/2.ts
+++ b/crates/stc_ts_file_analyzer/tests/pass/types/inference/genericContextualTypes1/2.ts
@@ -1,0 +1,5 @@
+// @strict: true
+// @declaration: true
+
+export const arrayFilter = <T>(f: (x: T) => boolean) => (a: T[]) => a.filter(f);
+

--- a/crates/stc_ts_file_analyzer/tests/pass/types/union/unionTypeReduction2/5.swc-stderr
+++ b/crates/stc_ts_file_analyzer/tests/pass/types/union/unionTypeReduction2/5.swc-stderr
@@ -36,7 +36,7 @@ warning: Type
 4 |     let f = !!true ? x : y;  // (x?: 'hello') => void
   |             ^^^^^^^^^^^^^^
   |
-  = note: (x?: 'hello') => void
+  = note: ((x: (string | undefined)) => void | (x?: 'hello') => void)
 
 warning: Type
  --> $DIR/tests/pass/types/union/unionTypeReduction2/5.ts:5:5
@@ -44,7 +44,7 @@ warning: Type
 5 |     f();
   |     ^
   |
-  = note: (x?: 'hello') => void
+  = note: ((x: (string | undefined)) => void | (x?: 'hello') => void)
 
 warning: Type
  --> $DIR/tests/pass/types/union/unionTypeReduction2/5.ts:5:5
@@ -60,7 +60,7 @@ warning: Type
 6 |     f('hello');
   |     ^
   |
-  = note: (x?: 'hello') => void
+  = note: ((x: (string | undefined)) => void | (x?: 'hello') => void)
 
 warning: Type
  --> $DIR/tests/pass/types/union/unionTypeReduction2/5.ts:6:5

--- a/crates/stc_ts_file_analyzer/tests/pass/types/union/unionTypeReduction2/5.swc-stderr
+++ b/crates/stc_ts_file_analyzer/tests/pass/types/union/unionTypeReduction2/5.swc-stderr
@@ -36,7 +36,7 @@ warning: Type
 4 |     let f = !!true ? x : y;  // (x?: 'hello') => void
   |             ^^^^^^^^^^^^^^
   |
-  = note: ((x: (string | undefined)) => void | (x?: 'hello') => void)
+  = note: (x?: 'hello') => void
 
 warning: Type
  --> $DIR/tests/pass/types/union/unionTypeReduction2/5.ts:5:5
@@ -44,7 +44,7 @@ warning: Type
 5 |     f();
   |     ^
   |
-  = note: ((x: (string | undefined)) => void | (x?: 'hello') => void)
+  = note: (x?: 'hello') => void
 
 warning: Type
  --> $DIR/tests/pass/types/union/unionTypeReduction2/5.ts:5:5
@@ -60,7 +60,7 @@ warning: Type
 6 |     f('hello');
   |     ^
   |
-  = note: ((x: (string | undefined)) => void | (x?: 'hello') => void)
+  = note: (x?: 'hello') => void
 
 warning: Type
  --> $DIR/tests/pass/types/union/unionTypeReduction2/5.ts:6:5

--- a/crates/stc_ts_type_checker/tests/conformance.pass.txt
+++ b/crates/stc_ts_type_checker/tests/conformance.pass.txt
@@ -1712,6 +1712,7 @@ parser/ecmascript5/RegressionTests/parser509546_1.ts
 parser/ecmascript5/RegressionTests/parser509546_2.ts
 parser/ecmascript5/RegressionTests/parser509677.ts
 parser/ecmascript5/RegressionTests/parser509693.ts
+parser/ecmascript5/RegressionTests/parser536727.ts
 parser/ecmascript5/RegressionTests/parser579071.ts
 parser/ecmascript5/RegressionTests/parser596700.ts
 parser/ecmascript5/RegressionTests/parser630933.ts
@@ -2194,6 +2195,7 @@ types/stringLiteral/stringLiteralTypesOverloads01.ts
 types/stringLiteral/stringLiteralTypesOverloads02.ts
 types/stringLiteral/stringLiteralTypesOverloads03.ts
 types/stringLiteral/stringLiteralTypesOverloads04.ts
+types/stringLiteral/stringLiteralTypesOverloads05.ts
 types/stringLiteral/stringLiteralTypesTypePredicates01.ts
 types/stringLiteral/stringLiteralTypesWithTemplateStrings01.ts
 types/stringLiteral/stringLiteralTypesWithTemplateStrings02.ts
@@ -2416,6 +2418,7 @@ types/typeRelationships/typeInference/genericCallWithOverloadedConstructorTypedA
 types/typeRelationships/typeInference/genericCallWithOverloadedFunctionTypedArguments.ts
 types/typeRelationships/typeInference/genericCallWithTupleType.ts
 types/typeRelationships/typeInference/genericClassWithObjectTypeArgsAndConstraints.ts
+types/typeRelationships/typeInference/genericContextualTypes1.ts
 types/typeRelationships/typeInference/genericFunctionParameters.ts
 types/typeRelationships/typeInference/keyofInferenceIntersectsResults.ts
 types/typeRelationships/typeInference/unionAndIntersectionInference2.ts

--- a/crates/stc_ts_type_checker/tests/tsc-stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/tsc-stats.rust-debug
@@ -1,5 +1,5 @@
 Stats {
-    required_error: 4158,
-    matched_error: 5537,
-    extra_error: 1015,
+    required_error: 4154,
+    matched_error: 5541,
+    extra_error: 1031,
 }

--- a/cspell.json
+++ b/cspell.json
@@ -3,6 +3,7 @@
         "ahash",
         "bitflags",
         "bivariant",
+        "castablity",
         "codegen",
         "concat",
         "cond",


### PR DESCRIPTION
**Description:**

This PR moves the reversing logic for the variance of function parameters from `assign_to_fn_like` to `assign_param`, to fix logic for validating parameter counts.

**Related issue:**
