### PR TITLE
fix(ts/analyzer): Use async iterator for `yield` in async generators

### DIFF
--- a/crates/stc_ts_errors/src/lib.rs
+++ b/crates/stc_ts_errors/src/lib.rs
@@ -1325,7 +1325,7 @@ pub enum Error {
         span: Span,
     },
 
-    MustHaveSymbolAsycIteratorThatReturnsIterator {
+    MustHaveSymbolAsyncIteratorThatReturnsIterator {
         span: Span,
     },
 
@@ -1721,7 +1721,7 @@ impl Error {
 
             Error::MustHaveSymbolIteratorThatReturnsIterator { .. } => 2488,
 
-            Error::MustHaveSymbolAsycIteratorThatReturnsIterator { .. } => 2504,
+            Error::MustHaveSymbolAsyncIteratorThatReturnsIterator { .. } => 2504,
 
             Error::MustHaveSymbolIteratorThatReturnsIteratorOrMustBeArray { .. } => 2548,
 

--- a/crates/stc_ts_file_analyzer/src/analyzer/class/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/class/mod.rs
@@ -600,8 +600,8 @@ impl Analyzer<'_, '_> {
             Default::default(),
             |child: &mut Analyzer| -> VResult<_> {
                 child.ctx.in_declare |= c.function.body.is_none();
-                child.ctx.in_async |= c.function.is_async;
-                child.ctx.in_generator |= c.function.is_generator;
+                child.ctx.in_async = c.function.is_async;
+                child.ctx.in_generator = c.function.is_generator;
 
                 child.scope.declaring_prop = match &key {
                     Key::Normal { sym, .. } => Some(Id::word(sym.clone())),

--- a/crates/stc_ts_file_analyzer/src/analyzer/expr/array.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/expr/array.rs
@@ -479,7 +479,7 @@ impl Analyzer<'_, '_> {
             .get_iterator_element_type(span, ty, true, Default::default())
             .context("tried to get element of iterator as a fallback logic for async iterator")
             .convert_err(|err| match err {
-                Error::MustHaveSymbolIteratorThatReturnsIterator { span } => Error::MustHaveSymbolAsycIteratorThatReturnsIterator { span },
+                Error::MustHaveSymbolIteratorThatReturnsIterator { span } => Error::MustHaveSymbolAsyncIteratorThatReturnsIterator { span },
                 _ => err,
             })?;
 

--- a/crates/stc_ts_file_analyzer/src/analyzer/stmt/return_type.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/stmt/return_type.rs
@@ -450,10 +450,15 @@ impl Analyzer<'_, '_> {
             .freezed();
 
             if let Some(declared) = self.scope.declared_return_type().cloned() {
-                match self
-                    .get_iterator_element_type(span, Cow::Owned(declared), true, Default::default())
-                    .map(Cow::into_owned)
-                    .map(Freeze::freezed)
+                match if self.ctx.in_async {
+                    self.get_async_iterator_element_type(e.span, Cow::Owned(declared))
+                        .context("tried to get an element type from an async iterator for normal yield")
+                } else {
+                    self.get_iterator_element_type(e.span, Cow::Owned(declared), false, GetIteratorOpts { ..Default::default() })
+                        .context("tried to get an element type from an iterator for normal yield")
+                }
+                .map(Cow::into_owned)
+                .map(Freeze::freezed)
                 {
                     Ok(declared) => {
                         match self.assign_with_opts(

--- a/crates/stc_ts_file_analyzer/src/analyzer/stmt/return_type.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/stmt/return_type.rs
@@ -454,7 +454,7 @@ impl Analyzer<'_, '_> {
                     self.get_async_iterator_element_type(e.span, Cow::Owned(declared))
                         .context("tried to get an element type from an async iterator for normal yield")
                 } else {
-                    self.get_iterator_element_type(e.span, Cow::Owned(declared), false, GetIteratorOpts { ..Default::default() })
+                    self.get_iterator_element_type(e.span, Cow::Owned(declared), true, GetIteratorOpts { ..Default::default() })
                         .context("tried to get an element type from an iterator for normal yield")
                 }
                 .map(Cow::into_owned)

--- a/crates/stc_ts_type_checker/tests/conformance/generators/generatorAssignability.ts.stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/conformance/generators/generatorAssignability.ts.stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
     required_error: 11,
     matched_error: 0,
-    extra_error: 4,
+    extra_error: 0,
     panic: 0,
 }

--- a/crates/stc_ts_type_checker/tests/conformance/types/asyncGenerators/types.asyncGenerators.es2018.1.ts.stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/conformance/types/asyncGenerators/types.asyncGenerators.es2018.1.ts.stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
     required_error: 0,
     matched_error: 0,
-    extra_error: 16,
+    extra_error: 8,
     panic: 0,
 }

--- a/crates/stc_ts_type_checker/tests/conformance/types/asyncGenerators/types.asyncGenerators.es2018.2.ts.stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/conformance/types/asyncGenerators/types.asyncGenerators.es2018.2.ts.stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
-    required_error: 10,
-    matched_error: 14,
+    required_error: 12,
+    matched_error: 12,
     extra_error: 0,
     panic: 0,
 }

--- a/crates/stc_ts_type_checker/tests/tsc-stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/tsc-stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
     required_error: 5155,
     matched_error: 4711,
-    extra_error: 1964,
+    extra_error: 1949,
     panic: 103,
 }


### PR DESCRIPTION
**Description:**

 - Use async iterator for `yield` in async generators.