### PR TITLE
fix(ts/analyzer): Reduce trivial false-positives

### DIFF
--- a/crates/stc_ts_file_analyzer/src/analyzer/assign/function.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/assign/function.rs
@@ -337,18 +337,7 @@ impl Analyzer<'_, '_> {
 
         // TypeScript functions are bivariant if strict_function_types is false.
         if !self.env.rule().strict_function_types || opts.is_params_of_method_definition {
-            if self
-                .assign_params(
-                    data,
-                    AssignOpts {
-                        is_params_of_method_definition: false,
-                        ..opts
-                    },
-                    &r_params,
-                    &l_params,
-                )
-                .is_ok()
-            {
+            if self.assign_params(data, AssignOpts { ..opts }, &r_params, &l_params).is_ok() {
                 return Ok(());
             }
         }
@@ -415,8 +404,6 @@ impl Analyzer<'_, '_> {
         l: &Function,
         r: &Type,
     ) -> VResult<()> {
-        opts.is_params_of_method_definition = false;
-
         let span = opts.span;
         let r = r.normalize();
 

--- a/crates/stc_ts_file_analyzer/src/analyzer/assign/function.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/assign/function.rs
@@ -382,7 +382,7 @@ impl Analyzer<'_, '_> {
                     for_overload: false,
                     allow_assignment_of_void: Some(opts.allow_assignment_of_void.unwrap_or(true)),
                     allow_assignment_to_void: !opts.for_overload,
-                    is_params_of_method_definition: false,
+
                     ..opts
                 };
 

--- a/crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs
@@ -376,7 +376,6 @@ impl Analyzer<'_, '_> {
         if self.is_builtin {
             return Ok(());
         }
-        opts.is_params_of_method_definition = false;
 
         left.assert_valid();
         right.assert_valid();
@@ -486,8 +485,6 @@ impl Analyzer<'_, '_> {
     fn assign_inner(&mut self, data: &mut AssignData, left: &Type, right: &Type, mut opts: AssignOpts) -> VResult<()> {
         left.assert_valid();
         right.assert_valid();
-
-        opts.is_params_of_method_definition = false;
 
         let l = dump_type_as_string(&self.cm, &left);
         let r = dump_type_as_string(&self.cm, &right);

--- a/crates/stc_ts_file_analyzer/src/analyzer/assign/type_el.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/assign/type_el.rs
@@ -868,7 +868,6 @@ impl Analyzer<'_, '_> {
         rhs: &[TypeElement],
     ) -> VResult<()> {
         let span = opts.span;
-        opts.is_params_of_method_definition = false;
 
         let mut errors = vec![];
 

--- a/crates/stc_ts_file_analyzer/src/analyzer/enums.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/enums.rs
@@ -510,7 +510,7 @@ impl Analyzer<'_, '_> {
         match m.init.as_deref() {
             Some(RExpr::Ident(..)) => {}
             Some(e) => {
-                if type_of_expr(&e).is_none() {
+                if type_of_expr(&e).is_none() && !matches!(e, RExpr::Tpl(..) | RExpr::Bin(..) | RExpr::Member(..)) {
                     self.storage.report(Error::ComputedMemberInEnumWithStrMember { span: m.span })
                 }
             }

--- a/crates/stc_ts_file_analyzer/src/analyzer/expr/type_cast.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/expr/type_cast.rs
@@ -256,6 +256,15 @@ impl Analyzer<'_, '_> {
             return Ok(true);
         }
 
+        match to {
+            Type::TypeLit(to) => {
+                if to.members.is_empty() {
+                    return Ok(true);
+                }
+            }
+            _ => {}
+        }
+
         if from.type_eq(to) {
             return Ok(true);
         }

--- a/crates/stc_ts_file_analyzer/src/analyzer/types/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/types/mod.rs
@@ -813,24 +813,6 @@ impl Analyzer<'_, '_> {
                 Type::Union(Union { types, ..ty }).fixed()
             }
 
-            Type::Array(ty) => {
-                let elem_type = box self.instantiate_for_normalization(span, &ty.elem_type)?;
-                Type::Array(Array { elem_type, ..ty })
-            }
-
-            Type::Tuple(ty) => {
-                let elems = ty
-                    .elems
-                    .into_iter()
-                    .map(|e| -> VResult<_> {
-                        let ty = box self.instantiate_for_normalization(span, &e.ty)?;
-                        Ok(TupleElement { ty, ..e })
-                    })
-                    .collect::<Result<_, _>>()?;
-
-                Type::Tuple(Tuple { elems, ..ty })
-            }
-
             _ => ty,
         })
     }

--- a/crates/stc_ts_file_analyzer/src/analyzer/types/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/types/mod.rs
@@ -12,7 +12,7 @@ use stc_ts_types::{
     name::Name, Accessor, Array, Class, ClassDef, ClassMember, ClassMetadata, ComputedKey, Conditional, ConditionalMetadata,
     ConstructorSignature, Id, IdCtx, IndexedAccessType, Instance, InstanceMetadata, Intersection, Intrinsic, IntrinsicKind, Key,
     KeywordType, KeywordTypeMetadata, LitType, LitTypeMetadata, MethodSignature, ModuleId, Operator, PropertySignature, QueryExpr, Ref,
-    ThisType, ThisTypeMetadata, Tuple, TupleElement, Type, TypeElement, TypeLit, TypeLitMetadata, TypeParam, TypeParamInstantiation, Union,
+    ThisType, ThisTypeMetadata, Type, TypeElement, TypeLit, TypeLitMetadata, TypeParam, TypeParamInstantiation, Union,
 };
 use stc_ts_utils::run;
 use stc_utils::{

--- a/crates/stc_ts_type_checker/tests/conformance/declarationEmit/typePredicates/declarationEmitThisPredicates02.ts.stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/conformance/declarationEmit/typePredicates/declarationEmitThisPredicates02.ts.stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
     required_error: 1,
     matched_error: 0,
-    extra_error: 1,
+    extra_error: 0,
     panic: 0,
 }

--- a/crates/stc_ts_type_checker/tests/conformance/declarationEmit/typePredicates/declarationEmitThisPredicatesWithPrivateName02.ts.stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/conformance/declarationEmit/typePredicates/declarationEmitThisPredicatesWithPrivateName02.ts.stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
     required_error: 1,
     matched_error: 0,
-    extra_error: 1,
+    extra_error: 0,
     panic: 0,
 }

--- a/crates/stc_ts_type_checker/tests/conformance/enums/enumConstantMemberWithString.ts.stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/conformance/enums/enumConstantMemberWithString.ts.stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
     required_error: 2,
     matched_error: 0,
-    extra_error: 3,
+    extra_error: 0,
     panic: 0,
 }

--- a/crates/stc_ts_type_checker/tests/conformance/enums/enumConstantMemberWithTemplateLiterals.ts.stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/conformance/enums/enumConstantMemberWithTemplateLiterals.ts.stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
     required_error: 2,
     matched_error: 0,
-    extra_error: 4,
+    extra_error: 0,
     panic: 0,
 }

--- a/crates/stc_ts_type_checker/tests/conformance/expressions/arrayLiterals/arrayLiterals.ts.stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/conformance/expressions/arrayLiterals/arrayLiterals.ts.stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
     required_error: 2,
     matched_error: 0,
-    extra_error: 1,
+    extra_error: 0,
     panic: 0,
 }

--- a/crates/stc_ts_type_checker/tests/conformance/types/thisType/typeRelationships.ts.stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/conformance/types/thisType/typeRelationships.ts.stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
     required_error: 3,
     matched_error: 0,
-    extra_error: 2,
+    extra_error: 0,
     panic: 0,
 }

--- a/crates/stc_ts_type_checker/tests/conformance/types/typeRelationships/assignmentCompatibility/covariantCallbacks.ts.stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/conformance/types/typeRelationships/assignmentCompatibility/covariantCallbacks.ts.stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
     required_error: 5,
     matched_error: 1,
-    extra_error: 1,
+    extra_error: 0,
     panic: 0,
 }

--- a/crates/stc_ts_type_checker/tests/tsc-stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/tsc-stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
     required_error: 5179,
     matched_error: 4687,
-    extra_error: 2020,
+    extra_error: 2007,
     panic: 103,
 }


### PR DESCRIPTION
**Description:**

 - Fix bivariant assignment.
 - Allow casting anything to `{}`.
 - Reduce false-positives related to enum initializers.
 - Remove wrong instantiation logic.


**Related issue (if exists):**


---

I don't want to wait for CI
