### PR TITLE
feat(ts/analyzer): Improve handling of mapped types

### DIFF
--- a/crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs
@@ -484,6 +484,7 @@ impl Analyzer<'_, '_> {
             | Type::Alias(..)
             | Type::Instance(..)
             | Type::Intrinsic(..)
+            | Type::Mapped(..)
             | Type::Operator(Operator {
                 op: TsTypeOperatorOp::KeyOf,
                 ..

--- a/crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs
@@ -1804,7 +1804,20 @@ impl Analyzer<'_, '_> {
                     | TsKeywordTypeKind::TsBooleanKeyword
                     | TsKeywordTypeKind::TsNullKeyword
                     | TsKeywordTypeKind::TsUndefinedKeyword => match rhs {
-                        Type::Lit(..) | Type::Interface(..) | Type::TypeLit(..) | Type::Function(..) | Type::Constructor(..) => fail!(),
+                        Type::Lit(..) | Type::Interface(..) | Type::Function(..) | Type::Constructor(..) => fail!(),
+                        Type::TypeLit(..) => {
+                            let left = self.normalize(
+                                Some(span),
+                                Cow::Borrowed(to),
+                                NormalizeTypeOpts {
+                                    normalize_keywords: true,
+                                    ..Default::default()
+                                },
+                            )?;
+                            return self
+                                .assign_inner(data, &left, rhs, opts)
+                                .context("tried to assign a type literal to an expanded keyword");
+                        }
                         _ => {}
                     },
                     _ => {}

--- a/crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs
@@ -1816,6 +1816,10 @@ impl Analyzer<'_, '_> {
                             )?;
                             return self
                                 .assign_inner(data, &left, rhs, opts)
+                                .convert_err(|err| Error::SimpleAssignFailed {
+                                    span: err.span(),
+                                    cause: Some(box err),
+                                })
                                 .context("tried to assign a type literal to an expanded keyword");
                         }
                         _ => {}

--- a/crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs
@@ -1262,10 +1262,7 @@ impl Analyzer<'_, '_> {
                 }
 
                 if let Ok(Some(rhs)) = self.convert_type_to_type_lit(opts.span, Cow::Borrowed(rhs)) {
-                    if self
-                        .assign_without_wrapping(data, to, &Type::TypeLit(rhs.into_owned()), opts)
-                        .is_ok()
-                    {
+                    if self.assign_inner(data, to, &Type::TypeLit(rhs.into_owned()), opts).is_ok() {
                         return Ok(());
                     }
                 }

--- a/crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs
@@ -589,7 +589,14 @@ impl Analyzer<'_, '_> {
                     right_ident: opts.right_ident_span,
                     cause: vec![],
                 })
-                .with_context(|| format!("`fail!()` called from assign/mod.rs:{}", line!()));
+                .with_context(|| {
+                    format!(
+                        "`fail!()` called from assign/mod.rs:{}\nLHS: {}\nRHS: {}",
+                        line!(),
+                        dump_type_as_string(&self.cm, to),
+                        dump_type_as_string(&self.cm, rhs)
+                    )
+                });
             }};
         }
 

