### PR TITLE
fix(ts/analyzer): Fix trivial false positives

### DIFF
--- a/crates/stc_ts_errors/src/lib.rs
+++ b/crates/stc_ts_errors/src/lib.rs
@@ -724,6 +724,7 @@ pub enum Error {
     /// TS2539
     CannotAssignToNonVariable {
         span: Span,
+        ty: Box<Type>,
     },
 
     /// TS2708

--- a/crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs
@@ -1728,7 +1728,12 @@ impl Analyzer<'_, '_> {
                             | Type::Interface(..)
                             | Type::Module(..)
                             | Type::EnumVariant(..) => fail!(),
-                            Type::Function(..) => return Err(Error::CannotAssignToNonVariable { span: rhs.span() }),
+                            Type::Function(..) => {
+                                return Err(Error::CannotAssignToNonVariable {
+                                    span: rhs.span(),
+                                    ty: box rhs.clone(),
+                                })
+                            }
                             _ => {}
                         }
                     }

--- a/crates/stc_ts_file_analyzer/src/analyzer/assign/type_el.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/assign/type_el.rs
@@ -1183,6 +1183,12 @@ impl Analyzer<'_, '_> {
                     }) if &**sym == "toString" => {}
 
                     _ => {
+                        if let Key::Computed(l_key) = l_key {
+                            if l_key.ty.is_unknown() {
+                                continue;
+                            }
+                        }
+
                         if !opts.allow_missing_fields {
                             // No property with `key` found.
                             missing_fields.push(lm.clone());

--- a/crates/stc_ts_file_analyzer/src/analyzer/control_flow.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/control_flow.rs
@@ -28,7 +28,7 @@ use tracing::info;
 use crate::{
     analyzer::{
         assign::AssignOpts,
-        expr::{AccessPropertyOpts, IdCtx, TypeOfMode},
+        expr::{optional_chaining::is_obj_opt_chaining, AccessPropertyOpts, IdCtx, TypeOfMode},
         scope::{ScopeKind, VarInfo},
         util::ResultExt,
         Analyzer, Ctx,
@@ -1028,7 +1028,6 @@ impl Analyzer<'_, '_> {
 
                                 RPat::Expr(expr) => {
                                     // { ...obj?.a["b"] }
-                                    use crate::analyzer::expr::optional_chaining::is_obj_opt_chaining;
                                     if is_obj_opt_chaining(&expr) {
                                         return Err(Error::InvalidRestPatternInOptionalChain { span: r.span });
                                     }

--- a/crates/stc_ts_file_analyzer/src/analyzer/control_flow.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/control_flow.rs
@@ -1036,7 +1036,8 @@ impl Analyzer<'_, '_> {
                                 }
 
                                 RPat::Invalid(_) => {
-                                    self.storage.report(Error::BindingPatNotAllowedInRestPatArg { span: r.arg.span() });
+                                    // self.storage.report(Error::BindingPatNotAllowedInRestPatArg { span:
+                                    // r.arg.span() });
                                     self.storage.report(Error::RestArgMustBeVarOrMemberAccess { span: r.arg.span() });
                                 }
 

--- a/crates/stc_ts_file_analyzer/src/analyzer/expr/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/expr/mod.rs
@@ -431,6 +431,11 @@ impl Analyzer<'_, '_> {
                                         _ => err,
                                     }
                                 }
+                                Error::CannotAssignToNamespace { .. }
+                                | Error::CannotAssignToModule { .. }
+                                | Error::CannotAssignToClass { .. }
+                                | Error::CannotAssignToEnum { .. }
+                                | Error::CannotAssignToFunction { .. } => err,
                                 _ => {
                                     skip_right = false;
                                     err

--- a/crates/stc_ts_file_analyzer/src/analyzer/expr/update.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/expr/update.rs
@@ -70,7 +70,7 @@ impl Analyzer<'_, '_> {
                 Type::Enum(..) => {
                     errored = true;
 
-                    Err(Error::CannotAssignToNonVariable { span: e.arg.span() })
+                    Err(Error::CannotAssignToEnum { span: e.arg.span() })
                 }
 
                 Type::Lit(LitType {

--- a/crates/stc_ts_type_checker/tests/conformance.pass.txt
+++ b/crates/stc_ts_type_checker/tests/conformance.pass.txt
@@ -1772,6 +1772,8 @@ parser/ecmascript5/Statements/parserWithStatement2.ts
 parser/ecmascript5/StrictMode/parserStrictMode1.ts
 parser/ecmascript5/StrictMode/parserStrictMode15-negative.ts
 parser/ecmascript5/StrictMode/parserStrictMode16.ts
+parser/ecmascript5/StrictMode/parserStrictMode3-negative.ts
+parser/ecmascript5/StrictMode/parserStrictMode6-negative.ts
 parser/ecmascript5/SuperExpressions/parserSuperExpression1.ts
 parser/ecmascript5/SuperExpressions/parserSuperExpression3.ts
 parser/ecmascript5/SuperExpressions/parserSuperExpression4.ts

--- a/crates/stc_ts_type_checker/tests/conformance.pass.txt
+++ b/crates/stc_ts_type_checker/tests/conformance.pass.txt
@@ -361,6 +361,7 @@ es6/Symbols/symbolProperty49.ts
 es6/Symbols/symbolProperty5.ts
 es6/Symbols/symbolProperty50.ts
 es6/Symbols/symbolProperty51.ts
+es6/Symbols/symbolProperty52.ts
 es6/Symbols/symbolProperty53.ts
 es6/Symbols/symbolProperty54.ts
 es6/Symbols/symbolProperty55.ts

--- a/crates/stc_ts_type_checker/tests/conformance/es6/Symbols/symbolProperty52.ts.stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/conformance/es6/Symbols/symbolProperty52.ts.stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
     required_error: 0,
     matched_error: 2,
-    extra_error: 1,
+    extra_error: 0,
     panic: 0,
 }

--- a/crates/stc_ts_type_checker/tests/conformance/expressions/optionalChaining/elementAccessChain/elementAccessChain.3.ts.stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/conformance/expressions/optionalChaining/elementAccessChain/elementAccessChain.3.ts.stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
     required_error: 13,
     matched_error: 9,
-    extra_error: 2,
+    extra_error: 1,
     panic: 0,
 }

--- a/crates/stc_ts_type_checker/tests/conformance/expressions/optionalChaining/propertyAccessChain/propertyAccessChain.3.ts.stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/conformance/expressions/optionalChaining/propertyAccessChain/propertyAccessChain.3.ts.stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
     required_error: 13,
     matched_error: 9,
-    extra_error: 2,
+    extra_error: 1,
     panic: 0,
 }

--- a/crates/stc_ts_type_checker/tests/conformance/expressions/valuesAndReferences/assignmentToParenthesizedIdentifiers.ts.stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/conformance/expressions/valuesAndReferences/assignmentToParenthesizedIdentifiers.ts.stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
-    required_error: 2,
-    matched_error: 22,
-    extra_error: 5,
+    required_error: 1,
+    matched_error: 23,
+    extra_error: 4,
     panic: 0,
 }

--- a/crates/stc_ts_type_checker/tests/conformance/parser/ecmascript5/StrictMode/parserStrictMode3-negative.ts.stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/conformance/parser/ecmascript5/StrictMode/parserStrictMode3-negative.ts.stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
-    required_error: 1,
-    matched_error: 0,
-    extra_error: 1,
+    required_error: 0,
+    matched_error: 1,
+    extra_error: 0,
     panic: 0,
 }

--- a/crates/stc_ts_type_checker/tests/conformance/parser/ecmascript5/StrictMode/parserStrictMode6-negative.ts.stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/conformance/parser/ecmascript5/StrictMode/parserStrictMode6-negative.ts.stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
-    required_error: 1,
-    matched_error: 0,
-    extra_error: 1,
+    required_error: 0,
+    matched_error: 1,
+    extra_error: 0,
     panic: 0,
 }

--- a/crates/stc_ts_type_checker/tests/conformance/types/rest/objectRestNegative.ts.stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/conformance/types/rest/objectRestNegative.ts.stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
     required_error: 5,
     matched_error: 1,
-    extra_error: 1,
+    extra_error: 0,
     panic: 0,
 }

--- a/crates/stc_ts_type_checker/tests/tsc-stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/tsc-stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
-    required_error: 4459,
-    matched_error: 5425,
-    extra_error: 1033,
+    required_error: 4456,
+    matched_error: 5428,
+    extra_error: 1026,
     panic: 90,
 }

--- a/crates/stc_ts_types/src/lib.rs
+++ b/crates/stc_ts_types/src/lib.rs
@@ -1500,7 +1500,7 @@ impl Type {
     }
 
     pub fn is_unique_symbol(&self) -> bool {
-        match *self {
+        match self.normalize() {
             Type::Operator(Operator {
                 op: TsTypeOperatorOp::Unique,
                 ref ty,
@@ -1508,6 +1508,10 @@ impl Type {
             }) => ty.is_kwd(TsKeywordTypeKind::TsSymbolKeyword),
             _ => false,
         }
+    }
+
+    pub fn is_symbol_like(&self) -> bool {
+        self.is_symbol() || self.is_unique_symbol() || self.is_kwd(TsKeywordTypeKind::TsSymbolKeyword)
     }
 
     pub fn is_never(&self) -> bool {


### PR DESCRIPTION
**Description:**

 - Ignore `unknown` keys for missing properties.
 - Change the error code for assignment to non-variables.
 - Remove wrong errors for invalid rest patterns.

