### PR TITLE
fix(ts/analyzer): Fix trivial false positives

### DIFF
--- a/crates/stc_ts_dts/tests/fixture.rs
+++ b/crates/stc_ts_dts/tests/fixture.rs
@@ -2,8 +2,6 @@
 #![feature(box_syntax)]
 #![feature(box_patterns)]
 #![feature(test)]
-// Disabled because .d.ts is currently broken
-#![cfg(disabled)]
 
 extern crate test;
 
@@ -40,8 +38,12 @@ use swc_ecma_utils::drop_span;
 use swc_ecma_visit::{Fold, FoldWith};
 use testing::{assert_eq, NormalizedOutput, StdErr};
 
-#[testing_macros::fixture("fixture/**/*.ts", exclude(".*.d\\.ts"))]
+#[testing_macros::fixture("tests/fixture/**/*.ts", exclude(".*.d\\.ts"))]
 fn fixture(input: PathBuf) {
+    // Disabled as .d.ts generation is currently broken
+    if true {
+        return;
+    }
     do_test(&input).unwrap();
 }
 

--- a/crates/stc_ts_errors/src/lib.rs
+++ b/crates/stc_ts_errors/src/lib.rs
@@ -920,8 +920,15 @@ pub enum Error {
         span: Span,
     },
 
-    // TS2493
+    /// TS2493
     TupleIndexError {
+        span: Span,
+        len: u64,
+        index: i64,
+    },
+
+    /// TS2514
+    NegativeTupleIndex {
         span: Span,
         len: u64,
         index: i64,
@@ -1646,6 +1653,7 @@ impl Error {
             Error::ComputedMemberInEnumWithStrMember { .. } => 2553,
 
             Error::TupleIndexError { .. } => 2493,
+            Error::NegativeTupleIndex { .. } => 2514,
             Error::InvalidLValue { .. } => 2540,
 
             Error::TS2378 { .. } => 2378,

--- a/crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs
@@ -1905,8 +1905,9 @@ impl Analyzer<'_, '_> {
                         self.assign_to_type_elements(data, opts, span, &lhs.members, rhs, Default::default())
                             .with_context(|| {
                                 format!(
-                                    "tried to assign a type to an interface to check if unknown rhs exists\nLHS: {}",
-                                    dump_type_as_string(&self.cm, &Type::TypeLit(lhs.into_owned()))
+                                    "tried to assign a type to an interface to check if unknown rhs exists\nLHS: {}\nRHS: {}",
+                                    dump_type_as_string(&self.cm, &Type::TypeLit(lhs.into_owned())),
+                                    dump_type_as_string(&self.cm, rhs)
                                 )
                             })?;
                     }

--- a/crates/stc_ts_file_analyzer/src/analyzer/expr/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/expr/mod.rs
@@ -2197,7 +2197,7 @@ impl Analyzer<'_, '_> {
                         let v = n.value.round() as i64;
 
                         if v < 0 {
-                            return Err(Error::TupleIndexError {
+                            return Err(Error::NegativeTupleIndex {
                                 span: n.span(),
                                 index: v,
                                 len: elems.len() as u64,

--- a/crates/stc_ts_type_checker/tests/conformance.pass.txt
+++ b/crates/stc_ts_type_checker/tests/conformance.pass.txt
@@ -2038,6 +2038,7 @@ types/members/objectTypeWithStringNamedNumericProperty.ts
 types/members/objectTypeWithStringNamedPropertyOfIllegalCharacters.ts
 types/members/typesWithOptionalProperty.ts
 types/members/typesWithPublicConstructor.ts
+types/members/typesWithSpecializedCallSignatures.ts
 types/members/typesWithSpecializedConstructSignatures.ts
 types/namedTypes/classWithOnlyPublicMembersEquivalentToInterface.ts
 types/namedTypes/classWithOnlyPublicMembersEquivalentToInterface2.ts

--- a/crates/stc_ts_type_checker/tests/conformance.pass.txt
+++ b/crates/stc_ts_type_checker/tests/conformance.pass.txt
@@ -2203,6 +2203,7 @@ types/tuple/castingTuple.ts
 types/tuple/contextualTypeWithTuple.ts
 types/tuple/emptyTuples/emptyTuplesTypeAssertion01.ts
 types/tuple/emptyTuples/emptyTuplesTypeAssertion02.ts
+types/tuple/indexerWithTuple.ts
 types/tuple/strictTupleLength.ts
 types/tuple/tupleElementTypes1.ts
 types/tuple/tupleElementTypes2.ts

--- a/crates/stc_ts_type_checker/tests/conformance/types/members/typesWithSpecializedCallSignatures.ts.stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/conformance/types/members/typesWithSpecializedCallSignatures.ts.stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
     required_error: 0,
     matched_error: 0,
-    extra_error: 1,
+    extra_error: 0,
     panic: 0,
 }

--- a/crates/stc_ts_type_checker/tests/conformance/types/tuple/indexerWithTuple.ts.stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/conformance/types/tuple/indexerWithTuple.ts.stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
-    required_error: 2,
-    matched_error: 4,
-    extra_error: 2,
+    required_error: 0,
+    matched_error: 6,
+    extra_error: 0,
     panic: 0,
 }


### PR DESCRIPTION
**Description:**

 - Fix deduplicating logic while checking for unknown properties on the RHS.
 - Change the error code of the negative tuple index