### PR TITLE
fix test case for-of15

### DIFF
--- a/crates/stc_ts_file_analyzer/src/analyzer/expr/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/expr/mod.rs
@@ -944,7 +944,7 @@ impl Analyzer<'_, '_> {
                     //
                     // I guess it's because javascript work in that way.
 
-                    if index_ty.is_kwd(TsKeywordTypeKind::TsNumberKeyword) && prop_ty.is_str() {
+                    if index_ty.is_kwd(TsKeywordTypeKind::TsNumberKeyword) && prop_ty.is_str() && prop.is_computed() {
                         return Ok(Some(Type::any(span, Default::default())));
                     }
 

--- a/crates/stc_ts_file_analyzer/tests/pass/exprs/member/indexSignature/mutliple/1.swc-stderr
+++ b/crates/stc_ts_file_analyzer/tests/pass/exprs/member/indexSignature/mutliple/1.swc-stderr
@@ -72,7 +72,7 @@ warning: Type
 12 |     var e = r2['1'];
    |             ^^^^^^^
    |
-   = note: any
+   = note: Object
 
 warning: Type
   --> $DIR/tests/pass/exprs/member/indexSignature/mutliple/1.ts:13:16

--- a/crates/stc_ts_file_analyzer/tests/pass/types/generic/extends/1.swc-stderr
+++ b/crates/stc_ts_file_analyzer/tests/pass/types/generic/extends/1.swc-stderr
@@ -72,7 +72,7 @@ warning: Type
 14 |     var e = r2['1'];
    |             ^^^^^^^
    |
-   = note: any
+   = note: Object
 
 warning: Type
   --> $DIR/tests/pass/types/generic/extends/1.ts:15:16

--- a/crates/stc_ts_type_checker/tests/conformance.pass.txt
+++ b/crates/stc_ts_type_checker/tests/conformance.pass.txt
@@ -699,6 +699,7 @@ es6/for-ofStatements/for-of11.ts
 es6/for-ofStatements/for-of12.ts
 es6/for-ofStatements/for-of13.ts
 es6/for-ofStatements/for-of14.ts
+es6/for-ofStatements/for-of15.ts
 es6/for-ofStatements/for-of16.ts
 es6/for-ofStatements/for-of17.ts
 es6/for-ofStatements/for-of18.ts

--- a/crates/stc_ts_type_checker/tests/conformance/es6/for-ofStatements/for-of15.ts.stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/conformance/es6/for-ofStatements/for-of15.ts.stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
-    required_error: 1,
-    matched_error: 0,
+    required_error: 0,
+    matched_error: 1,
     extra_error: 0,
     panic: 0,
 }


### PR DESCRIPTION
<!-- Note: CI script will automatically rebase your PR so please do not rebase unless required -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Make test case for-of15.ts pass. This also improves 2x different test cases.



Really cool project @kdy1, great work!

This is what I found:

anytime there is a type where you can access an index e.g:
```
const myArr = []
myArr[4]                   //  <- like here
const myString = "";
myString[5]              // <- like here
```

we can pass in a string instead of a number and it still succeeds I believe this is because accessing computed properties is valid when the property does not exist on the obj (returns any). whereas accessing `.` properties is invalid
```
const r = {}

r.abc = 123;     // invalid
r["abc"] = 123;  // valid
```

As a result, when we check IndexAccess, we should check whether it is computed/ non-computed property




This may be the completely wrong way to fix this, please let me know.