### PR TITLE
fix(ts/analyzer): Fix false positive arg count error with `void` types

### DIFF
--- a/crates/stc_ts_file_analyzer/src/analyzer/expr/call_new.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/expr/call_new.rs
@@ -2219,7 +2219,7 @@ impl Analyzer<'_, '_> {
         let mut max_param = Some(params.len());
         for (index, param) in params.iter().enumerate() {
             match &param.pat {
-                RPat::Rest(..) => match param.ty.normalize() {
+                RPat::Rest(..) => match param.ty.normalize_instance() {
                     Type::Tuple(param_ty) => {
                         for elem in &param_ty.elems {
                             match elem.ty.normalize() {

--- a/crates/stc_ts_file_analyzer/src/analyzer/expr/call_new.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/expr/call_new.rs
@@ -2214,10 +2214,10 @@ impl Analyzer<'_, '_> {
 
         let span = span.with_ctxt(SyntaxContext::empty());
 
-        let min_param: usize = params.iter().map(|v| &v.pat).map(count_required_pat).sum();
+        let mut min_param: usize = params.iter().map(|v| &v.pat).map(count_required_pat).sum();
 
         let mut max_param = Some(params.len());
-        for param in params {
+        for (index, param) in params.iter().enumerate() {
             match &param.pat {
                 RPat::Rest(..) => match param.ty.normalize() {
                     Type::Tuple(param_ty) => {
@@ -2274,8 +2274,12 @@ impl Analyzer<'_, '_> {
                         )
                         .is_ok()
                 {
-                    // Reduce min_params if the type of parameter accepts void.
-                    continue;
+                    // void is the last parameter, reduce min_params.
+                    //
+                    // function foo<A>(a: A, b: void) {}
+                    if index == params.len() - 1 {
+                        min_param -= 1;
+                    }
                 }
             }
         }

--- a/crates/stc_ts_type_checker/tests/tsc-stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/tsc-stats.rust-debug
@@ -1,5 +1,5 @@
 Stats {
-    required_error: 4156,
-    matched_error: 5539,
-    extra_error: 980,
+    required_error: 4159,
+    matched_error: 5536,
+    extra_error: 981,
 }

--- a/crates/stc_ts_type_checker/tests/tsc-stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/tsc-stats.rust-debug
@@ -1,5 +1,5 @@
 Stats {
-    required_error: 4159,
-    matched_error: 5536,
-    extra_error: 981,
+    required_error: 4156,
+    matched_error: 5539,
+    extra_error: 986,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -126,7 +126,7 @@ fn main() -> Result<(), Error> {
             let mut errors = vec![];
 
             let start = Instant::now();
-            for _ in 0..1000 {
+            for _ in 0..1 {
                 let mut checker = Checker::new(
                     cm.clone(),
                     handler.clone(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -126,7 +126,7 @@ fn main() -> Result<(), Error> {
             let mut errors = vec![];
 
             let start = Instant::now();
-            for _ in 0..1 {
+            for _ in 0..1000 {
                 let mut checker = Checker::new(
                     cm.clone(),
                     handler.clone(),


### PR DESCRIPTION
```ts
function a(x: number, y: string, z: void): void {}

a(4, "hello"); // ok
a(4, "hello", void 0); // ok
a(4); // not ok

function b(x: number, y: string, z: void, what: number): void {}

b(4, "hello", void 0, 2); // ok
b(4, "hello"); // not ok
b(4, "hello", void 0); // not ok
b(4); // not ok
```

```
error[TS2554]: ExpectedNArgsButGotM {
    span: Span {
        lo: BytePos(
            131,
        ),
        hi: BytePos(
            135,
        ),
        ctxt: #0,
    },
    min: 2,
    max: Some(
        3,
    ),
}
  --> ./a.ts:10:1
   |
10 | a(4); // not ok
   | ^^^^

error[TS2554]: ExpectedNArgsButGotM {
    span: Span {
        lo: BytePos(
            248,
        ),
        hi: BytePos(
            261,
        ),
        ctxt: #0,
    },
    min: 4,
    max: Some(
        4,
    ),
}
  --> ./a.ts:17:1
   |
17 | b(4, "hello"); // not ok
   | ^^^^^^^^^^^^^

error[TS2554]: ExpectedNArgsButGotM {
    span: Span {
        lo: BytePos(
            273,
        ),
        hi: BytePos(
            294,
        ),
        ctxt: #0,
    },
    min: 4,
    max: Some(
        4,
    ),
}
  --> ./a.ts:18:1
   |
18 | b(4, "hello", void 0); // not ok
   | ^^^^^^^^^^^^^^^^^^^^^

error[TS2554]: ExpectedNArgsButGotM {
    span: Span {
        lo: BytePos(
            306,
        ),
        hi: BytePos(
            310,
        ),
        ctxt: #0,
    },
    min: 4,
    max: Some(
        4,
    ),
}
  --> ./a.ts:19:1
   |
19 | b(4); // not ok
   | ^^^^
```