### PR TITLE
feat(ts/analyzer): disallow private identifiers in optional chain

### DIFF
--- a/crates/stc_ts_errors/src/lib.rs
+++ b/crates/stc_ts_errors/src/lib.rs
@@ -342,6 +342,11 @@ pub enum Error {
         span: Span,
     },
 
+    /// TS18030
+    OptionalChainCannotContainPrivateIdentifier {
+        span: Span,
+    },
+
     /// TS18011
     CannotDeletePrivateProperty {
         span: Span,
@@ -1735,6 +1740,8 @@ impl Error {
             Error::CannotDeletePrivateProperty { .. } => 18011,
 
             Error::CannotAccessPrivatePropertyFromOutside { .. } => 18013,
+
+            Error::OptionalChainCannotContainPrivateIdentifier { .. } => 18030,
 
             Error::TypeAnnOnLhsOfForInLoops { .. } => 2404,
             Error::TypeAnnOnLhsOfForOfLoops { .. } => 2483,

--- a/crates/stc_ts_file_analyzer/src/analyzer/expr/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/expr/mod.rs
@@ -1333,6 +1333,12 @@ impl Analyzer<'_, '_> {
             res.report(&mut self.storage);
         }
 
+        if self.ctx.in_opt_chain {
+            if let Key::Private(p) = prop {
+                return Err(Error::OptionalChainCannotContainPrivateIdentifier { span: p.span });
+            }
+        }
+
         let opts = AccessPropertyOpts {
             do_not_validate_type_of_computed_prop: false,
             ..opts

--- a/crates/stc_ts_type_checker/tests/tsc-stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/tsc-stats.rust-debug
@@ -1,5 +1,5 @@
 Stats {
-    required_error: 4161,
-    matched_error: 5534,
-    extra_error: 983,
+    required_error: 4159,
+    matched_error: 5536,
+    extra_error: 988,
 }


### PR DESCRIPTION
```ts
class A {
    a?: A;
    #b?: A;
    constructor() {
        this?.#b;           // Error
        this?.a.#b;         // Error
    }
}
```

```
error[TS18030]: DebugContext(
    context: tried to access property to validate an optional chaining expression
    context: tried to access property of an object (this;, id_ctx = Var)
    Prop=Private(PrivateName { span: Span { lo: BytePos(114), hi: BytePos(116), ctxt: #0 }, id: b#0 })
    OptionalChainCannotContainPrivateIdentifier {
        span: Span {
            lo: BytePos(
                114,
            ),
            hi: BytePos(
                116,
            ),
            ctxt: #0,
        },
    },
)
 --> ./a.ts:8:15
  |
8 |         this?.#b;           // Error
  |               ^^

error[TS18030]: DebugContext(
    context: tried to access property of an object to calculate type of a member expression
    context: tried to access property of an object (A;, id_ctx = Var)
    Prop=Private(PrivateName { span: Span { lo: BytePos(153), hi: BytePos(155), ctxt: #0 }, id: b#0 })
    OptionalChainCannotContainPrivateIdentifier {
        span: Span {
            lo: BytePos(
                153,
            ),
            hi: BytePos(
                155,
            ),
            ctxt: #0,
        },
    },
)
 --> ./a.ts:9:17
  |
9 |         this?.a.#b;         // Error
  |                 ^^
```

Note: there is another unrelated false positive in `expressions::optionalChaining::privateIdentifierChain::privateIdentifierChain.1.ts` (TS2339 NoSuchPropertyInClass)