--- a/crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs
@@ -591,7 +591,7 @@ impl Analyzer<'_, '_> {
                 })
                 .with_context(|| {
                     format!(
-                        "`fail!()` called from assign/mod.rs:{}\nLHS: {}\nRHS: {}",
+                        "`fail!()` called from assign/mod.rs:{}\nLHS (final): {}\nRHS (final): {}",
                         line!(),
                         dump_type_as_string(&self.cm, to),
                         dump_type_as_string(&self.cm, rhs)

--- a/crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs
@@ -818,7 +818,7 @@ impl Analyzer<'_, '_> {
             _ => {}
         }
 
-        if to.is_str() || to.is_num() {
+        if to.is_str_lit() || to.is_num_lit() || to.is_bool_lit() {
             if rhs.is_type_lit() {
                 fail!()
             }

--- a/crates/stc_ts_file_analyzer/src/analyzer/types/mapped.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/types/mapped.rs
@@ -6,8 +6,8 @@ use stc_ts_base_type_ops::apply_mapped_flags;
 use stc_ts_errors::{debug::dump_type_as_string, DebugExt};
 use stc_ts_generics::type_param::finder::TypeParamNameUsageFinder;
 use stc_ts_types::{
-    Conditional, FnParam, Id, IndexSignature, IndexedAccessType, Key, LitType, Mapped, Operator, PropertySignature, Type, TypeElement,
-    TypeLit,
+    Array, Conditional, FnParam, Id, IndexSignature, IndexedAccessType, Key, LitType, Mapped, Operator, PropertySignature, Type,
+    TypeElement, TypeLit,
 };
 use stc_utils::cache::{Freeze, ALLOW_DEEP_CLONE};
 use swc_common::{Span, Spanned, TypeEq};
@@ -67,6 +67,16 @@ impl Analyzer<'_, '_> {
                             return Ok(Some(Type::TypeLit(new)));
                         }
                     }
+                }
+
+                if let Some(array) = keyof_operand.as_array() {
+                    let ty = Type::Array(Array {
+                        span,
+                        elem_type: m.ty.clone().unwrap_or_else(|| box Type::any(span, Default::default())),
+                        metadata: array.metadata,
+                    })
+                    .freezed();
+                    return Ok(Some(ty));
                 }
 
                 let keys = self.get_property_names_for_mapped_type(span, keyof_operand)?;

--- a/crates/stc_ts_file_analyzer/src/analyzer/types/mapped.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/types/mapped.rs
@@ -6,12 +6,12 @@ use stc_ts_base_type_ops::apply_mapped_flags;
 use stc_ts_errors::{debug::dump_type_as_string, DebugExt};
 use stc_ts_generics::type_param::finder::TypeParamNameUsageFinder;
 use stc_ts_types::{
-    Array, Conditional, FnParam, Id, IndexSignature, IndexedAccessType, Key, LitType, Mapped, Operator, PropertySignature, Type,
-    TypeElement, TypeLit,
+    Array, Conditional, FnParam, Id, IndexSignature, IndexedAccessType, Key, KeywordType, LitType, Mapped, Operator, PropertySignature,
+    Type, TypeElement, TypeLit,
 };
 use stc_utils::cache::{Freeze, ALLOW_DEEP_CLONE};
 use swc_common::{Span, Spanned, TypeEq};
-use swc_ecma_ast::{TruePlusMinus, TsTypeOperatorOp};
+use swc_ecma_ast::{TruePlusMinus, TsKeywordTypeKind, TsTypeOperatorOp};
 use tracing::{debug, error, instrument};
 
 use crate::{
@@ -318,6 +318,11 @@ impl Analyzer<'_, '_> {
         }
 
         match ty.normalize() {
+            Type::Keyword(KeywordType {
+                kind: TsKeywordTypeKind::TsUndefinedKeyword | TsKeywordTypeKind::TsNullKeyword,
+                ..
+            }) => return Ok(Some(vec![])),
+
             Type::TypeLit(ty) => {
                 let mut keys = vec![];
                 for m in &ty.members {

--- a/crates/stc_ts_file_analyzer/src/analyzer/types/mapped.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/types/mapped.rs
@@ -36,7 +36,7 @@ impl Analyzer<'_, '_> {
         let ty = self.expand_mapped_inner(span, m)?;
 
         if let Some(ty) = &ty {
-            let expanded = dump_type_as_string(&self.cm, &ALLOW_DEEP_CLONE.set(&(), || Type::Mapped(m.clone())));
+            let expanded = dump_type_as_string(&self.cm, ty);
 
             debug!("[types/mapped]: Expanded {} as {}", orig, expanded);
         }

--- a/crates/stc_ts_file_analyzer/src/analyzer/types/mapped.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/types/mapped.rs
@@ -300,7 +300,7 @@ impl Analyzer<'_, '_> {
     fn get_property_names_for_mapped_type(&mut self, span: Span, ty: &Type) -> VResult<Option<Vec<PropertyName>>> {
         let ty = self
             .normalize(
-                None,
+                Some(span),
                 Cow::Borrowed(ty),
                 NormalizeTypeOpts {
                     normalize_keywords: true,

--- a/crates/stc_ts_file_analyzer/src/analyzer/types/mapped.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/types/mapped.rs
@@ -51,6 +51,43 @@ impl Analyzer<'_, '_> {
                 ty: keyof_operand,
                 ..
             })) => {
+                if let Some(mapped_ty) = m.ty.as_deref() {
+                    let found_type_param_in_keyof_operand = {
+                        let mut v = TypeParamNameUsageFinder::default();
+                        keyof_operand.visit_with(&mut v);
+                        !v.params.is_empty()
+                    };
+                    if !found_type_param_in_keyof_operand {
+                        // Check if type in `keyof T` is only used as `T[K]`.
+                        // If so, we can just use the type.
+                        //
+                        // {
+                        //     [P#5430#0 in keyof number[]]: Box<number[][P]>;
+                        // };
+
+                        let mut finder = IndexedAccessTypeFinder {
+                            obj: &keyof_operand,
+                            key: &m.type_param.name,
+                            can_replace_indexed_type: false,
+                        };
+
+                        mapped_ty.visit_with(&mut finder);
+                        if finder.can_replace_indexed_type {
+                            let mut replacer = IndexedAccessTypeReplacer {
+                                obj: &keyof_operand,
+                                key: &m.type_param.name,
+                            };
+
+                            let mut ret_ty = mapped_ty.clone();
+                            ret_ty.visit_mut_with(&mut replacer);
+
+                            ret_ty = self.apply_mapped_flags_to_type(span, ret_ty, m.optional, m.readonly)?;
+
+                            return Ok(Some(ret_ty));
+                        }
+                    }
+                }
+
                 let keyof_operand = self
                     .normalize(Some(span), Cow::Borrowed(keyof_operand), Default::default())
                     .context("tried to normalize the operand of `in keyof`")?;
@@ -149,43 +186,6 @@ impl Analyzer<'_, '_> {
                         members,
                         metadata: Default::default(),
                     })));
-                }
-
-                if let Some(mapped_ty) = m.ty.as_deref() {
-                    let found_type_param_in_keyof_operand = {
-                        let mut v = TypeParamNameUsageFinder::default();
-                        keyof_operand.visit_with(&mut v);
-                        !v.params.is_empty()
-                    };
-                    if !found_type_param_in_keyof_operand {
-                        // Check if type in `keyof T` is only used as `T[K]`.
-                        // If so, we can just use the type.
-                        //
-                        // {
-                        //     [P#5430#0 in keyof number[]]: Box<number[][P]>;
-                        // };
-
-                        let mut finder = IndexedAccessTypeFinder {
-                            obj: &keyof_operand,
-                            key: &m.type_param.name,
-                            can_replace_indexed_type: false,
-                        };
-
-                        mapped_ty.visit_with(&mut finder);
-                        if finder.can_replace_indexed_type {
-                            let mut replacer = IndexedAccessTypeReplacer {
-                                obj: &keyof_operand,
-                                key: &m.type_param.name,
-                            };
-
-                            let mut ret_ty = mapped_ty.clone();
-                            ret_ty.visit_mut_with(&mut replacer);
-
-                            ret_ty = self.apply_mapped_flags_to_type(span, ret_ty, m.optional, m.readonly)?;
-
-                            return Ok(Some(ret_ty));
-                        }
-                    }
                 }
             }
             _ => match m.type_param.constraint.as_deref() {

--- a/crates/stc_ts_file_analyzer/src/analyzer/types/mapped.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/types/mapped.rs
@@ -483,11 +483,7 @@ impl Analyzer<'_, '_> {
             _ => {}
         }
 
-        unimplemented!(
-            "get_property_names_for_mapped_type:\n{}\n{:#?}",
-            dump_type_as_string(&self.cm, &ty),
-            ty
-        );
+        Ok(None)
     }
 
     pub(crate) fn apply_mapped_flags_to_type(

--- a/crates/stc_ts_file_analyzer/src/analyzer/util.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/util.rs
@@ -1,4 +1,4 @@
-use std::iter::once;
+use std::{borrow::Cow, iter::once};
 
 use rnode::{Fold, FoldWith, Visit};
 use stc_ts_ast_rnode::{RExpr, RIdent, RPropName, RStr, RTsEntityName, RTsType};
@@ -27,6 +27,12 @@ impl Analyzer<'_, '_> {
         if !cfg!(debug_assertions) {
             return;
         }
+        let ty = match ty.normalize() {
+            Type::Mapped(..) => self
+                .normalize(Some(span), Cow::Borrowed(ty), Default::default())
+                .unwrap_or(Cow::Borrowed(&ty)),
+            _ => Cow::Borrowed(ty),
+        };
 
         if let Some(debugger) = &self.debugger {
             ALLOW_DEEP_CLONE.set(&(), || {

--- a/crates/stc_ts_file_analyzer/tests/pass/types/mapped/mappedTypeWithAny/1.swc-stderr
+++ b/crates/stc_ts_file_analyzer/tests/pass/types/mapped/mappedTypeWithAny/1.swc-stderr
@@ -1,0 +1,40 @@
+
+  x Type
+   ,-[$DIR/tests/pass/types/mapped/mappedTypeWithAny/1.ts:4:1]
+ 4 | export let abc: any[] = stringifyArray(void 0 as any);
+   :                                        ^^^^^^
+   `----
+
+Error: 
+  > undefined
+
+  x Type
+   ,-[$DIR/tests/pass/types/mapped/mappedTypeWithAny/1.ts:4:1]
+ 4 | export let abc: any[] = stringifyArray(void 0 as any);
+   :                                        ^^^^^^^^^^^^^
+   `----
+
+Error: 
+  > any
+
+  x Type
+   ,-[$DIR/tests/pass/types/mapped/mappedTypeWithAny/1.ts:4:1]
+ 4 | export let abc: any[] = stringifyArray(void 0 as any);
+   :                         ^^^^^^^^^^^^^^
+   `----
+
+Error: 
+  > <T extends readonly any[]>(arr: T) => {
+  |     -readonly [K in keyof T]: string;
+  | }
+
+  x Type
+   ,-[$DIR/tests/pass/types/mapped/mappedTypeWithAny/1.ts:4:1]
+ 4 | export let abc: any[] = stringifyArray(void 0 as any);
+   :                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   `----
+
+Error: 
+  > {
+  |     -readonly [K in keyof T]: string;
+  | }

--- a/crates/stc_ts_file_analyzer/tests/pass/types/mapped/mappedTypeWithAny/1.ts
+++ b/crates/stc_ts_file_analyzer/tests/pass/types/mapped/mappedTypeWithAny/1.ts
@@ -1,0 +1,4 @@
+//@strict: true
+
+declare function stringifyArray<T extends readonly any[]>(arr: T): { -readonly [K in keyof T]: string };
+export let abc: any[] = stringifyArray(void 0 as any);

--- a/crates/stc_ts_file_analyzer/tests/pass/types/mapped/mappedTypes4/1.ts
+++ b/crates/stc_ts_file_analyzer/tests/pass/types/mapped/mappedTypes4/1.ts
@@ -1,0 +1,21 @@
+
+type DeepReadonly<T> = {
+    readonly [P in keyof T]: DeepReadonly<T[P]>;
+};
+
+type Foo = {
+    x: number;
+    y: { a: string, b: number };
+    z: boolean;
+};
+
+type DeepReadonlyFoo = {
+    readonly x: number;
+    readonly y: { readonly a: string, readonly b: number };
+    readonly z: boolean;
+};
+
+var x1: DeepReadonly<Foo>;
+var x1: DeepReadonlyFoo;
+
+export { }

--- a/crates/stc_ts_type_checker/tests/conformance/controlFlow/controlFlowBindingElement.ts.stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/conformance/controlFlow/controlFlowBindingElement.ts.stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
     required_error: 0,
     matched_error: 0,
-    extra_error: 0,
-    panic: 1,
+    extra_error: 13,
+    panic: 0,
 }

--- a/crates/stc_ts_type_checker/tests/conformance/types/intersection/intersectionReductionStrict.ts.stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/conformance/types/intersection/intersectionReductionStrict.ts.stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
     required_error: 3,
     matched_error: 0,
-    extra_error: 20,
+    extra_error: 17,
     panic: 0,
 }

--- a/crates/stc_ts_type_checker/tests/conformance/types/intersection/intersectionWithUnionConstraint.ts.stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/conformance/types/intersection/intersectionWithUnionConstraint.ts.stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
-    required_error: 0,
-    matched_error: 5,
-    extra_error: 11,
+    required_error: 3,
+    matched_error: 2,
+    extra_error: 8,
     panic: 0,
 }

--- a/crates/stc_ts_type_checker/tests/conformance/types/mapped/isomorphicMappedTypeInference.ts.stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/conformance/types/mapped/isomorphicMappedTypeInference.ts.stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
     required_error: 0,
     matched_error: 0,
-    extra_error: 0,
-    panic: 1,
+    extra_error: 8,
+    panic: 0,
 }

--- a/crates/stc_ts_type_checker/tests/conformance/types/mapped/mappedTypeErrors.ts.stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/conformance/types/mapped/mappedTypeErrors.ts.stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
-    required_error: 22,
-    matched_error: 5,
+    required_error: 21,
+    matched_error: 6,
     extra_error: 19,
     panic: 0,
 }

--- a/crates/stc_ts_type_checker/tests/conformance/types/mapped/mappedTypeWithAny.ts.stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/conformance/types/mapped/mappedTypeWithAny.ts.stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
-    required_error: 3,
-    matched_error: 1,
-    extra_error: 1,
+    required_error: 2,
+    matched_error: 2,
+    extra_error: 0,
     panic: 0,
 }

--- a/crates/stc_ts_type_checker/tests/conformance/types/mapped/mappedTypes5.ts.stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/conformance/types/mapped/mappedTypes5.ts.stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
     required_error: 3,
     matched_error: 0,
-    extra_error: 12,
+    extra_error: 13,
     panic: 0,
 }

--- a/crates/stc_ts_type_checker/tests/conformance/types/mapped/mappedTypesArraysTuples.ts.stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/conformance/types/mapped/mappedTypesArraysTuples.ts.stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
     required_error: 0,
     matched_error: 0,
-    extra_error: 7,
+    extra_error: 5,
     panic: 0,
 }

--- a/crates/stc_ts_type_checker/tests/conformance/types/mapped/recursiveMappedTypes.ts.stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/conformance/types/mapped/recursiveMappedTypes.ts.stats.rust-debug
@@ -2,5 +2,5 @@ Stats {
     required_error: 9,
     matched_error: 0,
     extra_error: 0,
-    panic: 1,
+    panic: 0,
 }

--- a/crates/stc_ts_type_checker/tests/conformance/types/primitives/string/assignFromStringInterface2.ts.stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/conformance/types/primitives/string/assignFromStringInterface2.ts.stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
-    required_error: 1,
-    matched_error: 1,
-    extra_error: 2,
+    required_error: 0,
+    matched_error: 2,
+    extra_error: 1,
     panic: 0,
 }

--- a/crates/stc_ts_type_checker/tests/tsc-stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/tsc-stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
     required_error: 4461,
     matched_error: 5423,
-    extra_error: 988,
-    panic: 89,
+    extra_error: 1000,
+    panic: 86,
 }


### PR DESCRIPTION
**Description:**

 - Support array types in `keyof`.
 - Normalize while assigning.
 - Normalize the operand of `in keyof T`.
 - Resolve indexed access types in type arguments before expanding a reference.
 - Fix stack overflow of `convert_type_to_type_lit`.
 - `get_property_names_for_mapped_type`: Support `null` and `undefined`.

