### PR TITLE
fix(ts/analyzer): Fix assignment of intersection types

### DIFF
--- a/crates/stc_ts_file_analyzer/src/analyzer/assign/class.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/assign/class.rs
@@ -105,7 +105,7 @@ impl Analyzer<'_, '_> {
                         ..Default::default()
                     },
                     AssignOpts {
-                        allow_unknown_rhs: true,
+                        allow_unknown_rhs: Some(true),
                         is_assigning_to_class_members: true,
                         ..opts
                     },

--- a/crates/stc_ts_file_analyzer/src/analyzer/assign/class.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/assign/class.rs
@@ -209,7 +209,7 @@ impl Analyzer<'_, '_> {
                         ..Default::default()
                     },
                     AssignOpts {
-                        allow_unknown_rhs: true,
+                        allow_unknown_rhs: Some(true),
                         is_assigning_to_class_members: true,
                         ..opts
                     },

--- a/crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs
@@ -36,7 +36,18 @@ pub(crate) struct AssignOpts {
     /// This field should be overrided by caller.
     pub span: Span,
     pub right_ident_span: Option<Span>,
-    pub allow_unknown_rhs: bool,
+
+    /// # Values
+    ///
+    /// - `Some(false)`: `inexact` and `specified` of [TypeLitMetaadata] are
+    ///   ignored.
+    /// - `Some(true)`: extra properties are allowed.
+    /// - `None`: It depends on `inexact` and `specified` of [TypeLitMetaadata]
+    ///
+    /// # Usages
+    ///
+    /// - `Some(false)` is Used for `extends` check.
+    pub allow_unknown_rhs: Option<bool>,
 
     pub allow_missing_fields: bool,
 

--- a/crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs
@@ -795,7 +795,11 @@ impl Analyzer<'_, '_> {
                         &new_lhs,
                         rhs,
                         AssignOpts {
-                            allow_unknown_rhs: opts.allow_unknown_rhs || opts.allow_unknown_rhs_if_expanded,
+                            allow_unknown_rhs: if opts.allow_unknown_rhs_if_expanded {
+                                Some(true)
+                            } else {
+                                opts.allow_unknown_rhs
+                            },
                             allow_unknown_rhs_if_expanded: false,
                             ..opts
                         },
@@ -1060,7 +1064,7 @@ impl Analyzer<'_, '_> {
                             &ty,
                             rhs,
                             AssignOpts {
-                                allow_unknown_rhs: true,
+                                allow_unknown_rhs: Some(true),
                                 ..opts
                             },
                         )
@@ -1080,7 +1084,7 @@ impl Analyzer<'_, '_> {
                     _ => true,
                 };
 
-                if !left_contains_object && rhs_requires_unknown_property_check && !opts.allow_unknown_rhs {
+                if !left_contains_object && rhs_requires_unknown_property_check && !opts.allow_unknown_rhs.unwrap_or_default() {
                     let lhs = self.convert_type_to_type_lit(span, Cow::Borrowed(to))?;
 
                     if let Some(lhs) = lhs {
@@ -1306,7 +1310,7 @@ impl Analyzer<'_, '_> {
                                 to,
                                 rhs,
                                 AssignOpts {
-                                    allow_unknown_rhs: true,
+                                    allow_unknown_rhs: Some(true),
                                     ..opts
                                 },
                             )
@@ -1367,7 +1371,7 @@ impl Analyzer<'_, '_> {
                             to,
                             c,
                             AssignOpts {
-                                allow_unknown_rhs: true,
+                                allow_unknown_rhs: Some(true),
                                 ..opts
                             },
                         );
@@ -1841,7 +1845,7 @@ impl Analyzer<'_, '_> {
                     rhs,
                     Default::default(),
                     AssignOpts {
-                        allow_unknown_rhs: true,
+                        allow_unknown_rhs: Some(true),
                         allow_assignment_of_array_to_optional_type_lit: true,
                         ..opts
                     },
@@ -1862,7 +1866,7 @@ impl Analyzer<'_, '_> {
                         &parent,
                         &rhs,
                         AssignOpts {
-                            allow_unknown_rhs: true,
+                            allow_unknown_rhs: Some(true),
                             ..opts
                         },
                     );
@@ -1918,7 +1922,7 @@ impl Analyzer<'_, '_> {
 
                 // We should check for unknown rhs, while allowing assignment to parent
                 // interfaces.
-                if !opts.allow_unknown_rhs && !opts.allow_unknown_rhs_if_expanded {
+                if !opts.allow_unknown_rhs.unwrap_or_default() && !opts.allow_unknown_rhs_if_expanded {
                     let lhs = self.convert_type_to_type_lit(span, Cow::Borrowed(to))?;
                     if let Some(lhs) = lhs {
                         self.assign_to_type_elements(data, span, &lhs.members, rhs, Default::default(), opts)
@@ -2049,7 +2053,7 @@ impl Analyzer<'_, '_> {
                                         &l.ty,
                                         &r.ty,
                                         AssignOpts {
-                                            allow_unknown_rhs: true,
+                                            allow_unknown_rhs: Some(true),
                                             ..opts
                                         },
                                     )
@@ -2079,7 +2083,7 @@ impl Analyzer<'_, '_> {
                                     &l_ty,
                                     rhs_elem_type,
                                     AssignOpts {
-                                        allow_unknown_rhs: true,
+                                        allow_unknown_rhs: Some(true),
                                         ..opts
                                     },
                                 )?;
@@ -2343,7 +2347,7 @@ impl Analyzer<'_, '_> {
             &keys,
             &rhs_keys,
             AssignOpts {
-                allow_unknown_rhs: true,
+                allow_unknown_rhs: Some(true),
                 ..opts
             },
         )

--- a/crates/stc_ts_file_analyzer/src/analyzer/assign/type_el.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/assign/type_el.rs
@@ -119,7 +119,7 @@ impl Analyzer<'_, '_> {
                     metadata: rhs_metadata,
                     ..
                 }) => {
-                    let allow_unknown_rhs = opts.allow_unknown_rhs || rhs_metadata.inexact || rhs_metadata.specified;
+                    let allow_unknown_rhs = opts.allow_unknown_rhs.unwrap_or(rhs_metadata.inexact || rhs_metadata.specified);
 
                     // Exclude duplicate properties on rhs
                     let valid_rhs_indexes = {
@@ -186,7 +186,10 @@ impl Analyzer<'_, '_> {
                         lhs,
                         lhs_metadata,
                         &rhs_members,
-                        AssignOpts { allow_unknown_rhs, ..opts },
+                        AssignOpts {
+                            allow_unknown_rhs: Some(allow_unknown_rhs),
+                            ..opts
+                        },
                     )
                     .with_context(|| {
                         format!(
@@ -270,7 +273,7 @@ impl Analyzer<'_, '_> {
                                     &rhs,
                                     lhs_metadata,
                                     AssignOpts {
-                                        allow_unknown_rhs: true,
+                                        allow_unknown_rhs: Some(true),
                                         ..opts
                                     },
                                 )
@@ -312,7 +315,7 @@ impl Analyzer<'_, '_> {
                                     &rhs,
                                     lhs_metadata,
                                     AssignOpts {
-                                        allow_unknown_rhs: true,
+                                        allow_unknown_rhs: Some(true),
                                         ..opts
                                     },
                                 ) {
@@ -333,7 +336,7 @@ impl Analyzer<'_, '_> {
                                         &rhs,
                                         lhs_metadata,
                                         AssignOpts {
-                                            allow_unknown_rhs: true,
+                                            allow_unknown_rhs: Some(true),
                                             ..opts
                                         },
                                     )
@@ -374,7 +377,7 @@ impl Analyzer<'_, '_> {
                             &rhs,
                             lhs_metadata,
                             AssignOpts {
-                                allow_unknown_rhs: true,
+                                allow_unknown_rhs: Some(true),
                                 ..opts
                             },
                         )
@@ -423,7 +426,7 @@ impl Analyzer<'_, '_> {
                             &rhs,
                             lhs_metadata,
                             AssignOpts {
-                                allow_unknown_rhs: true,
+                                allow_unknown_rhs: Some(true),
                                 ..opts
                             },
                         )
@@ -470,7 +473,7 @@ impl Analyzer<'_, '_> {
                             &rhs,
                             lhs_metadata,
                             AssignOpts {
-                                allow_unknown_rhs: true,
+                                allow_unknown_rhs: Some(true),
                                 ..opts
                             },
                         )
@@ -544,7 +547,7 @@ impl Analyzer<'_, '_> {
                             &rhs,
                             lhs_metadata,
                             AssignOpts {
-                                allow_unknown_rhs: true,
+                                allow_unknown_rhs: Some(true),
                                 ..opts
                             },
                         )
@@ -856,7 +859,7 @@ impl Analyzer<'_, '_> {
                             &l,
                             &parent,
                             AssignOpts {
-                                allow_unknown_rhs: true,
+                                allow_unknown_rhs: Some(true),
                                 ..opts
                             },
                         );

--- a/crates/stc_ts_file_analyzer/src/analyzer/assign/type_el.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/assign/type_el.rs
@@ -119,7 +119,7 @@ impl Analyzer<'_, '_> {
                     metadata: rhs_metadata,
                     ..
                 }) => {
-                    let allow_unknown_rhs = opts.allow_unknown_rhs || rhs_metadata.inexact;
+                    let allow_unknown_rhs = opts.allow_unknown_rhs || rhs_metadata.inexact || rhs_metadata.specified;
 
                     // Exclude duplicate properties on rhs
                     let valid_rhs_indexes = {

--- a/crates/stc_ts_file_analyzer/src/analyzer/class/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/class/mod.rs
@@ -1315,7 +1315,7 @@ impl Analyzer<'_, '_> {
                     &class_ty,
                     AssignOpts {
                         span: parent.span(),
-                        allow_unknown_rhs: true,
+                        allow_unknown_rhs: Some(true),
                         ..Default::default()
                     },
                 )

--- a/crates/stc_ts_file_analyzer/src/analyzer/convert/interface.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/convert/interface.rs
@@ -49,7 +49,7 @@ impl Analyzer<'_, '_> {
                     }),
                     AssignOpts {
                         span,
-                        allow_unknown_rhs: true,
+                        allow_unknown_rhs: Some(true),
                         allow_missing_fields: true,
                         allow_assignment_of_param: true,
                         skip_call_and_constructor_elem: true,
@@ -98,7 +98,7 @@ impl Analyzer<'_, '_> {
                             span,
                             // required because interface can extend classes
                             use_missing_fields_for_class: true,
-                            allow_unknown_rhs: true,
+                            allow_unknown_rhs: Some(true),
                             ..Default::default()
                         },
                     ) {

--- a/crates/stc_ts_file_analyzer/src/analyzer/expr/bin.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/expr/bin.rs
@@ -1319,7 +1319,7 @@ impl Analyzer<'_, '_> {
                                     &rt,
                                     AssignOpts {
                                         span,
-                                        allow_unknown_rhs: true,
+                                        allow_unknown_rhs: Some(true),
                                         ..Default::default()
                                     },
                                 ),

--- a/crates/stc_ts_file_analyzer/src/analyzer/expr/call_new.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/expr/call_new.rs
@@ -2988,7 +2988,7 @@ impl Analyzer<'_, '_> {
                             &arg.ty,
                             AssignOpts {
                                 span: arg.span(),
-                                allow_unknown_rhs,
+                                allow_unknown_rhs: Some(allow_unknown_rhs),
                                 use_missing_fields_for_class: true,
                                 ..Default::default()
                             },
@@ -3291,7 +3291,7 @@ impl Analyzer<'_, '_> {
                                 &arg.ty,
                                 AssignOpts {
                                     span,
-                                    allow_unknown_rhs: true,
+                                    allow_unknown_rhs: Some(true),
                                     allow_assignment_to_param: true,
                                     ..Default::default()
                                 },

--- a/crates/stc_ts_file_analyzer/src/analyzer/generic/expander.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/generic/expander.rs
@@ -356,6 +356,7 @@ impl Analyzer<'_, '_> {
                 disallow_special_assignment_to_empty_class: true,
                 disallow_different_classes: opts.disallow_different_classes,
                 allow_assignment_to_param_constraint: true,
+                allow_unknown_rhs: Some(false),
                 ..Default::default()
             },
         );

--- a/crates/stc_ts_file_analyzer/src/analyzer/generic/expander.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/generic/expander.rs
@@ -357,6 +357,7 @@ impl Analyzer<'_, '_> {
                 disallow_different_classes: opts.disallow_different_classes,
                 allow_assignment_to_param_constraint: true,
                 allow_unknown_rhs: Some(false),
+                allow_unknown_rhs_if_expanded: true,
                 ..Default::default()
             },
         );

--- a/crates/stc_ts_file_analyzer/src/analyzer/stmt/return_type.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/stmt/return_type.rs
@@ -288,7 +288,7 @@ impl Analyzer<'_, '_> {
                     ret_ty,
                     AssignOpts {
                         span,
-                        allow_unknown_rhs: true,
+                        allow_unknown_rhs: Some(true),
                         may_unwrap_promise: true,
                         ..Default::default()
                     },
@@ -348,7 +348,7 @@ impl Analyzer<'_, '_> {
                         }),
                         AssignOpts {
                             span: node.span,
-                            allow_unknown_rhs: true,
+                            allow_unknown_rhs: Some(true),
                             ..Default::default()
                         },
                     )
@@ -363,7 +363,7 @@ impl Analyzer<'_, '_> {
                         &ty,
                         AssignOpts {
                             span: node.span,
-                            allow_unknown_rhs: true,
+                            allow_unknown_rhs: Some(true),
                             may_unwrap_promise: true,
                             ..Default::default()
                         },
@@ -397,7 +397,7 @@ impl Analyzer<'_, '_> {
                         }),
                         AssignOpts {
                             span: node.span,
-                            allow_unknown_rhs: true,
+                            allow_unknown_rhs: Some(true),
                             ..Default::default()
                         },
                     )
@@ -411,7 +411,7 @@ impl Analyzer<'_, '_> {
                         &ty,
                         AssignOpts {
                             span: node.span,
-                            allow_unknown_rhs: true,
+                            allow_unknown_rhs: Some(true),
                             ..Default::default()
                         },
                     )
@@ -467,7 +467,7 @@ impl Analyzer<'_, '_> {
                             &item_ty,
                             AssignOpts {
                                 span: e.span,
-                                allow_unknown_rhs: true,
+                                allow_unknown_rhs: Some(true),
                                 use_missing_fields_for_class: true,
                                 ..Default::default()
                             },

--- a/crates/stc_ts_file_analyzer/src/analyzer/stmt/var_decl.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/stmt/var_decl.rs
@@ -262,8 +262,8 @@ impl Analyzer<'_, '_> {
                         let opts = AssignOpts {
                             span: v_span,
                             allow_unknown_rhs: match &**init {
-                                RExpr::Ident(..) | RExpr::Member(..) | RExpr::MetaProp(..) | RExpr::New(..) | RExpr::Call(..) => true,
-                                _ => false,
+                                RExpr::Ident(..) | RExpr::Member(..) | RExpr::MetaProp(..) | RExpr::New(..) | RExpr::Call(..) => Some(true),
+                                _ => None,
                             },
                             ..Default::default()
                         };

--- a/crates/stc_ts_file_analyzer/src/analyzer/types/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/types/mod.rs
@@ -1224,7 +1224,10 @@ impl Analyzer<'_, '_> {
                 Cow::Owned(TypeLit {
                     span: t.span,
                     members,
-                    metadata: Default::default(),
+                    metadata: TypeLitMetadata {
+                        inexact: true,
+                        ..Default::default()
+                    },
                 })
             }
 

--- a/crates/stc_ts_file_analyzer/src/analyzer/types/narrowing.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/types/narrowing.rs
@@ -99,7 +99,7 @@ impl Analyzer<'_, '_> {
                     &actual,
                     AssignOpts {
                         span,
-                        allow_unknown_rhs: true,
+                        allow_unknown_rhs: Some(true),
                         ..Default::default()
                     },
                 ) {

--- a/crates/stc_ts_file_analyzer/tests/pass/types/union/assertions-1-2.swc-stderr
+++ b/crates/stc_ts_file_analyzer/tests/pass/types/union/assertions-1-2.swc-stderr
@@ -1,0 +1,42 @@
+
+  x Type
+   ,-[$DIR/tests/pass/types/union/assertions-1-2.ts:9:1]
+ 9 | export var x = { p1: 10, p2: 20 };
+   :                ^^^^^^^^^^^^^^^^^^
+   `----
+
+Error: 
+  > {
+  |     p1: 10;
+  |     p2: 20;
+  | }
+
+  x Type
+    ,-[$DIR/tests/pass/types/union/assertions-1-2.ts:10:1]
+ 10 | export var y: number | I2 = x;
+    :                             ^
+    `----
+
+Error: 
+  > {
+  |     p1: number;
+  |     p2: number;
+  | }
+
+  x Type
+    ,-[$DIR/tests/pass/types/union/assertions-1-2.ts:13:1]
+ 13 | export var d = <I1>y;
+    :                    ^
+    `----
+
+Error: 
+  > I2
+
+  x Type
+    ,-[$DIR/tests/pass/types/union/assertions-1-2.ts:13:1]
+ 13 | export var d = <I1>y;
+    :                ^^^^^
+    `----
+
+Error: 
+  > I1

--- a/crates/stc_ts_file_analyzer/tests/pass/types/union/assertions-1-2.ts
+++ b/crates/stc_ts_file_analyzer/tests/pass/types/union/assertions-1-2.ts
@@ -1,0 +1,13 @@
+export interface I1 {
+    p1: number
+}
+
+export interface I2 extends I1 {
+    p2: number;
+}
+
+export var x = { p1: 10, p2: 20 };
+export var y: number | I2 = x;
+
+
+export var d = <I1>y;

--- a/crates/stc_ts_file_analyzer/tests/pass/types/union/unionTypeReduction2/6.swc-stderr
+++ b/crates/stc_ts_file_analyzer/tests/pass/types/union/unionTypeReduction2/6.swc-stderr
@@ -1,0 +1,101 @@
+
+  x Type
+    ,-[$DIR/tests/pass/types/union/unionTypeReduction2/6.ts:13:5]
+ 13 | let z = !!true ? a : b;  // A | B
+    :          ^^^^^
+    `----
+
+Error: 
+  > false
+
+  x Type
+    ,-[$DIR/tests/pass/types/union/unionTypeReduction2/6.ts:13:5]
+ 13 | let z = !!true ? a : b;  // A | B
+    :         ^^^^^^
+    `----
+
+Error: 
+  > true
+
+  x Type
+    ,-[$DIR/tests/pass/types/union/unionTypeReduction2/6.ts:13:5]
+ 13 | let z = !!true ? a : b;  // A | B
+    :                  ^
+    `----
+
+Error: 
+  > {
+  |     f(): void;
+  | }
+
+  x Type
+    ,-[$DIR/tests/pass/types/union/unionTypeReduction2/6.ts:13:5]
+ 13 | let z = !!true ? a : b;  // A | B
+    :                      ^
+    `----
+
+Error: 
+  > {
+  |     f(x?: string): void;
+  |     g(): void;
+  | }
+
+  x Type
+    ,-[$DIR/tests/pass/types/union/unionTypeReduction2/6.ts:13:5]
+ 13 | let z = !!true ? a : b;  // A | B
+    :         ^^^^^^^^^^^^^^
+    `----
+
+Error: 
+  > ({
+  |     f(): void;
+  | } | {
+  |     f(x?: string): void;
+  |     g(): void;
+  | })
+
+  x Type
+    ,-[$DIR/tests/pass/types/union/unionTypeReduction2/6.ts:14:5]
+ 14 | z.f();
+    : ^
+    `----
+
+Error: 
+  > ({
+  |     f(): void;
+  | } | {
+  |     f(x?: string): void;
+  |     g(): void;
+  | })
+
+  x Type
+    ,-[$DIR/tests/pass/types/union/unionTypeReduction2/6.ts:14:5]
+ 14 | z.f();
+    : ^^^^^
+    `----
+
+Error: 
+  > void
+
+  x Type
+    ,-[$DIR/tests/pass/types/union/unionTypeReduction2/6.ts:15:5]
+ 15 | z.f('hello');
+    : ^
+    `----
+
+Error: 
+  > ({
+  |     f(): void;
+  | } | {
+  |     f(x?: string): void;
+  |     g(): void;
+  | })
+
+  x Type
+    ,-[$DIR/tests/pass/types/union/unionTypeReduction2/6.ts:15:5]
+ 15 | z.f('hello');
+    : ^^^^^^^^^^^^
+    `----
+
+Error: 
+  > void

--- a/crates/stc_ts_file_analyzer/tests/pass/types/union/unionTypeReduction2/6.ts
+++ b/crates/stc_ts_file_analyzer/tests/pass/types/union/unionTypeReduction2/6.ts
@@ -1,0 +1,17 @@
+//@strict: true
+
+type A = {
+    f(): void;
+}
+
+type B = {
+    f(x?: string): void;
+    g(): void;
+}
+
+export function f11(a: A, b: B) {
+    let z = !!true ? a : b;  // A | B
+    z.f();
+    z.f('hello');
+}
+

--- a/crates/stc_ts_type_checker/tests/conformance.pass.txt
+++ b/crates/stc_ts_type_checker/tests/conformance.pass.txt
@@ -1803,6 +1803,7 @@ parser/ecmascript5/parserExportAsFunctionIdentifier.ts
 parser/ecmascript5/parserImportDeclaration1.ts
 parser/ecmascript5/parserInExpression1.ts
 parser/ecmascript5/parserKeywordsAsIdentifierName1.ts
+parser/ecmascript5/parserNoASIOnCallAfterFunctionExpressambient/ambientDeclarationsPatterns_tooManyAsterisks.ts
 parser/ecmascript5/parserNoASIOnCallAfterFunctionExpression1.ts
 parser/ecmascript5/parserNotRegex2.ts
 parser/ecmascript5/parserObjectCreationArrayLiteral2.ts
@@ -1985,12 +1986,14 @@ types/intersection/intersectionMemberOfUnionNarrowsCorrectly.ts
 types/intersection/intersectionNarrowing.ts
 types/intersection/intersectionOfUnionNarrowing.ts
 types/intersection/intersectionOfUnionOfUnitTypes.ts
+types/intersection/intersectionTypeAssignment.ts
 types/intersection/intersectionTypeEquivalence.ts
 types/intersection/intersectionTypeInference.ts
 types/intersection/intersectionTypeInference2.ts
 types/intersection/intersectionTypeInference3.ts
 types/intersection/intersectionTypeMembers.ts
 types/intersection/operatorsAndIntersectionTypes.ts
+types/intersection/recursiveIntersectionTypes.ts
 types/keyof/keyofAndForIn.ts
 types/keyof/keyofIntersection.ts
 types/literal/booleanLiteralTypes1.ts

--- a/crates/stc_ts_type_checker/tests/conformance/expressions/functionCalls/callWithSpread4.ts.stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/conformance/expressions/functionCalls/callWithSpread4.ts.stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
     required_error: 2,
     matched_error: 0,
-    extra_error: 3,
+    extra_error: 2,
     panic: 0,
 }

--- a/crates/stc_ts_type_checker/tests/conformance/internalModules/DeclarationMerging/TwoInternalModulesThatMergeEachWithExportedInterfacesOfTheSameName.ts.stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/conformance/internalModules/DeclarationMerging/TwoInternalModulesThatMergeEachWithExportedInterfacesOfTheSameName.ts.stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
     required_error: 0,
     matched_error: 0,
-    extra_error: 2,
+    extra_error: 1,
     panic: 0,
 }

--- a/crates/stc_ts_type_checker/tests/conformance/types/intersection/intersectionAndUnionTypes.ts.stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/conformance/types/intersection/intersectionAndUnionTypes.ts.stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
-    required_error: 2,
-    matched_error: 12,
+    required_error: 4,
+    matched_error: 10,
     extra_error: 4,
     panic: 0,
 }

--- a/crates/stc_ts_type_checker/tests/conformance/types/intersection/intersectionTypeAssignment.ts.stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/conformance/types/intersection/intersectionTypeAssignment.ts.stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
     required_error: 0,
     matched_error: 4,
-    extra_error: 2,
+    extra_error: 0,
     panic: 0,
 }

--- a/crates/stc_ts_type_checker/tests/conformance/types/intersection/recursiveIntersectionTypes.ts.stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/conformance/types/intersection/recursiveIntersectionTypes.ts.stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
     required_error: 0,
     matched_error: 1,
-    extra_error: 1,
+    extra_error: 0,
     panic: 0,
 }

--- a/crates/stc_ts_type_checker/tests/tsc-stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/tsc-stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
-    required_error: 4457,
-    matched_error: 5427,
-    extra_error: 1038,
+    required_error: 4459,
+    matched_error: 5425,
+    extra_error: 1033,
     panic: 90,
 }


### PR DESCRIPTION
**Description:**

 - `assign`: Use `TypeLitMetadata.specified`.
 - `extends`: Use correct logic for unknown RHS.
