### PR TITLE
fix(ts/analyzer): Use empty tuple type for rest pattern with tuple initializer

### DIFF
--- a/crates/stc_ts_file_analyzer/src/analyzer/scope/vars.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/scope/vars.rs
@@ -5,7 +5,7 @@ use rnode::{FoldWith, NodeId};
 use stc_ts_ast_rnode::{RBindingIdent, RExpr, RIdent, RNumber, RObjectPatProp, RPat, RStr, RTsEntityName, RTsLit};
 use stc_ts_errors::{debug::dump_type_as_string, DebugExt, Error};
 use stc_ts_type_ops::{widen::Widen, Fix};
-use stc_ts_types::{Array, Key, KeywordType, LitType, ModuleId, Ref, Type, TypeLit, TypeParamInstantiation, Union};
+use stc_ts_types::{Array, Key, KeywordType, LitType, ModuleId, Ref, Tuple, Type, TypeLit, TypeParamInstantiation, Union};
 use stc_ts_utils::{run, PatExt};
 use stc_utils::{cache::Freeze, TryOpt};
 use swc_common::{Span, Spanned, SyntaxContext, DUMMY_SP};
@@ -288,6 +288,15 @@ impl Analyzer<'_, '_> {
                                                         .unwrap_or_else(|| Type::any(span, Default::default()));
 
                                                     Ok(right)
+                                                }
+                                                RPat::Rest(p) => {
+                                                    // [a, ...b] = [1]
+                                                    // b should be an empty tuple
+                                                    Ok(Type::Tuple(Tuple {
+                                                        span: p.span,
+                                                        elems: vec![],
+                                                        metadata: Default::default(),
+                                                    }))
                                                 }
                                                 _ => Err(err),
                                             },

--- a/crates/stc_ts_type_checker/tests/conformance/es6/destructuring/declarationsAndAssignments.ts.stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/conformance/es6/destructuring/declarationsAndAssignments.ts.stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
     required_error: 11,
     matched_error: 9,
-    extra_error: 7,
+    extra_error: 5,
     panic: 0,
 }

--- a/crates/stc_ts_type_checker/tests/conformance/es6/destructuring/destructuringVariableDeclaration2.ts.stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/conformance/es6/destructuring/destructuringVariableDeclaration2.ts.stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
     required_error: 2,
     matched_error: 2,
-    extra_error: 1,
+    extra_error: 0,
     panic: 0,
 }

--- a/crates/stc_ts_type_checker/tests/tsc-stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/tsc-stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
     required_error: 4457,
     matched_error: 5427,
-    extra_error: 1041,
+    extra_error: 1038,
     panic: 90,
 }


### PR DESCRIPTION
**Description:**



**Related issue:**

 - Closes https://github.com/dudykr/stc/issues/186.