### PR TITLE
test(ts/checker): Normalize more error codes

### DIFF
--- a/crates/stc_ts_errors/src/lib.rs
+++ b/crates/stc_ts_errors/src/lib.rs
@@ -1446,6 +1446,10 @@ impl Error {
             // TS2584: Type not found with recommendation to change target library to include `dom`.
             2318 | 2552 | 2580 | 2581 | 2582 | 2583 | 2584 => 2304,
 
+            // TS2350: new cannot be used for non-void function
+            // TS2350: new cannot be used because it's not constructor
+            2350 | 2351 => 2350,
+
             // TS2339: Property not found.
             // TS2550: Property not found with a suggestion to change `lib`.
             // TS2551: Property not found with a suggestion.

--- a/crates/stc_ts_errors/src/lib.rs
+++ b/crates/stc_ts_errors/src/lib.rs
@@ -1446,6 +1446,10 @@ impl Error {
             // TS2584: Type not found with recommendation to change target library to include `dom`.
             2318 | 2552 | 2580 | 2581 | 2582 | 2583 | 2584 => 2304,
 
+            // TS2348: Not callable, but with a suggestion to use new
+            // TS2349: Not callable
+            2348 | 2349 => 2349,
+
             // TS2350: new cannot be used for non-void function
             // TS2350: new cannot be used because it's not constructor
             2350 | 2351 => 2350,

--- a/crates/stc_ts_type_checker/tests/conformance.pass.txt
+++ b/crates/stc_ts_type_checker/tests/conformance.pass.txt
@@ -1235,6 +1235,7 @@ expressions/contextualTyping/taggedTemplateContextualTyping1.ts
 expressions/contextualTyping/taggedTemplateContextualTyping2.ts
 expressions/elementAccess/letIdentifierInElementAccess01.ts
 expressions/elementAccess/stringEnumInElementAccess01.ts
+expressions/functionCalls/forgottenNew.ts
 expressions/functionCalls/grammarAmbiguities.ts
 expressions/functionCalls/newWithSpreadES5.ts
 expressions/functionCalls/newWithSpreadES6.ts
@@ -2018,6 +2019,7 @@ types/members/objectTypePropertyAccess.ts
 types/members/objectTypeWithCallSignatureAppearsToBeFunctionType.ts
 types/members/objectTypeWithCallSignatureHidingMembersOfExtendedFunction.ts
 types/members/objectTypeWithCallSignatureHidingMembersOfFunction.ts
+types/members/objectTypeWithConstructSignatureAppearsToBeFunctionType.ts
 types/members/objectTypeWithConstructSignatureHidingMembersOfExtendedFunction.ts
 types/members/objectTypeWithConstructSignatureHidingMembersOfFunction.ts
 types/members/objectTypeWithConstructSignatureHidingMembersOfFunctionAssignmentCompat.ts
@@ -2114,6 +2116,8 @@ types/rest/objectRestReadonly.ts
 types/specifyingTypes/predefinedTypes/objectTypesWithPredefinedTypesAsName.ts
 types/specifyingTypes/typeLiterals/arrayLiteral.ts
 types/specifyingTypes/typeLiterals/arrayOfFunctionTypes3.ts
+types/specifyingTypes/typeLiterals/arrayTypeOfFunctionTypes.ts
+types/specifyingTypes/typeLiterals/arrayTypeOfFunctionTypes2.ts
 types/specifyingTypes/typeLiterals/functionLiteral.ts
 types/specifyingTypes/typeLiterals/functionLiteralForOverloads.ts
 types/specifyingTypes/typeLiterals/functionLiteralForOverloads2.ts

--- a/crates/stc_ts_type_checker/tests/conformance/expressions/functionCalls/forgottenNew.ts.stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/conformance/expressions/functionCalls/forgottenNew.ts.stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
-    required_error: 1,
-    matched_error: 0,
-    extra_error: 1,
+    required_error: 0,
+    matched_error: 1,
+    extra_error: 0,
     panic: 0,
 }

--- a/crates/stc_ts_type_checker/tests/conformance/types/members/objectTypeWithConstructSignatureAppearsToBeFunctionType.ts.stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/conformance/types/members/objectTypeWithConstructSignatureAppearsToBeFunctionType.ts.stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
-    required_error: 2,
-    matched_error: 0,
-    extra_error: 2,
+    required_error: 0,
+    matched_error: 2,
+    extra_error: 0,
     panic: 0,
 }

--- a/crates/stc_ts_type_checker/tests/conformance/types/specifyingTypes/typeLiterals/arrayTypeOfFunctionTypes.ts.stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/conformance/types/specifyingTypes/typeLiterals/arrayTypeOfFunctionTypes.ts.stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
-    required_error: 2,
-    matched_error: 0,
-    extra_error: 2,
+    required_error: 0,
+    matched_error: 2,
+    extra_error: 0,
     panic: 0,
 }

--- a/crates/stc_ts_type_checker/tests/conformance/types/specifyingTypes/typeLiterals/arrayTypeOfFunctionTypes2.ts.stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/conformance/types/specifyingTypes/typeLiterals/arrayTypeOfFunctionTypes2.ts.stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
-    required_error: 1,
-    matched_error: 0,
-    extra_error: 1,
+    required_error: 0,
+    matched_error: 1,
+    extra_error: 0,
     panic: 0,
 }

--- a/crates/stc_ts_type_checker/tests/tsc-stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/tsc-stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
-    required_error: 5188,
-    matched_error: 4678,
-    extra_error: 2057,
+    required_error: 5182,
+    matched_error: 4684,
+    extra_error: 2051,
     panic: 103,
 }


### PR DESCRIPTION
**Description:**

We should distinguish this at some time in the future, but for now, I think we should not bother matching them.

