### PR TITLE
fix(ts/analyzer): Fix bugs related to `globalThis`

### DIFF
--- a/crates/stc_ts_file_analyzer/src/analyzer/assign/function.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/assign/function.rs
@@ -662,17 +662,11 @@ impl Analyzer<'_, '_> {
 
         // TODO(kdy1): Change this to extends call.
 
-        let mut l_ty = self.normalize(Some(opts.span), Cow::Borrowed(&l.ty), Default::default())?;
-        let mut r_ty = self.normalize(Some(opts.span), Cow::Borrowed(&r.ty), Default::default())?;
-
-        l_ty.make_clone_cheap();
-        r_ty.make_clone_cheap();
-
         let res = if opts.for_overload {
-            self.assign_with_opts(data, &l_ty, &r_ty, opts)
+            self.assign_with_opts(data, &l.ty, &r.ty, opts)
                 .context("tried to assign the type of a parameter to another")
         } else {
-            self.assign_with_opts(data, &r_ty, &l_ty, opts)
+            self.assign_with_opts(data, &r.ty, &l.ty, opts)
                 .context("tried to assign the type of a parameter to another (reversed due to variance)")
         };
 

--- a/crates/stc_ts_file_analyzer/src/analyzer/expr/call_new.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/expr/call_new.rs
@@ -11,7 +11,7 @@ use stc_ts_ast_rnode::{
 };
 use stc_ts_env::MarkExt;
 use stc_ts_errors::{
-    debug::{dump_type_as_string, dump_type_map, print_backtrace, print_type},
+    debug::{dump_type_as_string, dump_type_map, print_type},
     DebugExt, Error,
 };
 use stc_ts_file_analyzer_macros::extra_validator;
@@ -2345,10 +2345,7 @@ impl Analyzer<'_, '_> {
 
         {
             let arg_check_res = self.validate_arg_count(span, &params, args, arg_types, spread_arg_types);
-            match arg_check_res {
-                Err(..) => print_backtrace(),
-                _ => {}
-            }
+
             arg_check_res.report(&mut self.storage);
         }
 

--- a/crates/stc_ts_file_analyzer/src/analyzer/expr/call_new.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/expr/call_new.rs
@@ -554,6 +554,7 @@ impl Analyzer<'_, '_> {
                     Cow::Borrowed(obj_type),
                     NormalizeTypeOpts {
                         preserve_intersection: true,
+                        preserve_global_this: true,
                         ..Default::default()
                     },
                 )

--- a/crates/stc_ts_file_analyzer/src/analyzer/expr/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/expr/mod.rs
@@ -1254,9 +1254,9 @@ impl Analyzer<'_, '_> {
 
         if obj.is_global_this() {
             match prop {
-                Key::Normal { span, sym }
+                Key::Normal { span: key_span, sym }
                 | Key::Computed(ComputedKey {
-                    span,
+                    span: key_span,
                     expr: box RExpr::Lit(RLit::Str(RStr { value: sym, .. })),
                     ..
                 }) => {
@@ -1268,12 +1268,12 @@ impl Analyzer<'_, '_> {
                         IdCtx::Var => {
                             let res = self
                                 .env
-                                .get_global_var(*span, &sym)
+                                .get_global_var(span, &sym)
                                 .context("tried to access a prperty of `globalThis`");
 
                             // TODO(kdy1): Apply correct rule
                             if res.is_err() {
-                                return Ok(Type::any(*span, Default::default()));
+                                return Ok(Type::any(span, Default::default()));
                             }
 
                             return res.convert_err(|err| match err.actual() {
@@ -1291,7 +1291,7 @@ impl Analyzer<'_, '_> {
                         IdCtx::Type => {
                             return self
                                 .env
-                                .get_global_type(*span, &sym)
+                                .get_global_type(span, &sym)
                                 .context("tried to access a prperty of `globalThis`")
                                 .convert_err(|err| match err.actual() {
                                     Error::NoSuchType { span, name } => Error::NoSuchProperty {

--- a/crates/stc_ts_file_analyzer/src/analyzer/expr/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/expr/mod.rs
@@ -1271,7 +1271,7 @@ impl Analyzer<'_, '_> {
                                 .get_global_var(*span, &sym)
                                 .context("tried to access a prperty of `globalThis`");
 
-                            if res.is_err() && type_mode == TypeOfMode::LValue {
+                            if res.is_err() && (type_mode == TypeOfMode::LValue || !self.rule().no_implicit_any) {
                                 return Ok(Type::any(*span, Default::default()));
                             }
 

--- a/crates/stc_ts_file_analyzer/src/analyzer/expr/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/expr/mod.rs
@@ -1270,7 +1270,12 @@ impl Analyzer<'_, '_> {
 
             if obj.is_global_this() {
                 match prop {
-                    Key::Normal { span, sym } => {
+                    Key::Normal { span, sym }
+                    | Key::Computed(ComputedKey {
+                        span,
+                        expr: box RExpr::Lit(RLit::Str(RStr { value: sym, .. })),
+                        ..
+                    }) => {
                         return self
                             .env
                             .get_global_var(*span, &sym)

--- a/crates/stc_ts_file_analyzer/src/analyzer/expr/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/expr/mod.rs
@@ -1481,7 +1481,7 @@ impl Analyzer<'_, '_> {
         };
         let mut obj = match obj.normalize() {
             Type::Conditional(..) | Type::Instance(..) => self.normalize(
-                None,
+                Some(span),
                 Cow::Borrowed(obj),
                 NormalizeTypeOpts {
                     preserve_intersection: true,

--- a/crates/stc_ts_file_analyzer/src/analyzer/expr/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/expr/mod.rs
@@ -1477,11 +1477,12 @@ impl Analyzer<'_, '_> {
             ..self.ctx
         };
         let mut obj = match obj.normalize() {
-            Type::Conditional(..) | Type::Instance(..) => self.normalize(
+            Type::Conditional(..) | Type::Instance(..) | Type::Query(..) => self.normalize(
                 Some(span),
                 Cow::Borrowed(obj),
                 NormalizeTypeOpts {
                     preserve_intersection: true,
+                    preserve_global_this: true,
                     ..Default::default()
                 },
             )?,
@@ -2752,14 +2753,6 @@ impl Analyzer<'_, '_> {
                     metadata: Default::default(),
                 });
                 return Ok(ty);
-            }
-
-            Type::Query(QueryType {
-                expr: box QueryExpr::TsEntityName(name),
-                ..
-            }) => {
-                let obj = self.type_of_ts_entity_name(span, &name.clone().into(), None)?;
-                return self.access_property(span, &obj, prop, type_mode, id_ctx, opts);
             }
 
             Type::Function(f) if type_mode == TypeOfMode::RValue => {

--- a/crates/stc_ts_file_analyzer/src/analyzer/expr/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/expr/mod.rs
@@ -13,10 +13,7 @@ use stc_ts_ast_rnode::{
     RTsEnumMemberId, RTsLit, RTsNonNullExpr, RUnaryExpr,
 };
 use stc_ts_base_type_ops::bindings::BindingKind;
-use stc_ts_errors::{
-    debug::{dump_type_as_string, print_backtrace},
-    DebugExt, Error, Errors,
-};
+use stc_ts_errors::{debug::dump_type_as_string, DebugExt, Error, Errors};
 use stc_ts_generics::ExpandGenericOpts;
 use stc_ts_type_ops::{generalization::prevent_generalize, is_str_lit_or_union, Fix};
 pub use stc_ts_types::IdCtx;
@@ -2502,7 +2499,6 @@ impl Analyzer<'_, '_> {
                     }
                 }
 
-                print_backtrace();
                 // No property found
                 return Err(Error::NoSuchPropertyInModule {
                     span,

--- a/crates/stc_ts_file_analyzer/src/analyzer/expr/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/expr/mod.rs
@@ -2263,7 +2263,6 @@ impl Analyzer<'_, '_> {
                             return Ok(ty);
                         }
 
-                        print_backtrace();
                         return Err(Error::NoSuchProperty {
                             span,
                             obj: Some(box obj),
@@ -2770,7 +2769,6 @@ impl Analyzer<'_, '_> {
             Type::Function(f) if type_mode == TypeOfMode::RValue => {
                 // Use builtin type `Function`
                 let interface = self.env.get_global_type(f.span, &js_word!("Function"))?;
-                print_backtrace();
                 return self.access_property(span, &interface, prop, type_mode, id_ctx, opts);
             }
 

--- a/crates/stc_ts_file_analyzer/src/analyzer/expr/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/expr/mod.rs
@@ -1271,7 +1271,8 @@ impl Analyzer<'_, '_> {
                                 .get_global_var(*span, &sym)
                                 .context("tried to access a prperty of `globalThis`");
 
-                            if res.is_err() && (type_mode == TypeOfMode::LValue || !self.rule().no_implicit_any) {
+                            // TODO(kdy1): Apply correct rule
+                            if res.is_err() {
                                 return Ok(Type::any(*span, Default::default()));
                             }
 

--- a/crates/stc_ts_file_analyzer/src/analyzer/expr/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/expr/mod.rs
@@ -1268,6 +1268,20 @@ impl Analyzer<'_, '_> {
                 }
             }
 
+            if obj.is_global_this() {
+                match prop {
+                    Key::Normal { span, sym } => {
+                        return self
+                            .env
+                            .get_global_var(*span, &sym)
+                            .context("tired to access a prperty of `globalTHis`")
+                    }
+                    _ => {
+                        unimplemented!("access_property_inner: global_this: {:?}", prop);
+                    }
+                }
+            }
+
             match &obj {
                 Type::This(this) if !self.ctx.in_computed_prop_name && self.scope.is_this_ref_to_object_lit() => {
                     if let Key::Computed(prop) = prop {

--- a/crates/stc_ts_file_analyzer/src/analyzer/expr/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/expr/mod.rs
@@ -1274,7 +1274,18 @@ impl Analyzer<'_, '_> {
                         return self
                             .env
                             .get_global_var(*span, &sym)
-                            .context("tired to access a prperty of `globalTHis`")
+                            .context("tired to access a prperty of `globalThis`")
+                            .convert_err(|err| match err.actual() {
+                                Error::NoSuchVar { span, name } => Error::NoSuchProperty {
+                                    span: *span,
+                                    obj: Some(box obj.clone()),
+                                    prop: Some(box Key::Normal {
+                                        span: *span,
+                                        sym: name.sym().clone(),
+                                    }),
+                                },
+                                _ => err,
+                            })
                     }
                     _ => {
                         unimplemented!("access_property_inner: global_this: {:?}", prop);

--- a/crates/stc_ts_file_analyzer/src/analyzer/expr/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/expr/mod.rs
@@ -1291,7 +1291,18 @@ impl Analyzer<'_, '_> {
                             return self
                                 .env
                                 .get_global_type(*span, &sym)
-                                .context("tried to access a prperty of `globalThis`");
+                                .context("tried to access a prperty of `globalThis`")
+                                .convert_err(|err| match err.actual() {
+                                    Error::NoSuchType { span, name } => Error::NoSuchProperty {
+                                        span: *span,
+                                        obj: Some(box obj.clone()),
+                                        prop: Some(box Key::Normal {
+                                            span: *span,
+                                            sym: name.sym().clone(),
+                                        }),
+                                    },
+                                    _ => err,
+                                });
                         }
                     }
                 }

--- a/crates/stc_ts_file_analyzer/src/analyzer/expr/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/expr/mod.rs
@@ -2851,7 +2851,6 @@ impl Analyzer<'_, '_> {
             _ => {}
         }
 
-        print_backtrace();
         unimplemented!(
             "access_property(MemberExpr):\nObject: {:?}\nProp: {:?}\nPath: {}",
             obj,

--- a/crates/stc_ts_file_analyzer/src/analyzer/generic/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/generic/mod.rs
@@ -2036,8 +2036,6 @@ impl Analyzer<'_, '_> {
             }
         }
 
-        print_backtrace();
-
         Ok(false)
     }
 

--- a/crates/stc_ts_file_analyzer/src/analyzer/scope/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/scope/mod.rs
@@ -13,10 +13,7 @@ use iter::once;
 use once_cell::sync::Lazy;
 use rnode::{Fold, FoldWith, VisitMut, VisitMutWith, VisitWith};
 use stc_ts_ast_rnode::{RPat, RTsEntityName, RTsQualifiedName};
-use stc_ts_errors::{
-    debug::{dump_type_as_string, print_backtrace},
-    DebugExt, Error,
-};
+use stc_ts_errors::{debug::dump_type_as_string, DebugExt, Error};
 use stc_ts_generics::ExpandGenericOpts;
 use stc_ts_type_ops::{expansion::ExpansionPreventer, union_finder::UnionFinder, Fix};
 use stc_ts_types::{
@@ -2191,7 +2188,6 @@ impl Expander<'_, '_, '_> {
         let _stack = match stack::track(self.span) {
             Ok(v) => v,
             Err(..) => {
-                print_backtrace();
                 error!("[expander] Stack overflow: {}", dump_type_as_string(&self.analyzer.cm, &ty));
                 return ty;
             }

--- a/crates/stc_ts_file_analyzer/src/analyzer/scope/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/scope/mod.rs
@@ -2140,8 +2140,6 @@ impl Expander<'_, '_, '_> {
             }
         }
 
-        print_backtrace();
-
         Ok(Some(Type::any(span, Default::default())))
     }
 

--- a/crates/stc_ts_file_analyzer/src/analyzer/scope/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/scope/mod.rs
@@ -1343,11 +1343,6 @@ impl Analyzer<'_, '_> {
 
         let ty = ty.map(|ty| ty.freezed());
 
-        if let Some(actual_ty) = &actual_ty {
-            if actual_ty.is_never() {
-                print_backtrace();
-            }
-        }
         let actual_ty = actual_ty
             .and_then(|ty| {
                 if ty.is_any()

--- a/crates/stc_ts_file_analyzer/src/analyzer/scope/vars.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/scope/vars.rs
@@ -702,7 +702,7 @@ impl Analyzer<'_, '_> {
 
         let ty = (|| -> VResult<_> {
             let mut ty = self.normalize(
-                None,
+                Some(span),
                 Cow::Borrowed(ty),
                 NormalizeTypeOpts {
                     preserve_mapped: false,

--- a/crates/stc_ts_file_analyzer/src/analyzer/stmt/var_decl.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/stmt/var_decl.rs
@@ -24,6 +24,7 @@ use crate::{
         expr::TypeOfMode,
         pat::PatMode,
         scope::VarKind,
+        types::NormalizeTypeOpts,
         util::{Generalizer, ResultExt},
         Analyzer, Ctx,
     },
@@ -682,8 +683,15 @@ impl Analyzer<'_, '_> {
                         if !self.is_builtin {
                             // Report error if type is not found.
                             if let Some(ty) = &ty {
-                                self.normalize(Some(i.id.span), Cow::Borrowed(ty), Default::default())
-                                    .report(&mut self.storage);
+                                self.normalize(
+                                    Some(i.id.span),
+                                    Cow::Borrowed(ty),
+                                    NormalizeTypeOpts {
+                                        preserve_global_this: true,
+                                        ..Default::default()
+                                    },
+                                )
+                                .report(&mut self.storage);
                             }
                         }
 

--- a/crates/stc_ts_file_analyzer/src/analyzer/types/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/types/mod.rs
@@ -444,10 +444,9 @@ impl Analyzer<'_, '_> {
                                         _ => {}
                                     }
 
-                                    let expanded_ty = self.resolve_typeof(actual_span, e).with_context(|| {
-                                        print_backtrace();
-                                        "tried to resolve typeof as a part of normalization".into()
-                                    })?;
+                                    let expanded_ty = self
+                                        .resolve_typeof(actual_span, e)
+                                        .with_context(|| "tried to resolve typeof as a part of normalization".into())?;
 
                                     if expanded_ty.is_global_this() {
                                         return Ok(Cow::Owned(expanded_ty));

--- a/crates/stc_ts_file_analyzer/src/analyzer/types/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/types/mod.rs
@@ -426,20 +426,22 @@ impl Analyzer<'_, '_> {
                         if !opts.preserve_typeof {
                             match &*q.expr {
                                 QueryExpr::TsEntityName(e) => {
-                                    if opts.preserve_global_this {
-                                        match e {
-                                            RTsEntityName::Ident(i) => {
-                                                //
-                                                if &*i.sym == "globalThis" {
+                                    match e {
+                                        RTsEntityName::Ident(i) => {
+                                            //
+                                            if &*i.sym == "globalThis" {
+                                                if opts.preserve_global_this {
                                                     return Ok(Cow::Owned(Type::Query(QueryType {
                                                         span: actual_span,
                                                         expr: box QueryExpr::TsEntityName(e.clone()),
                                                         metadata: Default::default(),
                                                     })));
+                                                } else {
+                                                    print_backtrace()
                                                 }
                                             }
-                                            _ => {}
                                         }
+                                        _ => {}
                                     }
 
                                     let expanded_ty = self.resolve_typeof(actual_span, e).with_context(|| {

--- a/crates/stc_ts_type_checker/tests/conformance.pass.txt
+++ b/crates/stc_ts_type_checker/tests/conformance.pass.txt
@@ -1821,7 +1821,6 @@ parser/ecmascript5/parserExportAsFunctionIdentifier.ts
 parser/ecmascript5/parserImportDeclaration1.ts
 parser/ecmascript5/parserInExpression1.ts
 parser/ecmascript5/parserKeywordsAsIdentifierName1.ts
-parser/ecmascript5/parserNoASIOnCallAfterFunctionExpressambient/ambientDeclarationsPatterns_tooManyAsterisks.ts
 parser/ecmascript5/parserNoASIOnCallAfterFunctionExpression1.ts
 parser/ecmascript5/parserNotRegex2.ts
 parser/ecmascript5/parserObjectCreationArrayLiteral2.ts

--- a/crates/stc_ts_type_checker/tests/conformance.pass.txt
+++ b/crates/stc_ts_type_checker/tests/conformance.pass.txt
@@ -310,6 +310,7 @@ es2017/useSharedArrayBuffer5.ts
 es2017/useSharedArrayBuffer6.ts
 es2018/usePromiseFinally.ts
 es2018/useRegexpGroups.ts
+es2019/globalThisTypeIndexAccess.ts
 es2020/bigintMissingES2019.ts
 es2020/modules/exportAsNamespace_nonExistent.ts
 es2020/numberFormatCurrencySign.ts

--- a/crates/stc_ts_type_checker/tests/conformance/classes/members/privateNames/privateNameStaticAccessorsAccess.ts.stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/conformance/classes/members/privateNames/privateNameStaticAccessorsAccess.ts.stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
     required_error: 3,
     matched_error: 0,
-    extra_error: 2,
+    extra_error: 0,
     panic: 0,
 }

--- a/crates/stc_ts_type_checker/tests/conformance/classes/members/privateNames/privateNameStaticAccessorssDerivedClasses.ts.stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/conformance/classes/members/privateNames/privateNameStaticAccessorssDerivedClasses.ts.stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
-    required_error: 1,
-    matched_error: 1,
-    extra_error: 0,
+    required_error: 2,
+    matched_error: 0,
+    extra_error: 1,
     panic: 0,
 }

--- a/crates/stc_ts_type_checker/tests/conformance/classes/members/privateNames/privateNameStaticMethodAssignment.ts.stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/conformance/classes/members/privateNames/privateNameStaticMethodAssignment.ts.stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
     required_error: 5,
     matched_error: 0,
-    extra_error: 1,
+    extra_error: 0,
     panic: 0,
 }

--- a/crates/stc_ts_type_checker/tests/conformance/es2019/globalThisAmbientModules.ts.stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/conformance/es2019/globalThisAmbientModules.ts.stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
-    required_error: 2,
-    matched_error: 0,
-    extra_error: 2,
+    required_error: 0,
+    matched_error: 2,
+    extra_error: 3,
     panic: 0,
 }

--- a/crates/stc_ts_type_checker/tests/conformance/es2019/globalThisBlockscopedProperties.ts.stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/conformance/es2019/globalThisBlockscopedProperties.ts.stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
-    required_error: 6,
-    matched_error: 0,
-    extra_error: 9,
+    required_error: 4,
+    matched_error: 2,
+    extra_error: 10,
     panic: 0,
 }

--- a/crates/stc_ts_type_checker/tests/conformance/es2019/globalThisBlockscopedProperties.ts.stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/conformance/es2019/globalThisBlockscopedProperties.ts.stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
     required_error: 6,
     matched_error: 0,
-    extra_error: 12,
+    extra_error: 9,
     panic: 0,
 }

--- a/crates/stc_ts_type_checker/tests/conformance/es2019/globalThisTypeIndexAccess.ts.stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/conformance/es2019/globalThisTypeIndexAccess.ts.stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
     required_error: 0,
     matched_error: 0,
-    extra_error: 1,
+    extra_error: 0,
     panic: 0,
 }

--- a/crates/stc_ts_type_checker/tests/conformance/es2019/globalThisUnknown.ts.stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/conformance/es2019/globalThisUnknown.ts.stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
     required_error: 1,
     matched_error: 0,
-    extra_error: 3,
+    extra_error: 2,
     panic: 0,
 }

--- a/crates/stc_ts_type_checker/tests/conformance/es2019/globalThisUnknownNoImplicitAny.ts.stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/conformance/es2019/globalThisUnknownNoImplicitAny.ts.stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
     required_error: 6,
     matched_error: 0,
-    extra_error: 3,
+    extra_error: 2,
     panic: 0,
 }

--- a/crates/stc_ts_type_checker/tests/conformance/es6/arrowFunction/emitArrowFunctionThisCapturing.ts.stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/conformance/es6/arrowFunction/emitArrowFunctionThisCapturing.ts.stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
     required_error: 1,
     matched_error: 0,
-    extra_error: 0,
+    extra_error: 1,
     panic: 0,
 }

--- a/crates/stc_ts_type_checker/tests/conformance/es6/arrowFunction/emitArrowFunctionThisCapturingES6.ts.stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/conformance/es6/arrowFunction/emitArrowFunctionThisCapturingES6.ts.stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
     required_error: 1,
     matched_error: 0,
-    extra_error: 0,
+    extra_error: 1,
     panic: 0,
 }

--- a/crates/stc_ts_type_checker/tests/conformance/expressions/functions/arrowFunctionContexts.ts.stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/conformance/expressions/functions/arrowFunctionContexts.ts.stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
     required_error: 4,
     matched_error: 2,
-    extra_error: 2,
+    extra_error: 4,
     panic: 0,
 }

--- a/crates/stc_ts_type_checker/tests/conformance/expressions/thisKeyword/typeOfThisGeneral.ts.stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/conformance/expressions/thisKeyword/typeOfThisGeneral.ts.stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
     required_error: 0,
     matched_error: 10,
-    extra_error: 21,
+    extra_error: 18,
     panic: 0,
 }

--- a/crates/stc_ts_type_checker/tests/conformance/functions/functionParameterObjectRestAndInitializers.ts.stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/conformance/functions/functionParameterObjectRestAndInitializers.ts.stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
     required_error: 0,
     matched_error: 0,
-    extra_error: 0,
-    panic: 1,
+    extra_error: 3,
+    panic: 0,
 }

--- a/crates/stc_ts_type_checker/tests/conformance/types/rest/objectRest.ts.stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/conformance/types/rest/objectRest.ts.stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
     required_error: 6,
     matched_error: 0,
-    extra_error: 0,
-    panic: 1,
+    extra_error: 5,
+    panic: 0,
 }

--- a/crates/stc_ts_type_checker/tests/conformance/types/rest/objectRestParameter.ts.stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/conformance/types/rest/objectRestParameter.ts.stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
     required_error: 0,
     matched_error: 0,
-    extra_error: 0,
-    panic: 1,
+    extra_error: 1,
+    panic: 0,
 }

--- a/crates/stc_ts_type_checker/tests/conformance/types/rest/objectRestParameterES5.ts.stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/conformance/types/rest/objectRestParameterES5.ts.stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
     required_error: 0,
     matched_error: 0,
-    extra_error: 0,
-    panic: 1,
+    extra_error: 1,
+    panic: 0,
 }

--- a/crates/stc_ts_type_checker/tests/conformance/types/specifyingTypes/typeQueries/typeofThis.ts.stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/conformance/types/specifyingTypes/typeQueries/typeofThis.ts.stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
     required_error: 8,
     matched_error: 0,
-    extra_error: 28,
+    extra_error: 26,
     panic: 0,
 }

--- a/crates/stc_ts_type_checker/tests/conformance/types/typeRelationships/typeAndMemberIdentity/objectTypesIdentityWithCallSignatures3.ts.stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/conformance/types/typeRelationships/typeAndMemberIdentity/objectTypesIdentityWithCallSignatures3.ts.stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
     required_error: 2,
     matched_error: 0,
-    extra_error: 1,
+    extra_error: 0,
     panic: 0,
 }

--- a/crates/stc_ts_type_checker/tests/tsc-stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/tsc-stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
-    required_error: 4392,
-    matched_error: 5492,
-    extra_error: 976,
-    panic: 82,
+    required_error: 4389,
+    matched_error: 5495,
+    extra_error: 978,
+    panic: 78,
 }


### PR DESCRIPTION
**Description:**

 - Remove needless normalizations.
 - Ignore `globalThis` in some code paths.
 - `access_property`: Support `globalThis`.