### PR TITLE
perf(ts/env): Use msgpack for caching

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1120,6 +1120,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "paste"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1de2e551fb905ac83f73f7aedf2f0cb4a0da7e35efa24a202a936269f1f18e1"
+
+[[package]]
 name = "path-clean"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1585,6 +1591,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9c17925a9027d298a4603d286befe3f9dc0e8ed02523141914eb628798d6e5b"
 
 [[package]]
+name = "rmp"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44519172358fd6d58656c86ab8e7fbc9e1490c3e8f14d35ed78ca0dd07403c9f"
+dependencies = [
+ "byteorder",
+ "num-traits",
+ "paste",
+]
+
+[[package]]
+name = "rmp-serde"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5b13be192e0220b8afb7222aa5813cb62cc269ebb5cac346ca6487681d2913e"
+dependencies = [
+ "byteorder",
+ "rmp",
+ "serde",
+]
+
+[[package]]
 name = "rnode"
 version = "0.0.0"
 dependencies = [
@@ -1982,10 +2010,10 @@ dependencies = [
  "petgraph",
  "rayon",
  "retain_mut",
+ "rmp-serde",
  "rnode",
  "rustc-hash",
  "serde",
- "serde_json",
  "sha1",
  "smallvec 1.6.1",
  "stc_arc_cow",

--- a/crates/stc_ts_file_analyzer/Cargo.toml
+++ b/crates/stc_ts_file_analyzer/Cargo.toml
@@ -28,10 +28,10 @@ once_cell = "1.5.2"
 petgraph = "0.5.1"
 rayon = "1.5.0"
 retain_mut = "0.1.1"
+rmp-serde = "1.1.1"
 rnode = {path = "../rnode"}
 rustc-hash = "1.1.0"
 serde = "1.0.125"
-serde_json = "1.0.87"
 sha1 = "0.10.5"
 smallvec = "1.5.1"
 stc_arc_cow = {path = "../stc_arc_cow"}

--- a/crates/stc_ts_file_analyzer/src/env.rs
+++ b/crates/stc_ts_file_analyzer/src/env.rs
@@ -38,12 +38,12 @@ pub trait BuiltInGen: Sized {
             format!("{:x}", result)
         };
 
-        let cache_path = Path::new(".stc").join(".builtin-cache").join(&format!("{}.json", key));
+        let cache_path = Path::new(".stc").join(".builtin-cache").join(&format!("{}.rmp", key));
 
         if cache_path.is_file() {
             let data =
                 std::fs::read(&cache_path).unwrap_or_else(|err| panic!("failed to read builtin cache at {:?}: {:?}", cache_path, err));
-            let builtin = serde_json::from_slice(&data)
+            let builtin = rmp_serde::decode::from_slice(&data)
                 .unwrap_or_else(|err| panic!("failed to deserialize builtin cache at {:?}: {:?}", cache_path, err));
             return builtin;
         }
@@ -68,7 +68,7 @@ pub trait BuiltInGen: Sized {
 
         let builtin = Self::from_module_items(env, iter);
 
-        let json_data = serde_json::to_vec(&builtin).unwrap_or_else(|err| panic!("failed to serialize builtin cache: {:?}", err));
+        let json_data = rmp_serde::encode::to_vec(&builtin).unwrap_or_else(|err| panic!("failed to serialize builtin cache: {:?}", err));
 
         std::fs::create_dir_all(cache_path.parent().unwrap())
             .unwrap_or_else(|err| panic!("failed to create directory for builtin cache at {:?}: {:?}", cache_path, err));


### PR DESCRIPTION
**Description:**

This is to make iteration faster.

**Related issue:**

---

On m1 Max Macbook pro 64GB, the total time for `check.sh` dropped to 1m 36s from 2m 56s.
