### PR TITLE
refactor(ts/errors): Prepare RAII-based context for errors

### DIFF
--- a/crates/stc_ts_env/src/lib.rs
+++ b/crates/stc_ts_env/src/lib.rs
@@ -4,7 +4,7 @@ use derivative::Derivative;
 use parking_lot::Mutex;
 use rustc_hash::FxHashMap;
 use serde::{Deserialize, Serialize};
-use stc_ts_errors::ErrorKind;
+use stc_ts_errors::{Error, ErrorKind};
 use stc_ts_type_ops::Fix;
 use stc_ts_types::{Id, Type};
 use stc_utils::cache::Freeze;
@@ -94,7 +94,7 @@ impl Env {
     }
 
     #[cfg_attr(debug_assertions, tracing::instrument(skip_all))]
-    pub fn get_global_var(&self, span: Span, name: &JsWord) -> Result<Type, ErrorKind> {
+    pub fn get_global_var(&self, span: Span, name: &JsWord) -> Result<Type, Error> {
         if let Some(ty) = self.global_vars.lock().get(name) {
             debug_assert!(ty.is_clone_cheap(), "{:?}", *ty);
             return Ok((*ty).clone());
@@ -108,11 +108,12 @@ impl Env {
         Err(ErrorKind::NoSuchVar {
             span,
             name: Id::word(name.clone()),
-        })
+        }
+        .into())
     }
 
     #[cfg_attr(debug_assertions, tracing::instrument(skip_all))]
-    pub fn get_global_type(&self, span: Span, name: &JsWord) -> Result<Type, ErrorKind> {
+    pub fn get_global_type(&self, span: Span, name: &JsWord) -> Result<Type, Error> {
         if let Some(ty) = self.global_types.lock().get(name) {
             debug_assert!(ty.is_clone_cheap(), "{:?}", *ty);
             return Ok((*ty).clone());
@@ -126,7 +127,8 @@ impl Env {
         Err(ErrorKind::NoSuchType {
             span,
             name: Id::word(name.clone()),
-        })
+        }
+        .into())
     }
 }
 

--- a/crates/stc_ts_env/src/lib.rs
+++ b/crates/stc_ts_env/src/lib.rs
@@ -4,7 +4,7 @@ use derivative::Derivative;
 use parking_lot::Mutex;
 use rustc_hash::FxHashMap;
 use serde::{Deserialize, Serialize};
-use stc_ts_errors::Error;
+use stc_ts_errors::ErrorKind;
 use stc_ts_type_ops::Fix;
 use stc_ts_types::{Id, Type};
 use stc_utils::cache::Freeze;
@@ -94,7 +94,7 @@ impl Env {
     }
 
     #[cfg_attr(debug_assertions, tracing::instrument(skip_all))]
-    pub fn get_global_var(&self, span: Span, name: &JsWord) -> Result<Type, Error> {
+    pub fn get_global_var(&self, span: Span, name: &JsWord) -> Result<Type, ErrorKind> {
         if let Some(ty) = self.global_vars.lock().get(name) {
             debug_assert!(ty.is_clone_cheap(), "{:?}", *ty);
             return Ok((*ty).clone());
@@ -105,14 +105,14 @@ impl Env {
             return Ok(v.clone());
         }
 
-        Err(Error::NoSuchVar {
+        Err(ErrorKind::NoSuchVar {
             span,
             name: Id::word(name.clone()),
         })
     }
 
     #[cfg_attr(debug_assertions, tracing::instrument(skip_all))]
-    pub fn get_global_type(&self, span: Span, name: &JsWord) -> Result<Type, Error> {
+    pub fn get_global_type(&self, span: Span, name: &JsWord) -> Result<Type, ErrorKind> {
         if let Some(ty) = self.global_types.lock().get(name) {
             debug_assert!(ty.is_clone_cheap(), "{:?}", *ty);
             return Ok((*ty).clone());
@@ -123,7 +123,7 @@ impl Env {
             return Ok(ty.clone());
         }
 
-        Err(Error::NoSuchType {
+        Err(ErrorKind::NoSuchType {
             span,
             name: Id::word(name.clone()),
         })

--- a/crates/stc_ts_errors/src/lib.rs
+++ b/crates/stc_ts_errors/src/lib.rs
@@ -56,7 +56,7 @@ impl std::ops::Deref for Error {
 impl From<ErrorKind> for Error {
     fn from(kind: ErrorKind) -> Self {
         Self {
-            contexts: with_ctx(|contexts| contexts.iter().map(|v| v()).collect()),
+            contexts: with_ctx(|contexts| contexts.iter().rev().map(|v| v()).collect()),
             inner: Box::new(kind),
         }
     }

--- a/crates/stc_ts_errors/src/lib.rs
+++ b/crates/stc_ts_errors/src/lib.rs
@@ -71,12 +71,23 @@ impl Error {
         self.contexts.push(context.to_string());
         self
     }
+
+    #[cold]
+    pub fn emit(&self, h: &Handler) {
+        let span = self.span();
+
+        let mut err = h.struct_span_err_with_code(
+            span,
+            &format!("{:?}", self),
+            DiagnosticId::Error(format!("TS{}", ErrorKind::normalize_error_code(self.code()))),
+        );
+
+        err.emit();
+    }
 }
 
 impl Debug for Error {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        let mut next = Some(self);
-
         for ctx in self.contexts.iter() {
             writeln!(f, "{}: {}", Yellow.paint("context"), ctx)?;
         }
@@ -1992,19 +2003,6 @@ impl ErrorKind {
 
             _ => format!("{:#?}", self).into(),
         }
-    }
-
-    #[cold]
-    pub fn emit(self, h: &Handler) {
-        let span = self.span();
-
-        let mut err = h.struct_span_err_with_code(
-            span,
-            &self.msg(),
-            DiagnosticId::Error(format!("TS{}", Self::normalize_error_code(self.code()))),
-        );
-
-        err.emit();
     }
 
     #[cold]

--- a/crates/stc_ts_errors/src/lib.rs
+++ b/crates/stc_ts_errors/src/lib.rs
@@ -1444,7 +1444,7 @@ impl ErrorKind {
                 let mut new = Vec::with_capacity(errors.capacity());
                 for err in errors {
                     new.push(Error {
-                        inner: box err.convert_all_inner(op),
+                        inner: box err.inner.convert_all_inner(op),
                     });
                 }
 

--- a/crates/stc_ts_errors/src/lib.rs
+++ b/crates/stc_ts_errors/src/lib.rs
@@ -88,7 +88,7 @@ impl Error {
 
 impl Debug for Error {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        for ctx in self.contexts.iter() {
+        for ctx in self.contexts.iter().rev() {
             writeln!(f, "{}: {}", Yellow.paint("context"), ctx)?;
         }
 

--- a/crates/stc_ts_errors/src/lib.rs
+++ b/crates/stc_ts_errors/src/lib.rs
@@ -2112,3 +2112,9 @@ impl From<StackOverflowError> for ErrorKind {
         ErrorKind::StackOverflow { span: e.span }
     }
 }
+
+impl From<StackOverflowError> for Error {
+    fn from(e: StackOverflowError) -> Self {
+        ErrorKind::from(e).into()
+    }
+}

--- a/crates/stc_ts_errors/src/lib.rs
+++ b/crates/stc_ts_errors/src/lib.rs
@@ -78,7 +78,7 @@ impl Error {
 
         let mut err = h.struct_span_err_with_code(
             span,
-            &format!("{:?}", self),
+            &format!("{:#?}", self),
             DiagnosticId::Error(format!("TS{}", ErrorKind::normalize_error_code(self.code()))),
         );
 

--- a/crates/stc_ts_errors/src/lib.rs
+++ b/crates/stc_ts_errors/src/lib.rs
@@ -32,6 +32,7 @@ pub mod context;
 pub mod debug;
 mod result_ext;
 
+/// [ErrorKind] with debug contexts attached.
 #[derive(Debug, Clone, PartialEq, Spanned)]
 pub struct Error {
     #[span]

--- a/crates/stc_ts_errors/src/lib.rs
+++ b/crates/stc_ts_errors/src/lib.rs
@@ -1428,11 +1428,12 @@ pub enum ErrorKind {
 assert_eq_size!(ErrorKind, [u8; 72]);
 
 impl Error {
-    pub fn convert<F>(self, op: F) -> Self
+    pub fn convert<F>(mut self, op: F) -> Self
     where
-        F: FnOnce(Self) -> Self,
+        F: FnOnce(ErrorKind) -> ErrorKind,
     {
-        op(self)
+        self.inner = box op(*self.inner);
+        self
     }
 
     /// Convert all errors if `self` is [Error::Errors] and convert itself

--- a/crates/stc_ts_errors/src/lib.rs
+++ b/crates/stc_ts_errors/src/lib.rs
@@ -38,6 +38,14 @@ pub struct Error {
     inner: Box<ErrorKind>,
 }
 
+impl std::ops::Deref for Error {
+    type Target = ErrorKind;
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+
 impl From<ErrorKind> for Error {
     fn from(kind: ErrorKind) -> Self {
         Self {
@@ -58,7 +66,7 @@ impl Errors {
             }
         }
 
-        match err {
+        match &*err.inner {
             // Error::UndefinedSymbol { .. } => panic!(),
             ErrorKind::Errors { ref errors, .. } => {
                 for err in errors {
@@ -1470,7 +1478,7 @@ impl DebugContext {
 pub struct DebugContext {
     pub span: Span,
     pub context: String,
-    pub inner: Box<Error>,
+    pub inner: Box<ErrorKind>,
 }
 
 impl Debug for DebugContext {

--- a/crates/stc_ts_errors/src/result_ext.rs
+++ b/crates/stc_ts_errors/src/result_ext.rs
@@ -7,6 +7,29 @@ pub trait DebugExt<T>: Into<Result<T, Error>> {
     {
         self.into().map_err(|err: Error| err.convert(op))
     }
+
+    #[inline]
+    #[track_caller]
+    fn context(self, msg: &str) -> Result<T, Error> {
+        if !cfg!(debug_assertions) {
+            return self.into();
+        }
+
+        self.into().map_err(|err: Error| err.context(msg))
+    }
+
+    #[inline]
+    #[track_caller]
+    fn with_context<F>(self, msg: F) -> Result<T, Error>
+    where
+        F: FnOnce() -> String,
+    {
+        if !cfg!(debug_assertions) {
+            return self.into();
+        }
+
+        self.into().map_err(|err: Error| err.context(msg()))
+    }
 }
 
 impl<T> DebugExt<T> for Result<T, Error> {}

--- a/crates/stc_ts_errors/src/result_ext.rs
+++ b/crates/stc_ts_errors/src/result_ext.rs
@@ -1,26 +1,26 @@
-use crate::ErrorKind;
+use crate::{Error, ErrorKind};
 
-pub trait DebugExt<T>: Into<Result<T, ErrorKind>> {
-    fn convert_err<F>(self, op: F) -> Result<T, ErrorKind>
+pub trait DebugExt<T>: Into<Result<T, Error>> {
+    fn convert_err<F>(self, op: F) -> Result<T, Error>
     where
-        F: FnOnce(ErrorKind) -> ErrorKind,
+        F: FnOnce(Error) -> Error,
     {
-        self.into().map_err(|err: ErrorKind| err.convert(op))
+        self.into().map_err(|err: Error| err.convert(op))
     }
 
     #[inline]
     #[track_caller]
-    fn context(self, msg: &str) -> Result<T, ErrorKind> {
+    fn context(self, msg: &str) -> Result<T, Error> {
         if !cfg!(debug_assertions) {
             return self.into();
         }
 
-        self.into().map_err(|err: ErrorKind| err.context(msg))
+        self.into().map_err(|err: Error| err.context(msg))
     }
 
     #[inline]
     #[track_caller]
-    fn with_context<F>(self, msg: F) -> Result<T, ErrorKind>
+    fn with_context<F>(self, msg: F) -> Result<T, Error>
     where
         F: FnOnce() -> String,
     {
@@ -28,8 +28,8 @@ pub trait DebugExt<T>: Into<Result<T, ErrorKind>> {
             return self.into();
         }
 
-        self.into().map_err(|err: ErrorKind| err.context(msg()))
+        self.into().map_err(|err: Error| err.context(msg()))
     }
 }
 
-impl<T> DebugExt<T> for Result<T, ErrorKind> {}
+impl<T> DebugExt<T> for Result<T, Error> {}

--- a/crates/stc_ts_errors/src/result_ext.rs
+++ b/crates/stc_ts_errors/src/result_ext.rs
@@ -1,26 +1,26 @@
-use crate::Error;
+use crate::ErrorKind;
 
-pub trait DebugExt<T>: Into<Result<T, Error>> {
-    fn convert_err<F>(self, op: F) -> Result<T, Error>
+pub trait DebugExt<T>: Into<Result<T, ErrorKind>> {
+    fn convert_err<F>(self, op: F) -> Result<T, ErrorKind>
     where
-        F: FnOnce(Error) -> Error,
+        F: FnOnce(ErrorKind) -> ErrorKind,
     {
-        self.into().map_err(|err: Error| err.convert(op))
+        self.into().map_err(|err: ErrorKind| err.convert(op))
     }
 
     #[inline]
     #[track_caller]
-    fn context(self, msg: &str) -> Result<T, Error> {
+    fn context(self, msg: &str) -> Result<T, ErrorKind> {
         if !cfg!(debug_assertions) {
             return self.into();
         }
 
-        self.into().map_err(|err: Error| err.context(msg))
+        self.into().map_err(|err: ErrorKind| err.context(msg))
     }
 
     #[inline]
     #[track_caller]
-    fn with_context<F>(self, msg: F) -> Result<T, Error>
+    fn with_context<F>(self, msg: F) -> Result<T, ErrorKind>
     where
         F: FnOnce() -> String,
     {
@@ -28,8 +28,8 @@ pub trait DebugExt<T>: Into<Result<T, Error>> {
             return self.into();
         }
 
-        self.into().map_err(|err: Error| err.context(msg()))
+        self.into().map_err(|err: ErrorKind| err.context(msg()))
     }
 }
 
-impl<T> DebugExt<T> for Result<T, Error> {}
+impl<T> DebugExt<T> for Result<T, ErrorKind> {}

--- a/crates/stc_ts_errors/src/result_ext.rs
+++ b/crates/stc_ts_errors/src/result_ext.rs
@@ -3,7 +3,7 @@ use crate::{Error, ErrorKind};
 pub trait DebugExt<T>: Into<Result<T, Error>> {
     fn convert_err<F>(self, op: F) -> Result<T, Error>
     where
-        F: FnOnce(Error) -> Error,
+        F: FnOnce(ErrorKind) -> ErrorKind,
     {
         self.into().map_err(|err: Error| err.convert(op))
     }

--- a/crates/stc_ts_file_analyzer/src/analyzer/assign/builtin.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/assign/builtin.rs
@@ -1,5 +1,5 @@
 use stc_ts_ast_rnode::{RExpr, RIdent, RTsEntityName};
-use stc_ts_errors::{DebugExt, Error};
+use stc_ts_errors::{DebugExt, ErrorKind};
 use stc_ts_types::{Array, ArrayMetadata, Ref, Type, TypeElement};
 use swc_atoms::js_word;
 use swc_common::{Spanned, TypeEq};
@@ -50,7 +50,7 @@ impl Analyzer<'_, '_> {
                             errors.extend(self.assign_inner(data, &type_args.params[0], &el.ty, opts).err());
                         }
                         if !errors.is_empty() {
-                            return Some(Err(Error::TupleAssignError { span, errors }));
+                            return Some(Err(ErrorKind::TupleAssignError { span, errors }));
                         }
                     }
                     return Some(Ok(()));
@@ -79,7 +79,7 @@ impl Analyzer<'_, '_> {
                         return Some(Ok(()));
                     }
 
-                    return Some(Err(Error::NoCallSignature {
+                    return Some(Err(ErrorKind::NoCallSignature {
                         span: opts.span,
                         callee: box r.clone(),
                     }));
@@ -115,7 +115,7 @@ impl Analyzer<'_, '_> {
                         }
                     }
 
-                    return Some(Err(Error::NoCallSignature {
+                    return Some(Err(ErrorKind::NoCallSignature {
                         span: opts.span,
                         callee: box r.clone(),
                     }));
@@ -215,7 +215,7 @@ impl Analyzer<'_, '_> {
                         }
 
                         if done {
-                            return Some(Err(Error::SimpleAssignFailed { span, cause: None }
+                            return Some(Err(ErrorKind::SimpleAssignFailed { span, cause: None }
                                 .context("tried optimized assignment of `Promise<T>` to union")));
                         }
                     }

--- a/crates/stc_ts_file_analyzer/src/analyzer/assign/builtin.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/assign/builtin.rs
@@ -50,7 +50,7 @@ impl Analyzer<'_, '_> {
                             errors.extend(self.assign_inner(data, &type_args.params[0], &el.ty, opts).err());
                         }
                         if !errors.is_empty() {
-                            return Some(Err(ErrorKind::TupleAssignError { span, errors }));
+                            return Some(Err(ErrorKind::TupleAssignError { span, errors }.into()));
                         }
                     }
                     return Some(Ok(()));
@@ -82,7 +82,8 @@ impl Analyzer<'_, '_> {
                     return Some(Err(ErrorKind::NoCallSignature {
                         span: opts.span,
                         callee: box r.clone(),
-                    }));
+                    }
+                    .into()));
                 }
                 Type::Interface(ri) => {
                     if *ri.name.sym() == js_word!("Function") {

--- a/crates/stc_ts_file_analyzer/src/analyzer/assign/builtin.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/assign/builtin.rs
@@ -119,7 +119,8 @@ impl Analyzer<'_, '_> {
                     return Some(Err(ErrorKind::NoCallSignature {
                         span: opts.span,
                         callee: box r.clone(),
-                    }));
+                    }
+                    .into()));
                 }
                 _ => {}
             },

--- a/crates/stc_ts_file_analyzer/src/analyzer/assign/class.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/assign/class.rs
@@ -240,7 +240,8 @@ impl Analyzer<'_, '_> {
         Err(ErrorKind::Unimplemented {
             span: opts.span,
             msg: format!("Assignment of non-class object to class\n{:#?}", r),
-        })
+        }
+        .into())
     }
 
     fn assign_class_members_to_class_member(
@@ -277,7 +278,7 @@ impl Analyzer<'_, '_> {
                                 }
 
                                 if rm.accessibility == Some(Accessibility::Private) || rm.key.is_private() {
-                                    return Err(ErrorKind::PrivateMethodIsDifferent { span });
+                                    return Err(ErrorKind::PrivateMethodIsDifferent { span }.into());
                                 }
 
                                 self.assign_to_fn_like(
@@ -302,14 +303,14 @@ impl Analyzer<'_, '_> {
                 }
 
                 if lm.accessibility == Some(Accessibility::Private) || lm.key.is_private() {
-                    return Err(ErrorKind::PrivateMethodIsDifferent { span });
+                    return Err(ErrorKind::PrivateMethodIsDifferent { span }.into());
                 }
 
                 if lm.is_optional {
                     return Ok(());
                 }
 
-                return Err(ErrorKind::SimpleAssignFailed { span, cause: None }).context("failed to assign a class member to another one");
+                return Err(ErrorKind::SimpleAssignFailed { span, cause: None }.context("failed to assign a class member to another one"));
             }
             ClassMember::Property(lp) => {
                 for rm in r {
@@ -333,7 +334,7 @@ impl Analyzer<'_, '_> {
                                 }
 
                                 if rp.accessibility == Some(Accessibility::Private) || rp.key.is_private() {
-                                    return Err(ErrorKind::PrivatePropertyIsDifferent { span });
+                                    return Err(ErrorKind::PrivatePropertyIsDifferent { span }.into());
                                 }
 
                                 return Ok(());
@@ -344,7 +345,7 @@ impl Analyzer<'_, '_> {
                 }
 
                 if lp.accessibility == Some(Accessibility::Private) || lp.key.is_private() {
-                    return Err(ErrorKind::PrivatePropertyIsDifferent { span });
+                    return Err(ErrorKind::PrivatePropertyIsDifferent { span }.into());
                 }
 
                 if lp.is_optional {
@@ -352,10 +353,10 @@ impl Analyzer<'_, '_> {
                 }
 
                 if opts.use_missing_fields_for_class {
-                    let err = ErrorKind::MissingFields { span, fields: vec![] };
-                    return Err(ErrorKind::Errors { span, errors: vec![err] });
+                    let err = ErrorKind::MissingFields { span, fields: vec![] }.into();
+                    return Err(ErrorKind::Errors { span, errors: vec![err] }.into());
                 } else {
-                    return Err(ErrorKind::SimpleAssignFailed { span, cause: None });
+                    return Err(ErrorKind::SimpleAssignFailed { span, cause: None }.into());
                 }
             }
             ClassMember::IndexSignature(_) => {}
@@ -364,6 +365,7 @@ impl Analyzer<'_, '_> {
         Err(ErrorKind::Unimplemented {
             span: opts.span,
             msg: format!("fine-grained class assignment to lhs member: {:#?}", l),
-        })
+        }
+        .into())
     }
 }

--- a/crates/stc_ts_file_analyzer/src/analyzer/assign/class.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/assign/class.rs
@@ -1,6 +1,6 @@
 use std::borrow::Cow;
 
-use stc_ts_errors::{DebugExt, Error};
+use stc_ts_errors::{DebugExt, ErrorKind};
 use stc_ts_types::{Class, ClassDef, ClassMember, Type, TypeLitMetadata};
 use stc_utils::cache::Freeze;
 use swc_common::EqIgnoreSpan;
@@ -25,7 +25,7 @@ impl Analyzer<'_, '_> {
                 }
 
                 if !l.is_abstract && rc.is_abstract {
-                    return Err(Error::CannotAssignAbstractConstructorToNonAbstractConstructor { span: opts.span });
+                    return Err(ErrorKind::CannotAssignAbstractConstructorToNonAbstractConstructor { span: opts.span });
                 }
 
                 if !rc.is_abstract {
@@ -46,7 +46,7 @@ impl Analyzer<'_, '_> {
                         new_body = members;
                         &*new_body
                     } else {
-                        return Err(Error::Unimplemented {
+                        return Err(ErrorKind::Unimplemented {
                             span: opts.span,
                             msg: format!("Failed to collect class members"),
                         });
@@ -101,7 +101,7 @@ impl Analyzer<'_, '_> {
             _ => {}
         }
 
-        Err(Error::Unimplemented {
+        Err(ErrorKind::Unimplemented {
             span: opts.span,
             msg: format!("Assignment of non-class object to class definition\n{:#?}", r),
         })
@@ -130,7 +130,7 @@ impl Analyzer<'_, '_> {
                         new_body = members;
                         &*new_body
                     } else {
-                        return Err(Error::Unimplemented {
+                        return Err(ErrorKind::Unimplemented {
                             span: opts.span,
                             msg: format!("Failed to collect class members"),
                         });
@@ -160,7 +160,7 @@ impl Analyzer<'_, '_> {
                 }
 
                 if opts.disallow_different_classes {
-                    return Err(Error::SimpleAssignFailed {
+                    return Err(ErrorKind::SimpleAssignFailed {
                         span: opts.span,
                         cause: None,
                     }
@@ -225,7 +225,7 @@ impl Analyzer<'_, '_> {
 
         match r {
             Type::Lit(..) | Type::Keyword(..) => {
-                return Err(Error::SimpleAssignFailed {
+                return Err(ErrorKind::SimpleAssignFailed {
                     span: opts.span,
                     cause: None,
                 }
@@ -234,7 +234,7 @@ impl Analyzer<'_, '_> {
             _ => {}
         }
 
-        Err(Error::Unimplemented {
+        Err(ErrorKind::Unimplemented {
             span: opts.span,
             msg: format!("Assignment of non-class object to class\n{:#?}", r),
         })
@@ -274,7 +274,7 @@ impl Analyzer<'_, '_> {
                                 }
 
                                 if rm.accessibility == Some(Accessibility::Private) || rm.key.is_private() {
-                                    return Err(Error::PrivateMethodIsDifferent { span });
+                                    return Err(ErrorKind::PrivateMethodIsDifferent { span });
                                 }
 
                                 self.assign_to_fn_like(
@@ -299,14 +299,14 @@ impl Analyzer<'_, '_> {
                 }
 
                 if lm.accessibility == Some(Accessibility::Private) || lm.key.is_private() {
-                    return Err(Error::PrivateMethodIsDifferent { span });
+                    return Err(ErrorKind::PrivateMethodIsDifferent { span });
                 }
 
                 if lm.is_optional {
                     return Ok(());
                 }
 
-                return Err(Error::SimpleAssignFailed { span, cause: None }).context("failed to assign a class member to another one");
+                return Err(ErrorKind::SimpleAssignFailed { span, cause: None }).context("failed to assign a class member to another one");
             }
             ClassMember::Property(lp) => {
                 for rm in r {
@@ -330,7 +330,7 @@ impl Analyzer<'_, '_> {
                                 }
 
                                 if rp.accessibility == Some(Accessibility::Private) || rp.key.is_private() {
-                                    return Err(Error::PrivatePropertyIsDifferent { span });
+                                    return Err(ErrorKind::PrivatePropertyIsDifferent { span });
                                 }
 
                                 return Ok(());
@@ -341,7 +341,7 @@ impl Analyzer<'_, '_> {
                 }
 
                 if lp.accessibility == Some(Accessibility::Private) || lp.key.is_private() {
-                    return Err(Error::PrivatePropertyIsDifferent { span });
+                    return Err(ErrorKind::PrivatePropertyIsDifferent { span });
                 }
 
                 if lp.is_optional {
@@ -349,16 +349,16 @@ impl Analyzer<'_, '_> {
                 }
 
                 if opts.use_missing_fields_for_class {
-                    let err = Error::MissingFields { span, fields: vec![] };
-                    return Err(Error::Errors { span, errors: vec![err] });
+                    let err = ErrorKind::MissingFields { span, fields: vec![] };
+                    return Err(ErrorKind::Errors { span, errors: vec![err] });
                 } else {
-                    return Err(Error::SimpleAssignFailed { span, cause: None });
+                    return Err(ErrorKind::SimpleAssignFailed { span, cause: None });
                 }
             }
             ClassMember::IndexSignature(_) => {}
         }
 
-        Err(Error::Unimplemented {
+        Err(ErrorKind::Unimplemented {
             span: opts.span,
             msg: format!("fine-grained class assignment to lhs member: {:#?}", l),
         })

--- a/crates/stc_ts_file_analyzer/src/analyzer/assign/class.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/assign/class.rs
@@ -25,7 +25,7 @@ impl Analyzer<'_, '_> {
                 }
 
                 if !l.is_abstract && rc.is_abstract {
-                    return Err(ErrorKind::CannotAssignAbstractConstructorToNonAbstractConstructor { span: opts.span });
+                    return Err(ErrorKind::CannotAssignAbstractConstructorToNonAbstractConstructor { span: opts.span }.into());
                 }
 
                 if !rc.is_abstract {
@@ -49,7 +49,8 @@ impl Analyzer<'_, '_> {
                         return Err(ErrorKind::Unimplemented {
                             span: opts.span,
                             msg: format!("Failed to collect class members"),
-                        });
+                        }
+                        .into());
                     }
                 } else {
                     &*rc.body
@@ -104,7 +105,8 @@ impl Analyzer<'_, '_> {
         Err(ErrorKind::Unimplemented {
             span: opts.span,
             msg: format!("Assignment of non-class object to class definition\n{:#?}", r),
-        })
+        }
+        .into())
     }
 
     pub(super) fn assign_to_class(&mut self, data: &mut AssignData, l: &Class, r: &Type, opts: AssignOpts) -> VResult<()> {
@@ -133,7 +135,8 @@ impl Analyzer<'_, '_> {
                         return Err(ErrorKind::Unimplemented {
                             span: opts.span,
                             msg: format!("Failed to collect class members"),
-                        });
+                        }
+                        .into());
                     }
                 } else {
                     &*rc.def.body

--- a/crates/stc_ts_file_analyzer/src/analyzer/assign/function.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/assign/function.rs
@@ -464,7 +464,7 @@ impl Analyzer<'_, '_> {
             _ => {}
         }
 
-        Err(ErrorKind::SimpleAssignFailed { span, cause: None })
+        Err(ErrorKind::SimpleAssignFailed { span, cause: None }.into())
     }
 
     ///

--- a/crates/stc_ts_file_analyzer/src/analyzer/assign/function.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/assign/function.rs
@@ -675,7 +675,7 @@ impl Analyzer<'_, '_> {
                 span,
                 cause: Some(box err.into()),
             },
-            ErrorKind::Errors { errors, .. } => {
+            ErrorKind::Errors { ref errors, .. } => {
                 if errors.iter().all(|err| match &**err {
                     ErrorKind::MissingFields { .. } => true,
                     _ => false,

--- a/crates/stc_ts_file_analyzer/src/analyzer/assign/function.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/assign/function.rs
@@ -5,7 +5,7 @@ use itertools::{EitherOrBoth, Itertools};
 use stc_ts_ast_rnode::{RBindingIdent, RIdent, RPat};
 use stc_ts_errors::{
     debug::{dump_type_as_string, dump_type_map},
-    DebugExt, Error,
+    DebugExt, ErrorKind,
 };
 use stc_ts_types::{ClassDef, Constructor, FnParam, Function, Type, TypeElement, TypeParamDecl};
 use stc_utils::{cache::Freeze, debug_ctx};
@@ -464,7 +464,7 @@ impl Analyzer<'_, '_> {
             _ => {}
         }
 
-        Err(Error::SimpleAssignFailed { span, cause: None })
+        Err(ErrorKind::SimpleAssignFailed { span, cause: None })
     }
 
     ///
@@ -537,7 +537,7 @@ impl Analyzer<'_, '_> {
                 return Ok(());
             }
             Type::Lit(..) | Type::ClassDef(ClassDef { is_abstract: true, .. }) | Type::Function(..) => {
-                return Err(Error::SimpleAssignFailed { span, cause: None })
+                return Err(ErrorKind::SimpleAssignFailed { span, cause: None })
             }
 
             Type::TypeLit(rt) => {
@@ -575,7 +575,7 @@ impl Analyzer<'_, '_> {
                 }
 
                 if !errors.is_empty() {
-                    return Err(Error::SimpleAssignFailedWithCause { span, cause: errors });
+                    return Err(ErrorKind::SimpleAssignFailedWithCause { span, cause: errors });
                 }
             }
             Type::Interface(..) => {
@@ -592,7 +592,7 @@ impl Analyzer<'_, '_> {
             _ => {}
         }
 
-        Err(Error::SimpleAssignFailed { span, cause: None })
+        Err(ErrorKind::SimpleAssignFailed { span, cause: None })
     }
 
     /// Assigns a parameter to another one.
@@ -671,17 +671,17 @@ impl Analyzer<'_, '_> {
         };
 
         res.convert_err(|err| match &err {
-            Error::MissingFields { span, .. } => Error::SimpleAssignFailed {
+            ErrorKind::MissingFields { span, .. } => ErrorKind::SimpleAssignFailed {
                 span: *span,
                 cause: Some(box err),
             },
 
-            Error::Errors { errors, .. } => {
+            ErrorKind::Errors { errors, .. } => {
                 if errors.iter().all(|err| match err.actual() {
-                    Error::MissingFields { .. } => true,
+                    ErrorKind::MissingFields { .. } => true,
                     _ => false,
                 }) {
-                    Error::SimpleAssignFailed {
+                    ErrorKind::SimpleAssignFailed {
                         span,
                         cause: Some(box err),
                     }
@@ -745,7 +745,7 @@ impl Analyzer<'_, '_> {
 
         if opts.for_overload {
             if required_li.clone().count() > required_ri.clone().count() {
-                return Err(Error::SimpleAssignFailed { span, cause: None }).context("l.params.required.len > r.params.required.len");
+                return Err(ErrorKind::SimpleAssignFailed { span, cause: None }).context("l.params.required.len > r.params.required.len");
             }
         }
 
@@ -758,7 +758,7 @@ impl Analyzer<'_, '_> {
                     return Ok(());
                 }
 
-                return Err(Error::SimpleAssignFailed { span, cause: None }).with_context(|| {
+                return Err(ErrorKind::SimpleAssignFailed { span, cause: None }).with_context(|| {
                     format!(
                         "!l_has_rest && l.params.required.len < r.params.required.len\nLeft: {:?}\nRight: {:?}\n",
                         required_non_void_li.collect_vec(),

--- a/crates/stc_ts_file_analyzer/src/analyzer/assign/function.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/assign/function.rs
@@ -760,11 +760,11 @@ impl Analyzer<'_, '_> {
                     return Ok(());
                 }
 
-                return Err(ErrorKind::SimpleAssignFailed { span, cause: None }).context(format!(
+                return Err(ErrorKind::SimpleAssignFailed { span, cause: None }.context(format!(
                     "!l_has_rest && l.params.required.len < r.params.required.len\nLeft: {:?}\nRight: {:?}\n",
                     required_non_void_li.collect_vec(),
                     required_non_void_ri.collect_vec()
-                ));
+                )));
             }
         }
 

--- a/crates/stc_ts_file_analyzer/src/analyzer/assign/function.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/assign/function.rs
@@ -670,13 +670,11 @@ impl Analyzer<'_, '_> {
                 .context("tried to assign the type of a parameter to another (reversed due to variance)")
         };
 
-        res.convert_err(|err| match &*err {
+        res.convert_err(|err| match err {
             ErrorKind::MissingFields { span, .. } => ErrorKind::SimpleAssignFailed {
-                span: *span,
-                cause: Some(box err),
-            }
-            .into(),
-
+                span,
+                cause: Some(box err.into()),
+            },
             ErrorKind::Errors { errors, .. } => {
                 if errors.iter().all(|err| match &**err {
                     ErrorKind::MissingFields { .. } => true,
@@ -684,7 +682,7 @@ impl Analyzer<'_, '_> {
                 }) {
                     ErrorKind::SimpleAssignFailed {
                         span,
-                        cause: Some(box err),
+                        cause: Some(box err.into()),
                     }
                     .into()
                 } else {

--- a/crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs
@@ -434,7 +434,7 @@ impl Analyzer<'_, '_> {
             _ => {}
         }
 
-        res.convert_err(|err| match err {
+        res.convert_err(|err| match &*err {
             ErrorKind::AssignFailed { .. }
             | ErrorKind::Errors { .. }
             | ErrorKind::Unimplemented { .. }
@@ -446,7 +446,8 @@ impl Analyzer<'_, '_> {
                 right: box right.clone(),
                 right_ident: opts.right_ident_span,
                 cause: vec![err],
-            },
+            }
+            .into(),
         })
     }
 

--- a/crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs
@@ -768,7 +768,7 @@ impl Analyzer<'_, '_> {
                     // TODO
                     prop: None,
                 };
-                return Err(ErrorKind::Errors { span, errors: vec![err] });
+                return Err(ErrorKind::Errors { span, errors: vec![err] }.into());
             }
             _ => {}
         }
@@ -887,7 +887,7 @@ impl Analyzer<'_, '_> {
                         })
                         | Type::Interface(ref i) => {
                             if i.name.as_str() == *interface {
-                                return Err(ErrorKind::AssignedWrapperToPrimitive { span });
+                                return Err(ErrorKind::AssignedWrapperToPrimitive { span }.into());
                             }
                         }
                         _ => {}
@@ -941,7 +941,8 @@ impl Analyzer<'_, '_> {
                             return Err(ErrorKind::Unimplemented {
                                 span,
                                 msg: format!("{:?} = {:?}", l_variance, r_variance),
-                            })
+                            }
+                            .into())
                         }
                     }
                 }

--- a/crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs
@@ -767,7 +767,8 @@ impl Analyzer<'_, '_> {
                     obj: Some(rhs.obj_type.clone()),
                     // TODO
                     prop: None,
-                };
+                }
+                .into();
                 return Err(ErrorKind::Errors { span, errors: vec![err] }.into());
             }
             _ => {}
@@ -998,7 +999,7 @@ impl Analyzer<'_, '_> {
                     _ => {}
                 }
                 dbg!();
-                return Err(ErrorKind::InvalidLValue { span: to.span() });
+                return Err(ErrorKind::InvalidLValue { span: to.span() }.into());
             }
             Type::Enum(..) => fail!(),
 
@@ -1067,7 +1068,7 @@ impl Analyzer<'_, '_> {
                 }
 
                 dbg!();
-                return Err(ErrorKind::InvalidLValue { span: e.span });
+                return Err(ErrorKind::InvalidLValue { span: e.span }.into());
             }
 
             Type::Intersection(ref li) => {
@@ -1096,9 +1097,12 @@ impl Analyzer<'_, '_> {
                             },
                         )
                         .context("tried to assign to an element of an intersection type")
-                        .convert_err(|err| ErrorKind::SimpleAssignFailed {
-                            span: err.span(),
-                            cause: Some(box err),
+                        .convert_err(|err| {
+                            ErrorKind::SimpleAssignFailed {
+                                span: err.span(),
+                                cause: Some(box err),
+                            }
+                            .into()
                         }) {
                         Ok(..) => {}
                         Err(err) => errors.push(err),
@@ -1122,12 +1126,15 @@ impl Analyzer<'_, '_> {
                                     dump_type_as_string(&self.cm, &Type::TypeLit(lhs.into_owned()))
                                 )
                             })
-                            .convert_err(|err| ErrorKind::SimpleAssignFailed {
-                                span: err.span(),
-                                cause: Some(box err),
+                            .convert_err(|err| {
+                                ErrorKind::SimpleAssignFailed {
+                                    span: err.span(),
+                                    cause: Some(box err),
+                                }
+                                .into()
                             })?;
 
-                        errors.retain(|err| match err.actual() {
+                        errors.retain(|err| match err {
                             ErrorKind::UnknownPropertyInObjectLiteralAssignment { .. } => false,
                             _ => true,
                         });
@@ -1138,7 +1145,7 @@ impl Analyzer<'_, '_> {
                     return Ok(());
                 }
 
-                return Err(ErrorKind::Errors { span, errors });
+                return Err(ErrorKind::Errors { span, errors }.into());
             }
 
             Type::Class(l) => match rhs {
@@ -1298,7 +1305,8 @@ impl Analyzer<'_, '_> {
                         right_ident: None,
                         right: box rhs.clone(),
                         cause: errors,
-                    });
+                    }
+                    .into());
                 }
 
                 return Err(ErrorKind::Errors { span, errors });
@@ -1646,7 +1654,8 @@ impl Analyzer<'_, '_> {
                         left: box to.clone(),
                         right: box rhs.clone(),
                         right_ident: opts.right_ident_span,
-                    });
+                    }
+                    .into());
                 } else {
                     return Err(ErrorKind::Errors { span, errors }.context("tried to assign a type to a union type"));
                 }
@@ -1658,7 +1667,7 @@ impl Analyzer<'_, '_> {
                 // TODO(kdy1): Multiple error
                 for v in vs {
                     if let Err(error) = v {
-                        return Err(ErrorKind::IntersectionError { span, error: box error });
+                        return Err(ErrorKind::IntersectionError { span, error: box error }.into());
                     }
                 }
 

--- a/crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs
@@ -232,7 +232,7 @@ impl Analyzer<'_, '_> {
                         rhs_errored = true;
                     }
                     self.storage
-                        .report(ErrorKind::UndefinedOrNullIsNotValidOperand { span: rhs.span() });
+                        .report(ErrorKind::UndefinedOrNullIsNotValidOperand { span: rhs.span() }.into());
                 } else {
                     self.deny_null_or_undefined(rhs.span(), rhs)
                         .context("checking operands of a numeric assignment")?;

--- a/crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs
@@ -1134,7 +1134,7 @@ impl Analyzer<'_, '_> {
                                 .into()
                             })?;
 
-                        errors.retain(|err| match err {
+                        errors.retain(|err| match &*err {
                             ErrorKind::UnknownPropertyInObjectLiteralAssignment { .. } => false,
                             _ => true,
                         });

--- a/crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs
@@ -1348,7 +1348,9 @@ impl Analyzer<'_, '_> {
                 if errors.is_empty() {
                     return Ok(());
                 }
-                return Err(ErrorKind::Errors { span, errors }.context("tried to assign a union to other type"));
+                return Err(ErrorKind::Errors { span, errors }
+                    .context("tried to assign a union to other type")
+                    .into());
             }
 
             Type::Keyword(KeywordType {

--- a/crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs
@@ -1129,7 +1129,7 @@ impl Analyzer<'_, '_> {
                             .convert_err(|err| {
                                 ErrorKind::SimpleAssignFailed {
                                     span: err.span(),
-                                    cause: Some(box err),
+                                    cause: Some(box err.into()),
                                 }
                                 .into()
                             })?;
@@ -1852,7 +1852,7 @@ impl Analyzer<'_, '_> {
                                 .convert_err(|err| {
                                     ErrorKind::SimpleAssignFailed {
                                         span: err.span(),
-                                        cause: Some(box err),
+                                        cause: Some(box err.into()),
                                     }
                                     .into()
                                 })

--- a/crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs
@@ -429,12 +429,12 @@ impl Analyzer<'_, '_> {
         // self.verify_before_assign("rhs", right);
         let res = self.assign_inner(data, left, right, opts);
 
-        match res {
+        match res.as_ref().map_err(|e| &**e) {
             Err(ErrorKind::Errors { errors, .. }) if errors.is_empty() => return Ok(()),
             _ => {}
         }
 
-        res.convert_err(|err| match &*err {
+        res.convert_err(|err| match err {
             ErrorKind::AssignFailed { .. }
             | ErrorKind::Errors { .. }
             | ErrorKind::Unimplemented { .. }
@@ -445,7 +445,7 @@ impl Analyzer<'_, '_> {
                 left: box left.clone(),
                 right: box right.clone(),
                 right_ident: opts.right_ident_span,
-                cause: vec![err],
+                cause: vec![err.into()],
             }
             .into(),
         })
@@ -1100,7 +1100,7 @@ impl Analyzer<'_, '_> {
                         .convert_err(|err| {
                             ErrorKind::SimpleAssignFailed {
                                 span: err.span(),
-                                cause: Some(box err),
+                                cause: Some(box err.into()),
                             }
                             .into()
                         }) {

--- a/crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs
@@ -609,15 +609,15 @@ impl Analyzer<'_, '_> {
                     right: box rhs.clone(),
                     right_ident: opts.right_ident_span,
                     cause: vec![],
-                })
-                .with_context(|| {
+                }
+                .context({
                     format!(
                         "`fail!()` called from assign/mod.rs:{}\nLHS (final): {}\nRHS (final): {}",
                         line!(),
                         dump_type_as_string(&self.cm, to),
                         dump_type_as_string(&self.cm, rhs)
                     )
-                });
+                }));
             }};
         }
 

--- a/crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs
@@ -598,7 +598,7 @@ impl Analyzer<'_, '_> {
 
         macro_rules! fail {
             () => {{
-                return Err(Error::AssignFailed {
+                return Err(ErrorKind::AssignFailed {
                     span,
                     left: box to.clone(),
                     right: box rhs.clone(),

--- a/crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs
@@ -1765,7 +1765,8 @@ impl Analyzer<'_, '_> {
                                 return Err(ErrorKind::CannotAssignToNonVariable {
                                     span: rhs.span(),
                                     ty: box rhs.clone(),
-                                })
+                                }
+                                .into())
                             }
                             _ => {}
                         }
@@ -1848,9 +1849,12 @@ impl Analyzer<'_, '_> {
                             )?;
                             return self
                                 .assign_inner(data, &left, rhs, opts)
-                                .convert_err(|err| ErrorKind::SimpleAssignFailed {
-                                    span: err.span(),
-                                    cause: Some(box err),
+                                .convert_err(|err| {
+                                    ErrorKind::SimpleAssignFailed {
+                                        span: err.span(),
+                                        cause: Some(box err),
+                                    }
+                                    .into()
                                 })
                                 .context("tried to assign a type literal to an expanded keyword");
                         }
@@ -1885,7 +1889,7 @@ impl Analyzer<'_, '_> {
                 _ => {}
             },
 
-            Type::This(ThisType { span, .. }) => return Err(ErrorKind::CannotAssingToThis { span: *span }),
+            Type::This(ThisType { span, .. }) => return Err(ErrorKind::CannotAssingToThis { span: *span }.into()),
 
             Type::Interface(Interface {
                 name,
@@ -1981,7 +1985,8 @@ impl Analyzer<'_, '_> {
                         right: box rhs.clone(),
                         right_ident: opts.right_ident_span,
                         cause: errors,
-                    });
+                    }
+                    .into());
                 }
 
                 // We should check for unknown rhs, while allowing assignment to parent
@@ -2007,7 +2012,8 @@ impl Analyzer<'_, '_> {
                         right: box rhs.clone(),
                         right_ident: opts.right_ident_span,
                         cause: errors,
-                    });
+                    }
+                    .into());
                 }
 
                 return Ok(());
@@ -2091,13 +2097,13 @@ impl Analyzer<'_, '_> {
                         // TODO: Handle Type::Rest
 
                         if elems.len() < rhs_elems.len() {
-                            return Err(ErrorKind::AssignFailedBecauseTupleLengthDiffers { span });
+                            return Err(ErrorKind::AssignFailedBecauseTupleLengthDiffers { span }.into());
                         }
 
                         // TODO: Handle Type::Rest
 
                         if elems.len() > rhs_elems.len() {
-                            return Err(ErrorKind::AssignFailedBecauseTupleLengthDiffers { span });
+                            return Err(ErrorKind::AssignFailedBecauseTupleLengthDiffers { span }.into());
                         }
 
                         let mut errors = vec![];
@@ -2127,7 +2133,7 @@ impl Analyzer<'_, '_> {
                         }
 
                         if !errors.is_empty() {
-                            return Err(ErrorKind::TupleAssignError { span, errors });
+                            return Err(ErrorKind::TupleAssignError { span, errors }.into());
                         }
 
                         return Ok(());

--- a/crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs
@@ -1134,7 +1134,7 @@ impl Analyzer<'_, '_> {
                                 .into()
                             })?;
 
-                        errors.retain(|err| match &*err {
+                        errors.retain(|err| match &**err {
                             ErrorKind::UnknownPropertyInObjectLiteralAssignment { .. } => false,
                             _ => true,
                         });
@@ -1309,7 +1309,7 @@ impl Analyzer<'_, '_> {
                     .into());
                 }
 
-                return Err(ErrorKind::Errors { span, errors });
+                return Err(ErrorKind::Errors { span, errors }.into());
             }
 
             Type::Union(r) => {

--- a/crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs
@@ -173,11 +173,11 @@ impl Analyzer<'_, '_> {
     /// of union.
     pub(crate) fn deny_null_or_undefined(&mut self, span: Span, ty: &Type) -> VResult<()> {
         if ty.is_kwd(TsKeywordTypeKind::TsUndefinedKeyword) {
-            return Err(ErrorKind::ObjectIsPossiblyUndefined { span });
+            return Err(ErrorKind::ObjectIsPossiblyUndefined { span }.into());
         }
 
         if ty.is_kwd(TsKeywordTypeKind::TsNullKeyword) {
-            return Err(ErrorKind::ObjectIsPossiblyNull { span });
+            return Err(ErrorKind::ObjectIsPossiblyNull { span }.into());
         }
 
         Ok(())

--- a/crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs
@@ -196,7 +196,7 @@ impl Analyzer<'_, '_> {
         if op == op!("+=") {
             if lhs.is_enum_variant() {
                 if rhs.is_type_lit() || rhs.is_bool() || rhs.is_symbol_like() {
-                    return Err(ErrorKind::OperatorCannotBeAppliedToTypes { span });
+                    return Err(ErrorKind::OperatorCannotBeAppliedToTypes { span }.into());
                 }
             }
         }
@@ -214,7 +214,7 @@ impl Analyzer<'_, '_> {
             | op!(">>=")
             | op!(">>>=") => {
                 if lhs.is_symbol_like() {
-                    return Err(ErrorKind::WrongTypeForLhsOfNumericOperation { span });
+                    return Err(ErrorKind::WrongTypeForLhsOfNumericOperation { span }.into());
                 }
             }
             _ => {}
@@ -239,17 +239,17 @@ impl Analyzer<'_, '_> {
                 }
 
                 match lhs {
-                    Type::TypeLit(..) => return Err(ErrorKind::WrongTypeForLhsOfNumericOperation { span }),
+                    Type::TypeLit(..) => return Err(ErrorKind::WrongTypeForLhsOfNumericOperation { span }.into()),
                     ty if ty.is_bool() || ty.is_str() || ty.is_tpl() || ty.is_kwd(TsKeywordTypeKind::TsVoidKeyword) => {
-                        return Err(ErrorKind::WrongTypeForLhsOfNumericOperation { span });
+                        return Err(ErrorKind::WrongTypeForLhsOfNumericOperation { span }.into());
                     }
                     _ => {}
                 }
 
                 match rhs {
-                    Type::TypeLit(..) => return Err(ErrorKind::WrongTypeForRhsOfNumericOperation { span }),
+                    Type::TypeLit(..) => return Err(ErrorKind::WrongTypeForRhsOfNumericOperation { span }.into()),
                     ty if ty.is_bool() || ty.is_str() || ty.is_tpl() || ty.is_kwd(TsKeywordTypeKind::TsVoidKeyword) => {
-                        return Err(ErrorKind::WrongTypeForRhsOfNumericOperation { span })
+                        return Err(ErrorKind::WrongTypeForRhsOfNumericOperation { span }.into())
                     }
                     _ => {}
                 }
@@ -306,7 +306,7 @@ impl Analyzer<'_, '_> {
                 if rhs_errored {
                     return Ok(());
                 }
-                return Err(ErrorKind::AssignOpCannotBeApplied { span, op });
+                return Err(ErrorKind::AssignOpCannotBeApplied { span, op }.into());
             }
         }
 
@@ -357,7 +357,8 @@ impl Analyzer<'_, '_> {
                             op,
                             lhs: box l.into_owned().clone(),
                             rhs: box r.into_owned().clone(),
-                        });
+                        }
+                        .into());
                     }
 
                     return Ok(());
@@ -375,11 +376,14 @@ impl Analyzer<'_, '_> {
                             ..Default::default()
                         },
                     )
-                    .convert_err(|err| ErrorKind::InvalidOpAssign {
-                        span,
-                        op,
-                        lhs: box l.into_owned().clone(),
-                        rhs: box r.into_owned().clone(),
+                    .convert_err(|err| {
+                        ErrorKind::InvalidOpAssign {
+                            span,
+                            op,
+                            lhs: box l.into_owned().clone(),
+                            rhs: box r.into_owned().clone(),
+                        }
+                        .into()
                     });
             }
             _ => {}
@@ -389,7 +393,7 @@ impl Analyzer<'_, '_> {
             return Ok(());
         }
 
-        Err(ErrorKind::AssignOpCannotBeApplied { span, op })
+        Err(ErrorKind::AssignOpCannotBeApplied { span, op }.into())
     }
 
     /// Assign `right` to `left`. You can just use default for [AssignData].

--- a/crates/stc_ts_file_analyzer/src/analyzer/assign/query.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/assign/query.rs
@@ -1,4 +1,4 @@
-use stc_ts_errors::{DebugExt, Error};
+use stc_ts_errors::{DebugExt, ErrorKind};
 use stc_ts_types::{QueryExpr, QueryType, Type};
 
 use crate::{
@@ -20,7 +20,7 @@ impl Analyzer<'_, '_> {
                     .context("tried to resolve typeof for assignment")?;
 
                 if to.is_global_this() {
-                    return Err(Error::SimpleAssignFailed {
+                    return Err(ErrorKind::SimpleAssignFailed {
                         span: opts.span,
                         cause: None,
                     }
@@ -44,7 +44,7 @@ impl Analyzer<'_, '_> {
                 .context("tried to resolve typeof for assignment")?;
 
             if rhs.is_global_this() {
-                return Err(Error::SimpleAssignFailed {
+                return Err(ErrorKind::SimpleAssignFailed {
                     span: opts.span,
                     cause: None,
                 }

--- a/crates/stc_ts_file_analyzer/src/analyzer/assign/tpl.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/assign/tpl.rs
@@ -1,5 +1,5 @@
 use stc_ts_ast_rnode::RTsLit;
-use stc_ts_errors::Error;
+use stc_ts_errors::ErrorKind;
 use stc_ts_types::{LitType, TplType, Type};
 
 use crate::{
@@ -100,14 +100,14 @@ impl Analyzer<'_, '_> {
                             positions.push(pos);
                             start += pos + 1;
                         }
-                        None => return Err(Error::SimpleAssignFailed { span, cause: None }),
+                        None => return Err(ErrorKind::SimpleAssignFailed { span, cause: None }),
                     }
                 }
 
                 Ok(())
             }
 
-            _ => Err(Error::SimpleAssignFailed { span, cause: None }),
+            _ => Err(ErrorKind::SimpleAssignFailed { span, cause: None }),
         }
     }
 }

--- a/crates/stc_ts_file_analyzer/src/analyzer/assign/tpl.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/assign/tpl.rs
@@ -100,14 +100,14 @@ impl Analyzer<'_, '_> {
                             positions.push(pos);
                             start += pos + 1;
                         }
-                        None => return Err(ErrorKind::SimpleAssignFailed { span, cause: None }),
+                        None => return Err(ErrorKind::SimpleAssignFailed { span, cause: None }.into()),
                     }
                 }
 
                 Ok(())
             }
 
-            _ => Err(ErrorKind::SimpleAssignFailed { span, cause: None }),
+            _ => Err(ErrorKind::SimpleAssignFailed { span, cause: None }.into()),
         }
     }
 }

--- a/crates/stc_ts_file_analyzer/src/analyzer/assign/type_el.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/assign/type_el.rs
@@ -746,7 +746,8 @@ impl Analyzer<'_, '_> {
                         .into_iter()
                         .map(|span| ErrorKind::UnknownPropertyInObjectLiteralAssignment { span })
                         .collect(),
-                });
+                }
+                .into());
             }
         }
 

--- a/crates/stc_ts_file_analyzer/src/analyzer/assign/type_el.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/assign/type_el.rs
@@ -380,7 +380,7 @@ impl Analyzer<'_, '_> {
                                 ..opts
                             },
                         )
-                        .convert_err(|err| match &*err {
+                        .convert_err(|err| match *err {
                             ErrorKind::Errors { span, .. } => ErrorKind::SimpleAssignFailed {
                                 span,
                                 cause: Some(box err),
@@ -404,7 +404,7 @@ impl Analyzer<'_, '_> {
                 Type::Class(rhs_cls) => {
                     // TODO(kdy1): Check if constructor exists.
                     if rhs_cls.def.is_abstract {
-                        return Err(ErrorKind::CannotAssignAbstractConstructorToNonAbstractConstructor { span });
+                        return Err(ErrorKind::CannotAssignAbstractConstructorToNonAbstractConstructor { span }.into());
                     }
 
                     // TODO(kdy1): Optimize
@@ -1014,7 +1014,7 @@ impl Analyzer<'_, '_> {
         }
 
         if !errors.is_empty() {
-            return Err(ErrorKind::Errors { span, errors });
+            return Err(ErrorKind::Errors { span, errors }.into());
         }
 
         Ok(())
@@ -1096,13 +1096,13 @@ impl Analyzer<'_, '_> {
                                             if lp.accessibility == Some(Accessibility::Private)
                                                 || rp.accessibility == Some(Accessibility::Private)
                                             {
-                                                return Err(ErrorKind::AssignFailedDueToAccessibility { span });
+                                                return Err(ErrorKind::AssignFailedDueToAccessibility { span }.into());
                                             }
                                         }
 
                                         if !opts.for_castablity {
                                             if !lp.optional && rp.optional {
-                                                return Err(ErrorKind::AssignFailedDueToOptionalityDifference { span });
+                                                return Err(ErrorKind::AssignFailedDueToOptionalityDifference { span }.into());
                                             }
                                         }
 

--- a/crates/stc_ts_file_analyzer/src/analyzer/assign/type_el.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/assign/type_el.rs
@@ -667,11 +667,11 @@ impl Analyzer<'_, '_> {
                             fields: lhs.to_vec(),
                         }
                         .context("keyword `object` is not assignable to a non-empty type literal");
-                        return Err(ErrorKind::Errors { span, errors: vec![err] });
+                        return Err(ErrorKind::Errors { span, errors: vec![err] }.into());
                     }
                 }
 
-                Type::EnumVariant(..) => return Err(ErrorKind::SimpleAssignFailed { span, cause: None }),
+                Type::EnumVariant(..) => return Err(ErrorKind::SimpleAssignFailed { span, cause: None }.into()),
 
                 Type::Keyword(..) => {
                     let rhs = self
@@ -723,7 +723,8 @@ impl Analyzer<'_, '_> {
                     return Err(ErrorKind::Unimplemented {
                         span,
                         msg: format!("assign_to_type_elements - {:#?}", rhs),
-                    })
+                    }
+                    .into())
                 }
             }
 
@@ -744,7 +745,7 @@ impl Analyzer<'_, '_> {
                     span,
                     errors: unhandled_rhs
                         .into_iter()
-                        .map(|span| ErrorKind::UnknownPropertyInObjectLiteralAssignment { span })
+                        .map(|span| ErrorKind::UnknownPropertyInObjectLiteralAssignment { span }.into())
                         .collect(),
                 }
                 .into());
@@ -830,15 +831,21 @@ impl Analyzer<'_, '_> {
 
         if !missing_fields.is_empty() {
             if self.should_report_properties(span, lhs, rhs) {
-                errors.push(ErrorKind::MissingFields {
-                    span,
-                    fields: missing_fields,
-                });
+                errors.push(
+                    ErrorKind::MissingFields {
+                        span,
+                        fields: missing_fields,
+                    }
+                    .into(),
+                );
             } else {
-                errors.push(ErrorKind::ObjectAssignFailed {
-                    span,
-                    errors: vec![ErrorKind::SimpleAssignFailed { span, cause: None }],
-                })
+                errors.push(
+                    ErrorKind::ObjectAssignFailed {
+                        span,
+                        errors: vec![ErrorKind::SimpleAssignFailed { span, cause: None }],
+                    }
+                    .into(),
+                )
             }
         }
 
@@ -846,7 +853,8 @@ impl Analyzer<'_, '_> {
             return Err(ErrorKind::Errors {
                 span,
                 errors: errors.into(),
-            });
+            }
+            .into());
         }
 
         Ok(())

--- a/crates/stc_ts_file_analyzer/src/analyzer/assign/type_el.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/assign/type_el.rs
@@ -380,15 +380,15 @@ impl Analyzer<'_, '_> {
                                 ..opts
                             },
                         )
-                        .convert_err(|err| match *err {
+                        .convert_err(|err| match err {
                             ErrorKind::Errors { span, .. } => ErrorKind::SimpleAssignFailed {
                                 span,
-                                cause: Some(box err),
+                                cause: Some(box err.into()),
                             }
                             .into(),
                             ErrorKind::MissingFields { span, .. } => ErrorKind::SimpleAssignFailed {
                                 span,
-                                cause: Some(box err),
+                                cause: Some(box err.into()),
                             }
                             .into(),
                             _ => err,
@@ -690,7 +690,7 @@ impl Analyzer<'_, '_> {
                         .convert_err(|err| {
                             ErrorKind::SimpleAssignFailed {
                                 span: err.span(),
-                                cause: Some(box err),
+                                cause: Some(box err.into()),
                             }
                             .into()
                         })
@@ -976,8 +976,10 @@ impl Analyzer<'_, '_> {
 
             match res {
                 Ok(()) => {}
-                Err(ErrorKind::Errors { ref errors, .. }) if errors.is_empty() => {}
-                Err(err) => errors.push(err),
+                Err(err) => match &*err {
+                    ErrorKind::Errors { ref errors, .. } if errors.is_empty() => {}
+                    _ => errors.push(err),
+                },
             }
         }
 

--- a/crates/stc_ts_file_analyzer/src/analyzer/assign/type_el.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/assign/type_el.rs
@@ -788,7 +788,7 @@ impl Analyzer<'_, '_> {
                                     ClassMember::Property(ref rp) => {
                                         match rp.accessibility {
                                             Some(Accessibility::Private) | Some(Accessibility::Protected) => {
-                                                errors.push(ErrorKind::AccessibilityDiffers { span });
+                                                errors.push(ErrorKind::AccessibilityDiffers { span }.into());
                                             }
                                             _ => {}
                                         }

--- a/crates/stc_ts_file_analyzer/src/analyzer/assign/type_el.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/assign/type_el.rs
@@ -88,7 +88,8 @@ impl Analyzer<'_, '_> {
                         Err(ErrorKind::Errors {
                             span,
                             errors: errors.into(),
-                        })
+                        }
+                        .into())
                     };
                 }
 
@@ -226,7 +227,7 @@ impl Analyzer<'_, '_> {
                             .context("tried to assign to type elements by converting rhs to a type literal");
                     }
 
-                    return Err(ErrorKind::SimpleAssignFailed { span, cause: None });
+                    return Err(ErrorKind::SimpleAssignFailed { span, cause: None }.into());
                 }
 
                 Type::Tuple(..) | Type::Array(..) | Type::EnumVariant(..) if lhs.is_empty() => return Ok(()),
@@ -246,7 +247,7 @@ impl Analyzer<'_, '_> {
                         | TypeElement::Method(MethodSignature { optional: true, .. }) => true,
                         _ => false,
                     }) {
-                        return Err(ErrorKind::SimpleAssignFailed { span, cause: None });
+                        return Err(ErrorKind::SimpleAssignFailed { span, cause: None }.into());
                     }
 
                     match rhs.normalize() {
@@ -842,7 +843,7 @@ impl Analyzer<'_, '_> {
                 errors.push(
                     ErrorKind::ObjectAssignFailed {
                         span,
-                        errors: vec![ErrorKind::SimpleAssignFailed { span, cause: None }],
+                        errors: vec![ErrorKind::SimpleAssignFailed { span, cause: None }.into()],
                     }
                     .into(),
                 )
@@ -1484,7 +1485,8 @@ impl Analyzer<'_, '_> {
             return Err(ErrorKind::ObjectAssignFailed {
                 span,
                 errors: ErrorKind::flatten(errors),
-            });
+            }
+            .into());
         }
 
         unhandled_rhs.clear();

--- a/crates/stc_ts_file_analyzer/src/analyzer/assign/unions.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/assign/unions.rs
@@ -2,7 +2,7 @@ use std::borrow::Cow;
 
 use itertools::Itertools;
 use stc_ts_ast_rnode::RBool;
-use stc_ts_errors::{DebugExt, Error};
+use stc_ts_errors::{DebugExt, ErrorKind};
 use stc_ts_type_ops::Fix;
 use stc_ts_types::{
     KeywordType, LitType, LitTypeMetadata, PropertySignature, Tuple, TupleElement, Type, TypeElement, TypeLit, Union, UnionMetadata,
@@ -127,7 +127,7 @@ impl Analyzer<'_, '_> {
 
                 Ok(())
             }
-            _ => Err(Error::SimpleAssignFailed { span, cause: None }),
+            _ => Err(ErrorKind::SimpleAssignFailed { span, cause: None }),
         }
     }
 
@@ -170,7 +170,7 @@ impl Analyzer<'_, '_> {
 
                 Ok(())
             }
-            _ => Err(Error::SimpleAssignFailed { span, cause: None }),
+            _ => Err(ErrorKind::SimpleAssignFailed { span, cause: None }),
         }
     }
 

--- a/crates/stc_ts_file_analyzer/src/analyzer/assign/unions.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/assign/unions.rs
@@ -127,7 +127,7 @@ impl Analyzer<'_, '_> {
 
                 Ok(())
             }
-            _ => Err(ErrorKind::SimpleAssignFailed { span, cause: None }),
+            _ => Err(ErrorKind::SimpleAssignFailed { span, cause: None }.into()),
         }
     }
 
@@ -170,7 +170,7 @@ impl Analyzer<'_, '_> {
 
                 Ok(())
             }
-            _ => Err(ErrorKind::SimpleAssignFailed { span, cause: None }),
+            _ => Err(ErrorKind::SimpleAssignFailed { span, cause: None }.into()),
         }
     }
 

--- a/crates/stc_ts_file_analyzer/src/analyzer/class/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/class/mod.rs
@@ -93,7 +93,7 @@ impl Analyzer<'_, '_> {
                             )
                             .is_err()
                         {
-                            self.storage.report(ErrorKind::ClassPropNotInitialized { span })
+                            self.storage.report(ErrorKind::ClassPropNotInitialized { span }.into())
                         }
                     }
                 }
@@ -148,7 +148,7 @@ impl Analyzer<'_, '_> {
                 RPropName::Ident(i) => {
                     if &*i.sym == "prototype" {
                         self.storage
-                            .report(ErrorKind::StaticPropertyCannotBeNamedPrototype { span: i.span })
+                            .report(ErrorKind::StaticPropertyCannotBeNamedPrototype { span: i.span }.into())
                     }
                 }
                 _ => {}
@@ -645,7 +645,7 @@ impl Analyzer<'_, '_> {
 
                 let type_params = try_opt!(c.function.type_params.validate_with(child));
                 if (c.kind == MethodKind::Getter || c.kind == MethodKind::Setter) && type_params.is_some() {
-                    child.storage.report(ErrorKind::TS1094 { span: key_span })
+                    child.storage.report(ErrorKind::TS1094 { span: key_span }.into())
                 }
 
                 let params = c.function.params.validate_with(child)?;
@@ -657,7 +657,7 @@ impl Analyzer<'_, '_> {
                 // }
 
                 if c.kind == MethodKind::Setter && c.function.return_type.is_some() {
-                    child.storage.report(ErrorKind::TS1095 { span: key_span })
+                    child.storage.report(ErrorKind::TS1095 { span: key_span }.into())
                 }
 
                 let declared_ret_ty = try_opt!(c.function.return_type.validate_with(child));
@@ -1342,11 +1342,12 @@ impl Analyzer<'_, '_> {
                                 })
                                 .collect(),
                         }
+                        .into()
                     } else {
                         err.convert_all(|err| {
                             match err {
                                 ErrorKind::MissingFields { .. } => {
-                                    return ErrorKind::ClassIncorrectlyImplementsInterface { span: parent.span() }
+                                    return ErrorKind::ClassIncorrectlyImplementsInterface { span: parent.span() }.into()
                                 }
                                 _ => {}
                             }

--- a/crates/stc_ts_file_analyzer/src/analyzer/class/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/class/mod.rs
@@ -945,9 +945,9 @@ impl Analyzer<'_, '_> {
 
                             for (span, is_staitc) in spans_for_error {
                                 if report_error_for_static && is_staitc {
-                                    self.storage.report(ErrorKind::ShouldBeInstanceMethod { span })
+                                    self.storage.report(ErrorKind::ShouldBeInstanceMethod { span }.into())
                                 } else if !report_error_for_static && !is_staitc {
-                                    self.storage.report(ErrorKind::ShouldBeStaticMethod { span })
+                                    self.storage.report(ErrorKind::ShouldBeStaticMethod { span }.into())
                                 }
                             }
                         }
@@ -1513,7 +1513,7 @@ impl Analyzer<'_, '_> {
 
                     ModuleConfig::None | ModuleConfig::Umd | ModuleConfig::System | ModuleConfig::Amd | ModuleConfig::CommonJs => {
                         self.storage
-                            .report(ErrorKind::ClassNameCannotBeObjectWhenTargetingEs5WithModule { span: c.span });
+                            .report(ErrorKind::ClassNameCannotBeObjectWhenTargetingEs5WithModule { span: c.span }.into());
                     }
                     _ => {}
                 },
@@ -1569,7 +1569,7 @@ impl Analyzer<'_, '_> {
                             | Type::Keyword(KeywordType {
                                 kind: TsKeywordTypeKind::TsBooleanKeyword,
                                 ..
-                            }) => Err(ErrorKind::InvalidSuperClass { span: super_ty.span() }),
+                            }) => Err(ErrorKind::InvalidSuperClass { span: super_ty.span() }.into()),
                             _ => Ok(()),
                         });
 
@@ -1697,7 +1697,7 @@ impl Analyzer<'_, '_> {
 
                 if constructors_with_body.len() >= 2 {
                     for &span in &constructors_with_body {
-                        child.storage.report(ErrorKind::DuplicateConstructor { span })
+                        child.storage.report(ErrorKind::DuplicateConstructor { span }.into())
                     }
                 }
 
@@ -1710,7 +1710,7 @@ impl Analyzer<'_, '_> {
                                     match *p {
                                         RParamOrTsParamProp::TsParamProp(..) => child
                                             .storage
-                                            .report(ErrorKind::ParamPropIsNotAllowedInAmbientConstructorx { span: p.span() }),
+                                            .report(ErrorKind::ParamPropIsNotAllowedInAmbientConstructorx { span: p.span() }.into()),
                                         _ => {}
                                     }
                                 }

--- a/crates/stc_ts_file_analyzer/src/analyzer/class/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/class/mod.rs
@@ -205,7 +205,7 @@ impl Analyzer<'_, '_> {
     fn validate(&mut self, p: &RPrivateProp) -> VResult<ClassProperty> {
         match p.key.id.sym {
             js_word!("constructor") => {
-                self.storage.report(ErrorKind::ConstructorIsKeyword { span: p.key.id.span });
+                self.storage.report(ErrorKind::ConstructorIsKeyword { span: p.key.id.span }.into());
             }
             _ => {}
         }
@@ -294,7 +294,7 @@ impl Analyzer<'_, '_> {
                                     })
                                     | RPat::Rest(..) => {}
                                     _ => {
-                                        child.storage.report(ErrorKind::TS1016 { span: p.span() });
+                                        child.storage.report(ErrorKind::TS1016 { span: p.span() }.into());
                                     }
                                 },
                                 _ => {}
@@ -367,7 +367,7 @@ impl Analyzer<'_, '_> {
             match p.param {
                 RTsParamPropParam::Assign(..) => self
                     .storage
-                    .report(ErrorKind::InitializerDisallowedInAmbientContext { span: p.span }),
+                    .report(ErrorKind::InitializerDisallowedInAmbientContext { span: p.span }.into()),
                 _ => {}
             }
         }
@@ -486,7 +486,7 @@ impl Analyzer<'_, '_> {
     fn validate(&mut self, c: &RPrivateMethod) -> VResult<ClassMember> {
         match c.key.id.sym {
             js_word!("constructor") => {
-                self.storage.report(ErrorKind::ConstructorIsKeyword { span: c.key.id.span });
+                self.storage.report(ErrorKind::ConstructorIsKeyword { span: c.key.id.span }.into());
             }
             _ => {}
         }
@@ -500,7 +500,7 @@ impl Analyzer<'_, '_> {
             |child: &mut Analyzer| -> VResult<_> {
                 let type_params = try_opt!(c.function.type_params.validate_with(child));
                 if (c.kind == MethodKind::Getter || c.kind == MethodKind::Setter) && type_params.is_some() {
-                    child.storage.report(ErrorKind::TS1094 { span: key_span })
+                    child.storage.report(ErrorKind::TS1094 { span: key_span }.into())
                 }
 
                 let params = c.function.params.validate_with(child)?;
@@ -607,7 +607,7 @@ impl Analyzer<'_, '_> {
                     // It's error if abstract method has a body
 
                     if c.is_abstract && c.function.body.is_some() {
-                        child.storage.report(ErrorKind::TS1318 { span: key_span });
+                        child.storage.report(ErrorKind::TS1318 { span: key_span }.into());
                     }
                 }
 
@@ -624,7 +624,7 @@ impl Analyzer<'_, '_> {
                                 })
                                 | RPat::Rest(..) => {}
                                 _ => {
-                                    child.storage.report(ErrorKind::TS1016 { span: p.span() });
+                                    child.storage.report(ErrorKind::TS1016 { span: p.span() }.into());
                                 }
                             }
                         }
@@ -688,7 +688,7 @@ impl Analyzer<'_, '_> {
 
             // getter property must have return statements.
             if let None = inferred_ret_ty {
-                self.storage.report(ErrorKind::TS2378 { span: key_span });
+                self.storage.report(ErrorKind::TS2378 { span: key_span }.into());
             }
         }
 
@@ -874,7 +874,7 @@ impl Analyzer<'_, '_> {
                         continue;
                     }
 
-                    self.storage.report(ErrorKind::DuplicateNameWithoutName { span: l.0.span() });
+                    self.storage.report(ErrorKind::DuplicateNameWithoutName { span: l.0.span() }.into());
                 }
             }
         }
@@ -895,7 +895,7 @@ impl Analyzer<'_, '_> {
                         continue;
                     }
 
-                    self.storage.report(ErrorKind::DuplicateNameWithoutName { span: l.0.span() });
+                    self.storage.report(ErrorKind::DuplicateNameWithoutName { span: l.0.span() }.into());
                 }
             }
         }
@@ -1059,9 +1059,9 @@ impl Analyzer<'_, '_> {
 
                                     for (span, is_abstract) in spans_for_error {
                                         if report_error_for_abstract && is_abstract {
-                                            self.storage.report(ErrorKind::AbstractAndConcreteIsMixed { span })
+                                            self.storage.report(ErrorKind::AbstractAndConcreteIsMixed { span }.into())
                                         } else if !report_error_for_abstract && !is_abstract {
-                                            self.storage.report(ErrorKind::AbstractAndConcreteIsMixed { span })
+                                            self.storage.report(ErrorKind::AbstractAndConcreteIsMixed { span }.into())
                                         }
                                     }
                                 }
@@ -1096,7 +1096,8 @@ impl Analyzer<'_, '_> {
                             // In this case, we report `abstract methods must be
                             // sequential`
                             if let Some((span, _)) = spans.last() {
-                                self.storage.report(ErrorKind::AbstractClassMethodShouldBeSequntial { span: *span })
+                                self.storage
+                                    .report(ErrorKind::AbstractClassMethodShouldBeSequntial { span: *span }.into())
                             }
                         }
                     }
@@ -1160,23 +1161,23 @@ impl Analyzer<'_, '_> {
                             if is_prop_name_eq_include_computed(&name.unwrap(), &constructor_name) {
                                 for (span, is_constructor) in replace(&mut spans, vec![]) {
                                     if is_constructor {
-                                        errors.push(Error::ConstructorImplMissingOrNotFollowedByDecl { span });
+                                        errors.push(ErrorKind::ConstructorImplMissingOrNotFollowedByDecl { span }.into());
                                     } else {
-                                        errors.push(Error::FnImplMissingOrNotFollowedByDecl { span });
+                                        errors.push(ErrorKind::FnImplMissingOrNotFollowedByDecl { span }.into());
                                     }
                                 }
                             } else if is_prop_name_eq_include_computed(&m.key, &constructor_name) {
                                 for (span, is_constructor) in replace(&mut spans, vec![]) {
                                     if is_constructor {
-                                        errors.push(Error::ConstructorImplMissingOrNotFollowedByDecl { span });
+                                        errors.push(ErrorKind::ConstructorImplMissingOrNotFollowedByDecl { span }.into());
                                     } else {
-                                        errors.push(Error::FnImplMissingOrNotFollowedByDecl { span });
+                                        errors.push(ErrorKind::FnImplMissingOrNotFollowedByDecl { span }.into());
                                     }
                                 }
                             } else {
                                 spans = vec![];
 
-                                errors.push(Error::TS2389 { span: m.key.span() });
+                                errors.push(ErrorKind::TS2389 { span: m.key.span() }.into());
                             }
 
                             name = None;
@@ -1213,9 +1214,9 @@ impl Analyzer<'_, '_> {
         // Class definition ended with `foo();`
         for (span, is_constructor) in replace(&mut spans, vec![]) {
             if is_constructor {
-                errors.push(ErrorKind::ConstructorImplMissingOrNotFollowedByDecl { span });
+                errors.push(ErrorKind::ConstructorImplMissingOrNotFollowedByDecl { span }.into());
             } else {
-                errors.push(ErrorKind::FnImplMissingOrNotFollowedByDecl { span });
+                errors.push(ErrorKind::FnImplMissingOrNotFollowedByDecl { span }.into());
             }
         }
 

--- a/crates/stc_ts_file_analyzer/src/analyzer/class/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/class/mod.rs
@@ -1348,15 +1348,13 @@ impl Analyzer<'_, '_> {
                         }
                         .into()
                     } else {
-                        err.convert_all(|err| {
-                            match &*err {
-                                ErrorKind::MissingFields { .. } => {
-                                    return ErrorKind::ClassIncorrectlyImplementsInterface { span: parent.span() }.into()
-                                }
-                                _ => {}
+                        match err {
+                            ErrorKind::MissingFields { .. } => {
+                                return ErrorKind::ClassIncorrectlyImplementsInterface { span: parent.span() }.into()
                             }
-                            err
-                        })
+                            _ => {}
+                        }
+                        err
                     }
                 })?;
             };

--- a/crates/stc_ts_file_analyzer/src/analyzer/class/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/class/mod.rs
@@ -260,14 +260,14 @@ impl Analyzer<'_, '_> {
             let mut v = ConstructorSuperCallFinder::default();
             c.visit_with(&mut v);
             if !v.has_valid_super_call {
-                self.storage.report(ErrorKind::SuperNotCalled { span: c.span });
+                self.storage.report(ErrorKind::SuperNotCalled { span: c.span }.into());
             } else {
                 debug_assert_eq!(self.scope.kind(), ScopeKind::Class);
                 *self.scope.class.need_super_call.borrow_mut() = true;
             }
 
             for span in v.nested_super_calls {
-                self.storage.report(ErrorKind::SuperInNestedFunction { span })
+                self.storage.report(ErrorKind::SuperInNestedFunction { span }.into())
             }
         }
 

--- a/crates/stc_ts_file_analyzer/src/analyzer/class/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/class/mod.rs
@@ -2229,7 +2229,7 @@ impl Analyzer<'_, '_> {
                         ..Default::default()
                     },
                 )
-                .convert_err(|err| ErrorKind::WrongOverloadSignature { span: err.span() })?;
+                .convert_err(|err| ErrorKind::WrongOverloadSignature { span: err.span() }.into())?;
             }
         }
 

--- a/crates/stc_ts_file_analyzer/src/analyzer/class/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/class/mod.rs
@@ -1248,7 +1248,7 @@ impl Analyzer<'_, '_> {
         }) {
             Ok(ty) => ty,
             Err(err) => {
-                match err {
+                match *err {
                     ErrorKind::TS2585 { span } => Err(ErrorKind::TS2585 { span })?,
                     _ => {}
                 }
@@ -1271,7 +1271,7 @@ impl Analyzer<'_, '_> {
                 ..
             }) => {}
             _ if is_symbol_access => {}
-            _ => errors.push(ErrorKind::TS1166 { span }),
+            _ => errors.push(ErrorKind::TS1166 { span }.into()),
         }
 
         if !errors.is_empty() {

--- a/crates/stc_ts_file_analyzer/src/analyzer/class/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/class/mod.rs
@@ -1123,9 +1123,9 @@ impl Analyzer<'_, '_> {
                         if name.is_some() && !is_key_optional(&m.key) && !is_prop_name_eq_include_computed(&name.unwrap(), &m.key) {
                             for (span, is_constructor) in replace(&mut spans, vec![]) {
                                 if is_constructor {
-                                    errors.push(Error::ConstructorImplMissingOrNotFollowedByDecl { span });
+                                    errors.push(ErrorKind::ConstructorImplMissingOrNotFollowedByDecl { span }.into());
                                 } else {
-                                    errors.push(Error::FnImplMissingOrNotFollowedByDecl { span });
+                                    errors.push(ErrorKind::FnImplMissingOrNotFollowedByDecl { span }.into());
                                 }
                             }
                         }

--- a/crates/stc_ts_file_analyzer/src/analyzer/class/type_param.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/class/type_param.rs
@@ -1,5 +1,5 @@
 use rnode::{Visit, VisitWith};
-use stc_ts_errors::Error;
+use stc_ts_errors::ErrorKind;
 use stc_ts_types::{Id, TypeParam};
 use swc_common::Span;
 
@@ -36,7 +36,7 @@ impl Visit<TypeParam> for StaticTypeParamValidator<'_, '_, '_> {
         if self.analyzer.is_type_param_declared_in_containing_class(&param.name) {
             self.analyzer
                 .storage
-                .report(Error::StaticMemberCannotUseTypeParamOfClass { span: self.span })
+                .report(ErrorKind::StaticMemberCannotUseTypeParamOfClass { span: self.span })
         }
     }
 }

--- a/crates/stc_ts_file_analyzer/src/analyzer/class/type_param.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/class/type_param.rs
@@ -36,7 +36,7 @@ impl Visit<TypeParam> for StaticTypeParamValidator<'_, '_, '_> {
         if self.analyzer.is_type_param_declared_in_containing_class(&param.name) {
             self.analyzer
                 .storage
-                .report(ErrorKind::StaticMemberCannotUseTypeParamOfClass { span: self.span })
+                .report(ErrorKind::StaticMemberCannotUseTypeParamOfClass { span: self.span }.into())
         }
     }
 }

--- a/crates/stc_ts_file_analyzer/src/analyzer/control_flow.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/control_flow.rs
@@ -834,10 +834,13 @@ impl Analyzer<'_, '_> {
                     }
                 } else {
                     if !opts.ignore_lhs_errors {
-                        self.storage.report(ErrorKind::NoSuchVar {
-                            span,
-                            name: i.id.clone().into(),
-                        });
+                        self.storage.report(
+                            ErrorKind::NoSuchVar {
+                                span,
+                                name: i.id.clone().into(),
+                            }
+                            .into(),
+                        );
                     }
                     return Ok(());
                 }
@@ -876,7 +879,8 @@ impl Analyzer<'_, '_> {
                                         span: i.id.span,
                                         left: lhs.span(),
                                         ty: Some(box ty.normalize().clone()),
-                                    });
+                                    }
+                                    .into());
                                 }
                                 _ => {}
                             }
@@ -890,7 +894,8 @@ impl Analyzer<'_, '_> {
                         Err(ErrorKind::UndefinedSymbol {
                             sym: i.id.clone().into(),
                             span: i.id.span,
-                        })
+                        }
+                        .into())
                     };
                 };
 
@@ -1070,7 +1075,7 @@ impl Analyzer<'_, '_> {
             RPat::Expr(lhs) => {
                 match &**lhs {
                     RExpr::Lit(..) => {
-                        self.storage.report(ErrorKind::InvalidLhsOfAssign { span: lhs.span() });
+                        self.storage.report(ErrorKind::InvalidLhsOfAssign { span: lhs.span() }.into());
                         return Ok(());
                     }
                     _ => {}
@@ -1211,7 +1216,7 @@ impl Analyzer<'_, '_> {
                     }
                 }
             }
-            Err(err) => match err.actual() {
+            Err(err) => match *err {
                 ErrorKind::NoSuchProperty { .. } | ErrorKind::NoSuchPropertyInClass { .. } => {
                     return Ok(Type::never(
                         src.span(),

--- a/crates/stc_ts_file_analyzer/src/analyzer/control_flow.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/control_flow.rs
@@ -1018,31 +1018,31 @@ impl Analyzer<'_, '_> {
                                 RPat::Ident(_) => {}
 
                                 RPat::Array(_) => {
-                                    self.storage.report(ErrorKind::NotArrayType { span: r.arg.span() });
+                                    self.storage.report(ErrorKind::NotArrayType { span: r.arg.span() }.into());
                                     self.storage
-                                        .report(ErrorKind::BindingPatNotAllowedInRestPatArg { span: r.arg.span() });
+                                        .report(ErrorKind::BindingPatNotAllowedInRestPatArg { span: r.arg.span() }.into());
                                 }
 
                                 RPat::Object(_) => {
                                     self.storage
-                                        .report(ErrorKind::BindingPatNotAllowedInRestPatArg { span: r.arg.span() });
+                                        .report(ErrorKind::BindingPatNotAllowedInRestPatArg { span: r.arg.span() }.into());
                                 }
 
                                 RPat::Expr(expr) => {
                                     // { ...obj?.a["b"] }
                                     if is_obj_opt_chaining(&expr) {
-                                        return Err(ErrorKind::InvalidRestPatternInOptionalChain { span: r.span });
+                                        return Err(ErrorKind::InvalidRestPatternInOptionalChain { span: r.span }.into());
                                     }
 
                                     self.storage
-                                        .report(ErrorKind::BindingPatNotAllowedInRestPatArg { span: r.arg.span() });
+                                        .report(ErrorKind::BindingPatNotAllowedInRestPatArg { span: r.arg.span() }.into());
                                 }
 
                                 RPat::Invalid(_) => {
                                     // self.storage.report(Error::BindingPatNotAllowedInRestPatArg { span:
                                     // r.arg.span() });
                                     self.storage
-                                        .report(ErrorKind::RestArgMustBeVarOrMemberAccess { span: r.arg.span() });
+                                        .report(ErrorKind::RestArgMustBeVarOrMemberAccess { span: r.arg.span() }.into());
                                 }
 
                                 _ => {}

--- a/crates/stc_ts_file_analyzer/src/analyzer/convert/interface.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/convert/interface.rs
@@ -59,7 +59,8 @@ impl Analyzer<'_, '_> {
             };
 
             if let Err(err) = res {
-                self.storage.report(ErrorKind::InvalidInterfaceInheritance { span, cause: box err });
+                self.storage
+                    .report(ErrorKind::InvalidInterfaceInheritance { span, cause: box err }.into());
                 return;
             }
         }
@@ -98,16 +99,18 @@ impl Analyzer<'_, '_> {
                             ..Default::default()
                         },
                     ) {
-                        match err.actual() {
+                        match &*err {
                             ErrorKind::MissingFields { .. } => {}
 
                             ErrorKind::Errors { errors, .. }
-                                if errors.iter().all(|err| match err.actual() {
+                                if errors.iter().all(|err| match &**err {
                                     ErrorKind::MissingFields { .. } => true,
                                     _ => false,
                                 }) => {}
 
-                            _ => self.storage.report(err.convert(|err| ErrorKind::InterfaceNotCompatible { span })),
+                            _ => self
+                                .storage
+                                .report(err.convert(|err| ErrorKind::InterfaceNotCompatible { span }.into())),
                         }
                     }
                 }

--- a/crates/stc_ts_file_analyzer/src/analyzer/convert/interface.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/convert/interface.rs
@@ -1,6 +1,6 @@
 use std::borrow::Cow;
 
-use stc_ts_errors::Error;
+use stc_ts_errors::ErrorKind;
 use stc_ts_types::{TsExpr, Type, TypeElement, TypeLit};
 use stc_utils::cache::Freeze;
 use swc_common::{Span, TypeEq, DUMMY_SP};
@@ -59,7 +59,7 @@ impl Analyzer<'_, '_> {
             };
 
             if let Err(err) = res {
-                self.storage.report(Error::InvalidInterfaceInheritance { span, cause: box err });
+                self.storage.report(ErrorKind::InvalidInterfaceInheritance { span, cause: box err });
                 return;
             }
         }
@@ -99,15 +99,15 @@ impl Analyzer<'_, '_> {
                         },
                     ) {
                         match err.actual() {
-                            Error::MissingFields { .. } => {}
+                            ErrorKind::MissingFields { .. } => {}
 
-                            Error::Errors { errors, .. }
+                            ErrorKind::Errors { errors, .. }
                                 if errors.iter().all(|err| match err.actual() {
-                                    Error::MissingFields { .. } => true,
+                                    ErrorKind::MissingFields { .. } => true,
                                     _ => false,
                                 }) => {}
 
-                            _ => self.storage.report(err.convert(|err| Error::InterfaceNotCompatible { span })),
+                            _ => self.storage.report(err.convert(|err| ErrorKind::InterfaceNotCompatible { span })),
                         }
                     }
                 }

--- a/crates/stc_ts_file_analyzer/src/analyzer/convert/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/convert/mod.rs
@@ -192,7 +192,7 @@ impl Analyzer<'_, '_> {
                         kind: TsKeywordTypeKind::TsIntrinsicKeyword,
                     }) if !child.is_builtin => {
                         let span = *span;
-                        child.storage.report(ErrorKind::IntrinsicIsBuiltinOnly { span });
+                        child.storage.report(ErrorKind::IntrinsicIsBuiltinOnly { span }.into());
                         Type::any(span.with_ctxt(SyntaxContext::empty()), Default::default())
                     }
 
@@ -265,7 +265,7 @@ impl Analyzer<'_, '_> {
         let ty = self.with_child(ScopeKind::Flow, Default::default(), |child: &mut Analyzer| -> VResult<_> {
             match &*d.id.sym {
                 "any" | "void" | "never" | "string" | "number" | "boolean" | "null" | "undefined" | "symbol" => {
-                    child.storage.report(ErrorKind::InvalidInterfaceName { span: d.id.span });
+                    child.storage.report(ErrorKind::InvalidInterfaceName { span: d.id.span }.into());
                 }
                 _ => {}
             }
@@ -736,14 +736,16 @@ impl Analyzer<'_, '_> {
 
                     if !self.is_builtin && !found && self.ctx.in_actual_type {
                         if let Some(..) = self.scope.get_var(&i.into()) {
-                            self.storage.report(ErrorKind::NoSuchTypeButVarExists { span, name: i.into() });
+                            self.storage
+                                .report(ErrorKind::NoSuchTypeButVarExists { span, name: i.into() }.into());
                             reported_type_not_found = true;
                         }
                     }
                 } else {
                     if !self.is_builtin && self.ctx.in_actual_type {
                         if let Some(..) = self.scope.get_var(&i.into()) {
-                            self.storage.report(ErrorKind::NoSuchTypeButVarExists { span, name: i.into() });
+                            self.storage
+                                .report(ErrorKind::NoSuchTypeButVarExists { span, name: i.into() }.into());
                             reported_type_not_found = true;
                         }
                     }
@@ -986,10 +988,13 @@ impl Analyzer<'_, '_> {
                         if !a.is_builtin {
                             let span = ty.span;
 
-                            a.storage.report(ErrorKind::NoSuchType {
-                                span,
-                                name: Id::word("intrinsic".into()),
-                            });
+                            a.storage.report(
+                                ErrorKind::NoSuchType {
+                                    span,
+                                    name: Id::word("intrinsic".into()),
+                                }
+                                .into(),
+                            );
                             return Ok(Type::any(span.with_ctxt(SyntaxContext::empty()), Default::default()));
                         }
                     }
@@ -1062,8 +1067,9 @@ impl Analyzer<'_, '_> {
                             continue;
                         }
                         if let Some(prev) = prev_keys.iter().find(|prev_key| key.type_eq(&*prev_key)) {
-                            self.storage.report(ErrorKind::DuplicateNameWithoutName { span: prev.span() });
-                            self.storage.report(ErrorKind::DuplicateNameWithoutName { span: key.span() });
+                            self.storage
+                                .report(ErrorKind::DuplicateNameWithoutName { span: prev.span() }.into());
+                            self.storage.report(ErrorKind::DuplicateNameWithoutName { span: key.span() }.into());
                         } else {
                             prev_keys.push(key);
                         }
@@ -1087,10 +1093,13 @@ impl Analyzer<'_, '_> {
             for id in ids {
                 if let Some(prev) = prev_ids.iter().find(|v| v.sym == id.sym) {
                     self.storage
-                        .report(ErrorKind::DuplicateName {
-                            span: prev.span,
-                            name: prev.into(),
-                        })
+                        .report(
+                            ErrorKind::DuplicateName {
+                                span: prev.span,
+                                name: prev.into(),
+                            }
+                            .into(),
+                        )
                         .into();
                     self.storage.report(
                         ErrorKind::DuplicateName {
@@ -1131,7 +1140,8 @@ impl Analyzer<'_, '_> {
         });
 
         if static_method.is_some() {
-            self.storage.report(ErrorKind::StaticMemberCannotUseTypeParamOfClass { span })
+            self.storage
+                .report(ErrorKind::StaticMemberCannotUseTypeParamOfClass { span }.into())
         }
     }
 

--- a/crates/stc_ts_file_analyzer/src/analyzer/convert/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/convert/mod.rs
@@ -1092,15 +1092,13 @@ impl Analyzer<'_, '_> {
 
             for id in ids {
                 if let Some(prev) = prev_ids.iter().find(|v| v.sym == id.sym) {
-                    self.storage
-                        .report(
-                            ErrorKind::DuplicateName {
-                                span: prev.span,
-                                name: prev.into(),
-                            }
-                            .into(),
-                        )
-                        .into();
+                    self.storage.report(
+                        ErrorKind::DuplicateName {
+                            span: prev.span,
+                            name: prev.into(),
+                        }
+                        .into(),
+                    );
                     self.storage.report(
                         ErrorKind::DuplicateName {
                             span: id.span,

--- a/crates/stc_ts_file_analyzer/src/analyzer/convert/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/convert/mod.rs
@@ -1086,14 +1086,19 @@ impl Analyzer<'_, '_> {
 
             for id in ids {
                 if let Some(prev) = prev_ids.iter().find(|v| v.sym == id.sym) {
-                    self.storage.report(ErrorKind::DuplicateName {
-                        span: prev.span,
-                        name: prev.into(),
-                    });
-                    self.storage.report(ErrorKind::DuplicateName {
-                        span: id.span,
-                        name: id.into(),
-                    });
+                    self.storage
+                        .report(ErrorKind::DuplicateName {
+                            span: prev.span,
+                            name: prev.into(),
+                        })
+                        .into();
+                    self.storage.report(
+                        ErrorKind::DuplicateName {
+                            span: id.span,
+                            name: id.into(),
+                        }
+                        .into(),
+                    );
                 } else {
                     prev_ids.push(id);
                 }

--- a/crates/stc_ts_file_analyzer/src/analyzer/convert/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/convert/mod.rs
@@ -11,7 +11,7 @@ use stc_ts_ast_rnode::{
     RTsTypeAnn, RTsTypeElement, RTsTypeLit, RTsTypeOperator, RTsTypeParam, RTsTypeParamDecl, RTsTypeParamInstantiation, RTsTypePredicate,
     RTsTypeQuery, RTsTypeQueryExpr, RTsTypeRef, RTsUnionOrIntersectionType, RTsUnionType,
 };
-use stc_ts_errors::Error;
+use stc_ts_errors::ErrorKind;
 use stc_ts_file_analyzer_macros::extra_validator;
 use stc_ts_types::{
     type_id::SymbolId, Accessor, Alias, AliasMetadata, Array, CallSignature, CommonTypeMetadata, ComputedKey, Conditional,
@@ -64,7 +64,7 @@ impl Analyzer<'_, '_> {
                 for name in names {
                     if !found.insert(name.sym.clone()) {
                         self.storage.report(
-                            Error::DuplicateName {
+                            ErrorKind::DuplicateName {
                                 span: name.span,
                                 name: name.into(),
                             }
@@ -192,7 +192,7 @@ impl Analyzer<'_, '_> {
                         kind: TsKeywordTypeKind::TsIntrinsicKeyword,
                     }) if !child.is_builtin => {
                         let span = *span;
-                        child.storage.report(Error::IntrinsicIsBuiltinOnly { span });
+                        child.storage.report(ErrorKind::IntrinsicIsBuiltinOnly { span });
                         Type::any(span.with_ctxt(SyntaxContext::empty()), Default::default())
                     }
 
@@ -265,7 +265,7 @@ impl Analyzer<'_, '_> {
         let ty = self.with_child(ScopeKind::Flow, Default::default(), |child: &mut Analyzer| -> VResult<_> {
             match &*d.id.sym {
                 "any" | "void" | "never" | "string" | "number" | "boolean" | "null" | "undefined" | "symbol" => {
-                    child.storage.report(Error::InvalidInterfaceName { span: d.id.span });
+                    child.storage.report(ErrorKind::InvalidInterfaceName { span: d.id.span });
                 }
                 _ => {}
             }
@@ -736,14 +736,14 @@ impl Analyzer<'_, '_> {
 
                     if !self.is_builtin && !found && self.ctx.in_actual_type {
                         if let Some(..) = self.scope.get_var(&i.into()) {
-                            self.storage.report(Error::NoSuchTypeButVarExists { span, name: i.into() });
+                            self.storage.report(ErrorKind::NoSuchTypeButVarExists { span, name: i.into() });
                             reported_type_not_found = true;
                         }
                     }
                 } else {
                     if !self.is_builtin && self.ctx.in_actual_type {
                         if let Some(..) = self.scope.get_var(&i.into()) {
-                            self.storage.report(Error::NoSuchTypeButVarExists { span, name: i.into() });
+                            self.storage.report(ErrorKind::NoSuchTypeButVarExists { span, name: i.into() });
                             reported_type_not_found = true;
                         }
                     }
@@ -986,7 +986,7 @@ impl Analyzer<'_, '_> {
                         if !a.is_builtin {
                             let span = ty.span;
 
-                            a.storage.report(Error::NoSuchType {
+                            a.storage.report(ErrorKind::NoSuchType {
                                 span,
                                 name: Id::word("intrinsic".into()),
                             });
@@ -1062,8 +1062,8 @@ impl Analyzer<'_, '_> {
                             continue;
                         }
                         if let Some(prev) = prev_keys.iter().find(|prev_key| key.type_eq(&*prev_key)) {
-                            self.storage.report(Error::DuplicateNameWithoutName { span: prev.span() });
-                            self.storage.report(Error::DuplicateNameWithoutName { span: key.span() });
+                            self.storage.report(ErrorKind::DuplicateNameWithoutName { span: prev.span() });
+                            self.storage.report(ErrorKind::DuplicateNameWithoutName { span: key.span() });
                         } else {
                             prev_keys.push(key);
                         }
@@ -1086,11 +1086,11 @@ impl Analyzer<'_, '_> {
 
             for id in ids {
                 if let Some(prev) = prev_ids.iter().find(|v| v.sym == id.sym) {
-                    self.storage.report(Error::DuplicateName {
+                    self.storage.report(ErrorKind::DuplicateName {
                         span: prev.span,
                         name: prev.into(),
                     });
-                    self.storage.report(Error::DuplicateName {
+                    self.storage.report(ErrorKind::DuplicateName {
                         span: id.span,
                         name: id.into(),
                     });
@@ -1126,7 +1126,7 @@ impl Analyzer<'_, '_> {
         });
 
         if static_method.is_some() {
-            self.storage.report(Error::StaticMemberCannotUseTypeParamOfClass { span })
+            self.storage.report(ErrorKind::StaticMemberCannotUseTypeParamOfClass { span })
         }
     }
 
@@ -1156,7 +1156,8 @@ impl Analyzer<'_, '_> {
             let no_type_ann =
                 !self.ctx.in_argument && !(self.ctx.in_return_arg && self.ctx.in_fn_with_return_type) && !self.ctx.in_assign_rhs;
             if no_type_ann || self.ctx.in_useless_expr_for_seq || self.ctx.check_for_implicit_any {
-                self.storage.report(Error::ImplicitAny { span: i.id.span }.context("default type"));
+                self.storage
+                    .report(ErrorKind::ImplicitAny { span: i.id.span }.context("default type"));
             }
         }
 

--- a/crates/stc_ts_file_analyzer/src/analyzer/enums.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/enums.rs
@@ -275,7 +275,7 @@ impl Evaluator<'_> {
             }
         }
 
-        Err(ErrorKind::InvalidEnumInit { span })
+        Err(ErrorKind::InvalidEnumInit { span }.into())
     }
 
     fn compute_bin(&mut self, span: Span, expr: &RBinExpr) -> Result<RTsLit, ErrorKind> {
@@ -465,7 +465,7 @@ impl Analyzer<'_, '_> {
         match rhs_ty.normalize() {
             // Report an error for `a = G` where G is name of the const enum itself.
             Type::Enum(ref e) if e.is_const => {
-                self.storage.report(ErrorKind::InvalidUseOfConstEnum { span });
+                self.storage.report(ErrorKind::InvalidUseOfConstEnum { span }.into());
             }
             Type::Keyword(KeywordType {
                 kind: TsKeywordTypeKind::TsVoidKeyword,
@@ -474,7 +474,7 @@ impl Analyzer<'_, '_> {
                 if self.rule().strict_null_checks {
                     match lhs {
                         RPat::Array(_) | RPat::Rest(_) | RPat::Object(_) => {
-                            self.storage.report(ErrorKind::ObjectIsPossiblyUndefined { span });
+                            self.storage.report(ErrorKind::ObjectIsPossiblyUndefined { span }.into());
                         }
                         _ => {}
                     }

--- a/crates/stc_ts_file_analyzer/src/analyzer/enums.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/enums.rs
@@ -59,7 +59,7 @@ impl Analyzer<'_, '_> {
                 .map(|m| -> VResult<_> {
                     let id_span = m.id.span();
                     let val = eval
-                        .compute(id_span, Some(default), m.init.as_ref().map(|v| &**v))
+                        .compute(id_span, Some(default), m.init.as_deref())
                         .map(|val| {
                             match &val {
                                 RTsLit::Number(n) => {

--- a/crates/stc_ts_file_analyzer/src/analyzer/enums.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/enums.rs
@@ -158,7 +158,7 @@ impl Analyzer<'_, '_> {
                     init.visit_with(&mut v);
                     self.storage.report_all(v.errors);
                     if v.error {
-                        self.storage.report(ErrorKind::InvalidInitInConstEnum { span: init.span() })
+                        self.storage.report(ErrorKind::InvalidInitInConstEnum { span: init.span() }.into())
                     }
                 }
             }

--- a/crates/stc_ts_file_analyzer/src/analyzer/export.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/export.rs
@@ -4,7 +4,7 @@ use stc_ts_ast_rnode::{
     RExportSpecifier, RExpr, RIdent, RModuleExportName, RNamedExport, RPat, RStmt, RTsExportAssignment, RTsModuleName, RTsTypeAnn,
     RVarDecl, RVarDeclarator,
 };
-use stc_ts_errors::{DebugExt, Error};
+use stc_ts_errors::{DebugExt, ErrorKind};
 use stc_ts_file_analyzer_macros::extra_validator;
 use stc_ts_types::{Id, IdCtx, ModuleId};
 use stc_ts_utils::find_ids_in_pat;
@@ -180,9 +180,9 @@ impl Analyzer<'_, '_> {
         if v.len() >= 2 {
             for &span in &*v {
                 if sym == js_word!("default") {
-                    self.storage.report(Error::DuplicateDefaultExport { span });
+                    self.storage.report(ErrorKind::DuplicateDefaultExport { span });
                 } else {
-                    self.storage.report(Error::DuplicateExport { span });
+                    self.storage.report(ErrorKind::DuplicateExport { span });
                 }
             }
         }
@@ -467,7 +467,7 @@ impl Analyzer<'_, '_> {
         }
 
         if !did_work {
-            self.storage.report(Error::ExportFailed { span, orig, id })
+            self.storage.report(ErrorKind::ExportFailed { span, orig, id })
         }
     }
 }

--- a/crates/stc_ts_file_analyzer/src/analyzer/export.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/export.rs
@@ -180,9 +180,9 @@ impl Analyzer<'_, '_> {
         if v.len() >= 2 {
             for &span in &*v {
                 if sym == js_word!("default") {
-                    self.storage.report(ErrorKind::DuplicateDefaultExport { span });
+                    self.storage.report(ErrorKind::DuplicateDefaultExport { span }.into());
                 } else {
-                    self.storage.report(ErrorKind::DuplicateExport { span });
+                    self.storage.report(ErrorKind::DuplicateExport { span }.into());
                 }
             }
         }
@@ -467,7 +467,7 @@ impl Analyzer<'_, '_> {
         }
 
         if !did_work {
-            self.storage.report(ErrorKind::ExportFailed { span, orig, id })
+            self.storage.report(ErrorKind::ExportFailed { span, orig, id }.into())
         }
     }
 }

--- a/crates/stc_ts_file_analyzer/src/analyzer/expr/array.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/expr/array.rs
@@ -275,7 +275,7 @@ impl Analyzer<'_, '_> {
                         .get_element_from_iterator(span, Cow::Borrowed(iterator_elem), n)
                         .with_context(|| format!("failed to get element type from {}th element", idx))
                         .convert_err(|err| match &*err {
-                            ErrorKind::TupleIndexError { span, .. } => ErrorKind::TupleTooShort { span }.into(),
+                            ErrorKind::TupleIndexError { span, .. } => ErrorKind::TupleTooShort { span: *span }.into(),
                             _ => err,
                         })
                         .map(Cow::into_owned);
@@ -305,7 +305,8 @@ impl Analyzer<'_, '_> {
                         span,
                         obj: Some(box iterator.into_owned()),
                         prop: None,
-                    });
+                    }
+                    .into());
                 }
 
                 types.dedup_type();

--- a/crates/stc_ts_file_analyzer/src/analyzer/expr/array.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/expr/array.rs
@@ -349,7 +349,7 @@ impl Analyzer<'_, '_> {
                 None,
                 CallOpts { ..Default::default() },
             )
-            .convert_err(|err| match err {
+            .convert_err(|err| match &*err {
                 ErrorKind::NoCallablePropertyWithName { span, .. }
                 | ErrorKind::NoSuchProperty { span, .. }
                 | ErrorKind::NoSuchPropertyInClass { span, .. } => {
@@ -360,7 +360,8 @@ impl Analyzer<'_, '_> {
                                     span,
                                     obj: None,
                                     prop: None,
-                                };
+                                }
+                                .into();
                             }
                         }
                         _ => {}

--- a/crates/stc_ts_file_analyzer/src/analyzer/expr/array.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/expr/array.rs
@@ -274,8 +274,8 @@ impl Analyzer<'_, '_> {
                     let res = self
                         .get_element_from_iterator(span, Cow::Borrowed(iterator_elem), n)
                         .with_context(|| format!("failed to get element type from {}th element", idx))
-                        .convert_err(|err| match err {
-                            ErrorKind::TupleIndexError { span, .. } => ErrorKind::TupleTooShort { span },
+                        .convert_err(|err| match &*err {
+                            ErrorKind::TupleIndexError { span, .. } => ErrorKind::TupleTooShort { span }.into(),
                             _ => err,
                         })
                         .map(Cow::into_owned);

--- a/crates/stc_ts_file_analyzer/src/analyzer/expr/array.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/expr/array.rs
@@ -625,7 +625,7 @@ impl Analyzer<'_, '_> {
                 if !opts.disallow_str {
                     return Ok(ty);
                 } else {
-                    return Err(ErrorKind::NotArrayType { span });
+                    return Err(ErrorKind::NotArrayType { span }.into());
                 }
             }
 
@@ -653,7 +653,7 @@ impl Analyzer<'_, '_> {
                 | Type::Lit(LitType {
                     lit: RTsLit::BigInt(..), ..
                 })
-                | Type::Lit(LitType { lit: RTsLit::Bool(..), .. }) => return Err(ErrorKind::NotArrayType { span }),
+                | Type::Lit(LitType { lit: RTsLit::Bool(..), .. }) => return Err(ErrorKind::NotArrayType { span }.into()),
 
                 Type::Array(..) | Type::Tuple(..) => return Ok(ty),
                 Type::Union(u) => {
@@ -721,7 +721,7 @@ impl Analyzer<'_, '_> {
             .convert_err(|err| match err {
                 ErrorKind::NoCallablePropertyWithName { span, .. }
                 | ErrorKind::NoSuchPropertyInClass { span, .. }
-                | ErrorKind::NoSuchProperty { span, .. } => ErrorKind::MustHaveSymbolIteratorThatReturnsIterator { span },
+                | ErrorKind::NoSuchProperty { span, .. } => ErrorKind::MustHaveSymbolIteratorThatReturnsIterator { span }.into(),
                 _ => err,
             })
             .map(Cow::Owned)

--- a/crates/stc_ts_file_analyzer/src/analyzer/expr/array.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/expr/array.rs
@@ -274,8 +274,8 @@ impl Analyzer<'_, '_> {
                     let res = self
                         .get_element_from_iterator(span, Cow::Borrowed(iterator_elem), n)
                         .with_context(|| format!("failed to get element type from {}th element", idx))
-                        .convert_err(|err| match &*err {
-                            ErrorKind::TupleIndexError { span, .. } => ErrorKind::TupleTooShort { span: *span }.into(),
+                        .convert_err(|err| match err {
+                            ErrorKind::TupleIndexError { span, .. } => ErrorKind::TupleTooShort { span }.into(),
                             _ => err,
                         })
                         .map(Cow::into_owned);
@@ -350,7 +350,7 @@ impl Analyzer<'_, '_> {
                 None,
                 CallOpts { ..Default::default() },
             )
-            .convert_err(|err| match &*err {
+            .convert_err(|err| match err {
                 ErrorKind::NoCallablePropertyWithName { span, .. }
                 | ErrorKind::NoSuchProperty { span, .. }
                 | ErrorKind::NoSuchPropertyInClass { span, .. } => {
@@ -358,7 +358,7 @@ impl Analyzer<'_, '_> {
                         Type::Union(iterator) => {
                             if iterator.types.iter().all(|ty| ty.is_tuple()) {
                                 return ErrorKind::NoSuchProperty {
-                                    span: *span,
+                                    span,
                                     obj: None,
                                     prop: None,
                                 }
@@ -367,7 +367,7 @@ impl Analyzer<'_, '_> {
                         }
                         _ => {}
                     }
-                    ErrorKind::MustHaveSymbolIteratorThatReturnsIterator { span: *span }.into()
+                    ErrorKind::MustHaveSymbolIteratorThatReturnsIterator { span }.into()
                 }
                 _ => err,
             })
@@ -485,9 +485,9 @@ impl Analyzer<'_, '_> {
         let elem_ty = self
             .get_iterator_element_type(span, ty, true, Default::default())
             .context("tried to get element of iterator as a fallback logic for async iterator")
-            .convert_err(|err| match &*err {
+            .convert_err(|err| match err {
                 ErrorKind::MustHaveSymbolIteratorThatReturnsIterator { span } => {
-                    ErrorKind::MustHaveSymbolAsyncIteratorThatReturnsIterator { span: *span }.into()
+                    ErrorKind::MustHaveSymbolAsyncIteratorThatReturnsIterator { span }.into()
                 }
                 _ => err,
             })?;
@@ -664,9 +664,9 @@ impl Analyzer<'_, '_> {
                         .map(|v| self.get_iterator(span, Cow::Borrowed(v), opts))
                         .map(|res| res.map(Cow::into_owned))
                         .collect::<Result<_, _>>()
-                        .convert_err(|err| match &*err {
+                        .convert_err(|err| match err {
                             ErrorKind::MustHaveSymbolIteratorThatReturnsIterator { span } => {
-                                ErrorKind::MustHaveSymbolIteratorThatReturnsIteratorOrMustBeArray { span: *span }.into()
+                                ErrorKind::MustHaveSymbolIteratorThatReturnsIteratorOrMustBeArray { span }.into()
                             }
                             _ => err,
                         })?;
@@ -719,10 +719,10 @@ impl Analyzer<'_, '_> {
                     ..Default::default()
                 },
             )
-            .convert_err(|err| match &*err {
+            .convert_err(|err| match err {
                 ErrorKind::NoCallablePropertyWithName { span, .. }
                 | ErrorKind::NoSuchPropertyInClass { span, .. }
-                | ErrorKind::NoSuchProperty { span, .. } => ErrorKind::MustHaveSymbolIteratorThatReturnsIterator { span: *span }.into(),
+                | ErrorKind::NoSuchProperty { span, .. } => ErrorKind::MustHaveSymbolIteratorThatReturnsIterator { span }.into(),
                 _ => err,
             })
             .map(Cow::Owned)
@@ -856,8 +856,8 @@ impl Analyzer<'_, '_> {
                 None,
                 Default::default(),
             )
-            .convert_err(|err| match &*err {
-                ErrorKind::NoCallablePropertyWithName { span, .. } => ErrorKind::NoMethodNamedNext { span: *span }.into(),
+            .convert_err(|err| match err {
+                ErrorKind::NoCallablePropertyWithName { span, .. } => ErrorKind::NoMethodNamedNext { span }.into(),
                 _ => err,
             })
             .context("tried calling `next()` to get element type of iterator")?;

--- a/crates/stc_ts_file_analyzer/src/analyzer/expr/array.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/expr/array.rs
@@ -2,7 +2,7 @@ use std::{borrow::Cow, time::Instant};
 
 use itertools::Itertools;
 use stc_ts_ast_rnode::{RArrayLit, RExpr, RExprOrSpread, RInvalid, RNumber, RTsLit};
-use stc_ts_errors::{debug::dump_type_as_string, DebugExt, Error};
+use stc_ts_errors::{debug::dump_type_as_string, DebugExt, ErrorKind};
 use stc_ts_type_ops::Fix;
 use stc_ts_types::{
     type_id::SymbolId, Array, CommonTypeMetadata, ComputedKey, Intersection, Key, KeywordType, KeywordTypeMetadata, LitType, Symbol, Tuple,
@@ -275,7 +275,7 @@ impl Analyzer<'_, '_> {
                         .get_element_from_iterator(span, Cow::Borrowed(iterator_elem), n)
                         .with_context(|| format!("failed to get element type from {}th element", idx))
                         .convert_err(|err| match err {
-                            Error::TupleIndexError { span, .. } => Error::TupleTooShort { span },
+                            ErrorKind::TupleIndexError { span, .. } => ErrorKind::TupleTooShort { span },
                             _ => err,
                         })
                         .map(Cow::into_owned);
@@ -301,7 +301,7 @@ impl Analyzer<'_, '_> {
                         return Ok(Cow::Owned(Type::union(types)));
                     }
 
-                    return Err(Error::NoSuchProperty {
+                    return Err(ErrorKind::NoSuchProperty {
                         span,
                         obj: Some(box iterator.into_owned()),
                         prop: None,
@@ -350,13 +350,13 @@ impl Analyzer<'_, '_> {
                 CallOpts { ..Default::default() },
             )
             .convert_err(|err| match err {
-                Error::NoCallablePropertyWithName { span, .. }
-                | Error::NoSuchProperty { span, .. }
-                | Error::NoSuchPropertyInClass { span, .. } => {
+                ErrorKind::NoCallablePropertyWithName { span, .. }
+                | ErrorKind::NoSuchProperty { span, .. }
+                | ErrorKind::NoSuchPropertyInClass { span, .. } => {
                     match iterator.normalize() {
                         Type::Union(iterator) => {
                             if iterator.types.iter().all(|ty| ty.is_tuple()) {
-                                return Error::NoSuchProperty {
+                                return ErrorKind::NoSuchProperty {
                                     span,
                                     obj: None,
                                     prop: None,
@@ -365,7 +365,7 @@ impl Analyzer<'_, '_> {
                         }
                         _ => {}
                     }
-                    Error::MustHaveSymbolIteratorThatReturnsIterator { span }
+                    ErrorKind::MustHaveSymbolIteratorThatReturnsIterator { span }
                 }
                 _ => err,
             })
@@ -484,7 +484,9 @@ impl Analyzer<'_, '_> {
             .get_iterator_element_type(span, ty, true, Default::default())
             .context("tried to get element of iterator as a fallback logic for async iterator")
             .convert_err(|err| match err {
-                Error::MustHaveSymbolIteratorThatReturnsIterator { span } => Error::MustHaveSymbolAsyncIteratorThatReturnsIterator { span },
+                ErrorKind::MustHaveSymbolIteratorThatReturnsIterator { span } => {
+                    ErrorKind::MustHaveSymbolAsyncIteratorThatReturnsIterator { span }
+                }
                 _ => err,
             })?;
 
@@ -510,7 +512,7 @@ impl Analyzer<'_, '_> {
                 },
             )
             .context("tried to get the type of property named `value` to determine the type of an iterator")
-            .convert_err(|err| Error::NextOfItertorShouldReturnTypeWithPropertyValue { span: err.span() })?;
+            .convert_err(|err| ErrorKind::NextOfItertorShouldReturnTypeWithPropertyValue { span: err.span() })?;
 
         // TODO(kdy1): Remove `done: true` instead of removing `any` from value.
         if matches!(elem_ty.normalize(), Type::Union(..)) {
@@ -597,7 +599,7 @@ impl Analyzer<'_, '_> {
                     Default::default(),
                 ) {
                     if !return_prop_ty.is_fn_type() {
-                        self.storage.report(Error::ReturnPropertyOfIteratorMustBeMethod { span })
+                        self.storage.report(ErrorKind::ReturnPropertyOfIteratorMustBeMethod { span })
                     }
                 }
             }
@@ -622,7 +624,7 @@ impl Analyzer<'_, '_> {
                 if !opts.disallow_str {
                     return Ok(ty);
                 } else {
-                    return Err(Error::NotArrayType { span });
+                    return Err(ErrorKind::NotArrayType { span });
                 }
             }
 
@@ -650,7 +652,7 @@ impl Analyzer<'_, '_> {
                 | Type::Lit(LitType {
                     lit: RTsLit::BigInt(..), ..
                 })
-                | Type::Lit(LitType { lit: RTsLit::Bool(..), .. }) => return Err(Error::NotArrayType { span }),
+                | Type::Lit(LitType { lit: RTsLit::Bool(..), .. }) => return Err(ErrorKind::NotArrayType { span }),
 
                 Type::Array(..) | Type::Tuple(..) => return Ok(ty),
                 Type::Union(u) => {
@@ -661,8 +663,8 @@ impl Analyzer<'_, '_> {
                         .map(|res| res.map(Cow::into_owned))
                         .collect::<Result<_, _>>()
                         .convert_err(|err| match err {
-                            Error::MustHaveSymbolIteratorThatReturnsIterator { span } => {
-                                Error::MustHaveSymbolIteratorThatReturnsIteratorOrMustBeArray { span }
+                            ErrorKind::MustHaveSymbolIteratorThatReturnsIterator { span } => {
+                                ErrorKind::MustHaveSymbolIteratorThatReturnsIteratorOrMustBeArray { span }
                             }
                             _ => err,
                         })?;
@@ -716,9 +718,9 @@ impl Analyzer<'_, '_> {
                 },
             )
             .convert_err(|err| match err {
-                Error::NoCallablePropertyWithName { span, .. }
-                | Error::NoSuchPropertyInClass { span, .. }
-                | Error::NoSuchProperty { span, .. } => Error::MustHaveSymbolIteratorThatReturnsIterator { span },
+                ErrorKind::NoCallablePropertyWithName { span, .. }
+                | ErrorKind::NoSuchPropertyInClass { span, .. }
+                | ErrorKind::NoSuchProperty { span, .. } => ErrorKind::MustHaveSymbolIteratorThatReturnsIterator { span },
                 _ => err,
             })
             .map(Cow::Owned)
@@ -853,7 +855,7 @@ impl Analyzer<'_, '_> {
                 Default::default(),
             )
             .convert_err(|err| match err {
-                Error::NoCallablePropertyWithName { span, .. } => Error::NoMethodNamedNext { span },
+                ErrorKind::NoCallablePropertyWithName { span, .. } => ErrorKind::NoMethodNamedNext { span },
                 _ => err,
             })
             .context("tried calling `next()` to get element type of iterator")?;

--- a/crates/stc_ts_file_analyzer/src/analyzer/expr/bin.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/expr/bin.rs
@@ -306,18 +306,24 @@ impl Analyzer<'_, '_> {
 
                 if !self.is_valid_for_switch_case(span, &lt, &rt)? {
                     if self.ctx.in_switch_case_test {
-                        self.storage.report(ErrorKind::SwitchCaseTestNotCompatible {
-                            span,
-                            disc: box lt.clone(),
-                            test: box rt.clone(),
-                        })
+                        self.storage.report(
+                            ErrorKind::SwitchCaseTestNotCompatible {
+                                span,
+                                disc: box lt.clone(),
+                                test: box rt.clone(),
+                            }
+                            .into(),
+                        )
                     } else {
-                        self.storage.report(ErrorKind::NoOverlap {
-                            span,
-                            value: true,
-                            left: box lt.clone(),
-                            right: box rt.clone(),
-                        })
+                        self.storage.report(
+                            ErrorKind::NoOverlap {
+                                span,
+                                value: true,
+                                left: box lt.clone(),
+                                right: box rt.clone(),
+                            }
+                            .into(),
+                        )
                     }
                 }
 
@@ -387,10 +393,13 @@ impl Analyzer<'_, '_> {
                         // Type guards involving type parameters produce intersection types
                         let mut orig_ty = self.type_of_var(i, TypeOfMode::RValue, None)?;
                         if !self.is_valid_lhs_of_instanceof(span, &orig_ty) {
-                            self.storage.report(ErrorKind::InvalidLhsInInstanceOf {
-                                ty: box lt.clone(),
-                                span: left.span(),
-                            })
+                            self.storage.report(
+                                ErrorKind::InvalidLhsInInstanceOf {
+                                    ty: box lt.clone(),
+                                    span: left.span(),
+                                }
+                                .into(),
+                            )
                         }
                         orig_ty.make_clone_cheap();
 
@@ -616,7 +625,7 @@ impl Analyzer<'_, '_> {
                         || lt.is_interface()
                         || lt.is_tpl()
                     {
-                        self.storage.report(ErrorKind::WrongTypeForLhsOfNumericOperation { span });
+                        self.storage.report(ErrorKind::WrongTypeForLhsOfNumericOperation { span }.into());
                     }
 
                     if !reported_null_or_undefined {
@@ -652,10 +661,13 @@ impl Analyzer<'_, '_> {
 
             op!("instanceof") => {
                 if !self.is_valid_lhs_of_instanceof(span, &lt) {
-                    self.storage.report(ErrorKind::InvalidLhsInInstanceOf {
-                        ty: box lt.clone(),
-                        span: left.span(),
-                    })
+                    self.storage.report(
+                        ErrorKind::InvalidLhsInInstanceOf {
+                            ty: box lt.clone(),
+                            span: left.span(),
+                        }
+                        .into(),
+                    )
                 }
 
                 return Ok(Type::Keyword(KeywordType {

--- a/crates/stc_ts_file_analyzer/src/analyzer/expr/bin.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/expr/bin.rs
@@ -640,7 +640,7 @@ impl Analyzer<'_, '_> {
                         || rt.is_interface()
                         || rt.is_tpl()
                     {
-                        self.storage.report(ErrorKind::WrongTypeForRhsOfNumericOperation { span });
+                        self.storage.report(ErrorKind::WrongTypeForRhsOfNumericOperation { span }.into());
                     }
                 }
 

--- a/crates/stc_ts_file_analyzer/src/analyzer/expr/bin.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/expr/bin.rs
@@ -476,7 +476,7 @@ impl Analyzer<'_, '_> {
                         ..
                     }) => {
                         debug_assert!(!span.is_dummy());
-                        return Err(Error::Unknown { span });
+                        return Err(ErrorKind::Unknown { span }.into());
                     }
                     _ => {}
                 }
@@ -501,7 +501,7 @@ impl Analyzer<'_, '_> {
                     _ => None,
                 }) {
                     debug_assert!(!span.is_dummy());
-                    return Err(ErrorKind::Unknown { span });
+                    return Err(ErrorKind::Unknown { span }.into());
                 }
 
                 if lt.is_num() && rt.is_num() {
@@ -549,7 +549,7 @@ impl Analyzer<'_, '_> {
                 }
 
                 if c.any(|(_, ty)| ty.is_kwd(TsKeywordTypeKind::TsUndefinedKeyword) || ty.is_kwd(TsKeywordTypeKind::TsNullKeyword)) {
-                    return Err(ErrorKind::TS2365 { span });
+                    return Err(ErrorKind::TS2365 { span }.into());
                 }
 
                 // Rule:
@@ -567,7 +567,7 @@ impl Analyzer<'_, '_> {
 
                     _ => false,
                 }) {
-                    return Err(ErrorKind::TS2365 { span });
+                    return Err(ErrorKind::TS2365 { span }.into());
                 }
 
                 if is_str_like_for_addition(&lt) || is_str_like_for_addition(&rt) {
@@ -594,7 +594,8 @@ impl Analyzer<'_, '_> {
                     op,
                     left: box lt,
                     right: box rt,
-                });
+                }
+                .into());
             }
             op!("*") | op!("/") => {
                 no_unknown!();
@@ -1892,7 +1893,7 @@ impl Analyzer<'_, '_> {
                 match operand {
                     RExpr::Bin(bin) => {
                         if bin.op == op!("||") || bin.op == op!("&&") {
-                            return Err(ErrorKind::NullishCoalescingMixedWithLogicalWithoutParen { span });
+                            return Err(ErrorKind::NullishCoalescingMixedWithLogicalWithoutParen { span }.into());
                         }
                     }
                     _ => {}
@@ -1901,7 +1902,7 @@ impl Analyzer<'_, '_> {
                 match operand {
                     RExpr::Bin(bin) => {
                         if bin.op == op!("??") {
-                            return Err(ErrorKind::NullishCoalescingMixedWithLogicalWithoutParen { span });
+                            return Err(ErrorKind::NullishCoalescingMixedWithLogicalWithoutParen { span }.into());
                         }
                     }
                     _ => {}

--- a/crates/stc_ts_file_analyzer/src/analyzer/expr/call_new.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/expr/call_new.rs
@@ -842,17 +842,19 @@ impl Analyzer<'_, '_> {
             let callee_str = dump_type_as_string(&self.cm, &callee);
 
             self.get_best_return_type(span, expr, callee, kind, type_args, args, &arg_types, &spread_arg_types, type_ann)
-                .convert_err(|err| match err {
+                .convert_err(|err| match &*err {
                     ErrorKind::NoCallSignature { span, .. } => ErrorKind::NoCallablePropertyWithName {
                         span,
                         obj: box obj_type.clone(),
                         key: box prop.clone(),
-                    },
+                    }
+                    .into(),
                     ErrorKind::NoNewSignature { span, .. } => ErrorKind::NoConstructablePropertyWithName {
                         span,
                         obj: box obj_type.clone(),
                         key: box prop.clone(),
-                    },
+                    }
+                    .into(),
                     _ => err,
                 })
                 .with_context(|| {

--- a/crates/stc_ts_file_analyzer/src/analyzer/expr/call_new.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/expr/call_new.rs
@@ -100,7 +100,7 @@ impl Analyzer<'_, '_> {
 
                 if type_args.is_some() {
                     // super<T>() is invalid.
-                    self.storage.report(ErrorKind::SuperCannotUseTypeArgs { span })
+                    self.storage.report(ErrorKind::SuperCannotUseTypeArgs { span }.into())
                 }
 
                 self.validate_args(args).report(&mut self.storage);
@@ -1472,16 +1472,18 @@ impl Analyzer<'_, '_> {
                 dbg!();
                 match kind {
                     ExtractKind::Call => {
-                        return Err(Error::NoCallSignature {
+                        return Err(ErrorKind::NoCallSignature {
                             span,
                             callee: box ty.clone(),
-                        })
+                        }
+                        .into())
                     }
                     ExtractKind::New => {
-                        return Err(Error::NoNewSignature {
+                        return Err(ErrorKind::NoNewSignature {
                             span,
                             callee: box ty.clone(),
-                        })
+                        }
+                        .into())
                     }
                 }
             }};
@@ -3326,7 +3328,7 @@ impl Analyzer<'_, '_> {
         })
     }
 
-    fn validate_args(&mut self, args: &[RExprOrSpread]) -> Result<Vec<TypeOrSpread>, ErrorKind> {
+    fn validate_args(&mut self, args: &[RExprOrSpread]) -> VResult<Vec<TypeOrSpread>> {
         let ctx = Ctx {
             in_argument: true,
             should_store_truthy_for_access: false,

--- a/crates/stc_ts_file_analyzer/src/analyzer/expr/call_new.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/expr/call_new.rs
@@ -3001,10 +3001,10 @@ impl Analyzer<'_, '_> {
                             let err = err.convert(|err| {
                                 match err {
                                     ErrorKind::TupleAssignError { span, errors } if !arg.ty.metadata().resolved_from_var => {
-                                        return ErrorKind::Errors { span, errors }.context("tuple")
+                                        return ErrorKind::Errors { span, errors }
                                     }
                                     ErrorKind::ObjectAssignFailed { span, errors } if !arg.ty.metadata().resolved_from_var => {
-                                        return ErrorKind::Errors { span, errors }.context("object")
+                                        return ErrorKind::Errors { span, errors }
                                     }
                                     ErrorKind::Errors { span, ref errors } => {
                                         if errors.iter().all(|err| match err.actual() {
@@ -3015,9 +3015,12 @@ impl Analyzer<'_, '_> {
                                                 span,
                                                 errors: errors
                                                     .iter()
-                                                    .map(|err| ErrorKind::WrongArgType {
-                                                        span: err.span(),
-                                                        inner: box err.clone(),
+                                                    .map(|err| {
+                                                        ErrorKind::WrongArgType {
+                                                            span: err.span(),
+                                                            inner: box err.clone(),
+                                                        }
+                                                        .into()
                                                     })
                                                     .collect(),
                                             };
@@ -3030,7 +3033,6 @@ impl Analyzer<'_, '_> {
                                     span: arg.span(),
                                     inner: box err,
                                 }
-                                .context("tried basical argument assignment")
                             });
 
                             report_err!(err);
@@ -3224,7 +3226,8 @@ impl Analyzer<'_, '_> {
                         max: type_params.len(),
                         min: type_params.len(),
                         actual: type_args.params.len(),
-                    });
+                    }
+                    .into());
                 }
             }
         }

--- a/crates/stc_ts_file_analyzer/src/analyzer/expr/call_new.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/expr/call_new.rs
@@ -2728,7 +2728,7 @@ impl Analyzer<'_, '_> {
 
         macro_rules! report_err {
             ($err:expr) => {{
-                self.storage.report($err);
+                self.storage.report($err.into());
                 if is_generic {
                     return;
                 }

--- a/crates/stc_ts_file_analyzer/src/analyzer/expr/call_new.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/expr/call_new.rs
@@ -311,7 +311,7 @@ impl Analyzer<'_, '_> {
                 sym: js_word!("Symbol"), ..
             }) => {
                 if kind == ExtractKind::New {
-                    self.storage.report(ErrorKind::CannotCallWithNewNonVoidFunction { span })
+                    self.storage.report(ErrorKind::CannotCallWithNewNonVoidFunction { span }.into())
                 }
 
                 // Symbol uses special type
@@ -438,7 +438,7 @@ impl Analyzer<'_, '_> {
                     }) if type_args.is_some() => {
                         // If it's implicit any, we should postpone this check.
                         if !analyzer.is_implicitly_typed(&callee_ty) {
-                            analyzer.storage.report(ErrorKind::AnyTypeUsedAsCalleeWithTypeArgs { span })
+                            analyzer.storage.report(ErrorKind::AnyTypeUsedAsCalleeWithTypeArgs { span }.into())
                         }
                     }
                     _ => {}
@@ -572,7 +572,8 @@ impl Analyzer<'_, '_> {
 
                 Type::This(..) => {
                     if self.ctx.in_computed_prop_name {
-                        self.storage.report(ErrorKind::CannotReferenceThisInComputedPropName { span });
+                        self.storage
+                            .report(ErrorKind::CannotReferenceThisInComputedPropName { span }.into());
                         // Return any to prevent other errors
                         return Ok(Type::any(span, Default::default()));
                     }
@@ -636,12 +637,14 @@ impl Analyzer<'_, '_> {
                                 span,
                                 obj: box obj_type.clone(),
                                 key: box prop.clone(),
-                            });
+                            }
+                            .into());
                         } else {
                             return Err(ErrorKind::NoSuchConstructor {
                                 span,
                                 key: box prop.clone(),
-                            });
+                            }
+                            .into());
                         }
                     }
 
@@ -809,11 +812,13 @@ impl Analyzer<'_, '_> {
                             span,
                             obj: box obj_type.clone(),
                             key: box prop.clone(),
-                        },
+                        }
+                        .into(),
                         ExtractKind::New => ErrorKind::NoSuchConstructor {
                             span,
                             key: box prop.clone(),
-                        },
+                        }
+                        .into(),
                     });
                 }
                 _ => {}

--- a/crates/stc_ts_file_analyzer/src/analyzer/expr/const_assertion.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/expr/const_assertion.rs
@@ -1,5 +1,5 @@
 use stc_ts_ast_rnode::RTsConstAssertion;
-use stc_ts_errors::{DebugExt, Error};
+use stc_ts_errors::{DebugExt, ErrorKind};
 use stc_ts_file_analyzer_macros::validator;
 use stc_ts_type_ops::{generalization::prevent_generalize, tuple_to_array::prevent_tuple_to_array};
 use stc_ts_types::{Type, TypeParamInstantiation};
@@ -38,7 +38,7 @@ impl Analyzer<'_, '_> {
 
             Ok(ty)
         } else {
-            return Err(Error::Unimplemented {
+            return Err(ErrorKind::Unimplemented {
                 span,
                 msg: format!("Proper error reporting for using const assertion expression in left hand side of an assignment expression"),
             });

--- a/crates/stc_ts_file_analyzer/src/analyzer/expr/const_assertion.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/expr/const_assertion.rs
@@ -41,7 +41,8 @@ impl Analyzer<'_, '_> {
             return Err(ErrorKind::Unimplemented {
                 span,
                 msg: format!("Proper error reporting for using const assertion expression in left hand side of an assignment expression"),
-            });
+            }
+            .into());
         }
     }
 }

--- a/crates/stc_ts_file_analyzer/src/analyzer/expr/meta_prop.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/expr/meta_prop.rs
@@ -13,7 +13,7 @@ impl Analyzer<'_, '_> {
         match e.kind {
             MetaPropKind::NewTarget => {
                 if !self.ctx.allow_new_target {
-                    self.storage.report(ErrorKind::InvalidUsageOfNewTarget { span: e.span() })
+                    self.storage.report(ErrorKind::InvalidUsageOfNewTarget { span: e.span() }.into())
                 }
 
                 return Ok(Type::any(e.span, Default::default()));

--- a/crates/stc_ts_file_analyzer/src/analyzer/expr/meta_prop.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/expr/meta_prop.rs
@@ -1,5 +1,5 @@
 use stc_ts_ast_rnode::RMetaPropExpr;
-use stc_ts_errors::Error;
+use stc_ts_errors::ErrorKind;
 use stc_ts_file_analyzer_macros::validator;
 use stc_ts_types::Type;
 use swc_common::Spanned;
@@ -13,7 +13,7 @@ impl Analyzer<'_, '_> {
         match e.kind {
             MetaPropKind::NewTarget => {
                 if !self.ctx.allow_new_target {
-                    self.storage.report(Error::InvalidUsageOfNewTarget { span: e.span() })
+                    self.storage.report(ErrorKind::InvalidUsageOfNewTarget { span: e.span() })
                 }
 
                 return Ok(Type::any(e.span, Default::default()));

--- a/crates/stc_ts_file_analyzer/src/analyzer/expr/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/expr/mod.rs
@@ -615,10 +615,12 @@ impl Analyzer<'_, '_> {
                 let mut a = self.with_ctx(ctx);
                 match e.validate_with_default(&mut *a) {
                     Ok(..) => {}
-                    Err(ErrorKind::ReferencedInInit { .. }) => {
-                        is_any = true;
-                    }
-                    Err(err) => a.storage.report(err),
+                    Err(err) => match *err {
+                        ErrorKind::ReferencedInInit { .. } => {
+                            is_any = true;
+                        }
+                        _ => a.storage.report(err),
+                    },
                 }
             }
         }

--- a/crates/stc_ts_file_analyzer/src/analyzer/expr/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/expr/mod.rs
@@ -3437,17 +3437,17 @@ impl Analyzer<'_, '_> {
                     }
                 }
 
-                self.storage.report(ErrorKind::BlockScopedVarUsedBeforeInit { span })
+                self.storage.report(ErrorKind::BlockScopedVarUsedBeforeInit { span }.into())
             })();
 
             if self.ctx.allow_ref_declaring {
                 if self.rule().no_implicit_any {
-                    self.storage.report(ErrorKind::ImplicitAnyBecauseOfSelfRef { span });
+                    self.storage.report(ErrorKind::ImplicitAnyBecauseOfSelfRef { span }.into());
                 }
 
                 return Ok(Type::any(span, Default::default()));
             } else {
-                return Err(ErrorKind::ReferencedInInit { span });
+                return Err(ErrorKind::ReferencedInInit { span }.into());
             }
         }
 
@@ -3496,7 +3496,8 @@ impl Analyzer<'_, '_> {
             Err(ErrorKind::TypeUsedAsVar {
                 span,
                 name: i.clone().into(),
-            })
+            }
+            .into())
         } else {
             if let Some(scope) = self.scope.first_kind(|kind| match kind {
                 ScopeKind::Class | ScopeKind::ObjectLit => true,
@@ -3508,7 +3509,8 @@ impl Analyzer<'_, '_> {
                             return Err(ErrorKind::NoSuchVar {
                                 span,
                                 name: i.clone().into(),
-                            });
+                            }
+                            .into());
                         }
                     }
                 }
@@ -3536,18 +3538,21 @@ impl Analyzer<'_, '_> {
                 Err(ErrorKind::NoSuchVarButThisHasSuchProperty {
                     span,
                     name: i.clone().into(),
-                })
+                }
+                .into())
             } else {
                 if self.ctx.in_shorthand {
                     Err(ErrorKind::NoSuchVarForShorthand {
                         span,
                         name: i.clone().into(),
-                    })
+                    }
+                    .into())
                 } else {
                     Err(ErrorKind::NoSuchVar {
                         span,
                         name: i.clone().into(),
-                    })
+                    }
+                    .into())
                 }
             }
         }
@@ -3638,7 +3643,9 @@ impl Analyzer<'_, '_> {
                                         }) => {
                                             params = self.instantiate_type_params_using_args(span, type_params, type_args).map(Some)?;
                                         }
-                                        _ => self.storage.report(ErrorKind::TypeParamsProvidedButCalleeIsNotGeneric { span }),
+                                        _ => self
+                                            .storage
+                                            .report(ErrorKind::TypeParamsProvidedButCalleeIsNotGeneric { span }.into()),
                                     }
                                 }
                                 if let Some(params) = params {
@@ -3909,7 +3916,7 @@ impl Analyzer<'_, '_> {
         let mut obj_ty = match *obj {
             RSuper { span, .. } => {
                 if self.scope.cannot_use_this_because_super_not_called() {
-                    self.storage.report(ErrorKind::SuperUsedBeforeCallingSuper { span })
+                    self.storage.report(ErrorKind::SuperUsedBeforeCallingSuper { span }.into())
                 }
 
                 self.report_error_for_super_reference_in_compute_keys(span, false);
@@ -3917,7 +3924,7 @@ impl Analyzer<'_, '_> {
                 if let Some(v) = self.scope.get_super_class() {
                     v.clone()
                 } else {
-                    self.storage.report(ErrorKind::SuperInClassWithoutSuper { span });
+                    self.storage.report(ErrorKind::SuperInClassWithoutSuper { span }.into());
                     Type::any(span, Default::default())
                 }
             }
@@ -4051,7 +4058,8 @@ impl Analyzer<'_, '_> {
         {
             Some(ScopeKind::Class) => {
                 // Using proerties of super class in class property names are not allowed.
-                self.storage.report(ErrorKind::CannotReferenceSuperInComputedPropName { span })
+                self.storage
+                    .report(ErrorKind::CannotReferenceSuperInComputedPropName { span }.into())
             }
 
             Some(ScopeKind::ArrowFn) => {
@@ -4059,7 +4067,8 @@ impl Analyzer<'_, '_> {
                     return;
                 }
 
-                self.storage.report(ErrorKind::CannotReferenceSuperInComputedPropName { span })
+                self.storage
+                    .report(ErrorKind::CannotReferenceSuperInComputedPropName { span }.into())
             }
 
             kind => {

--- a/crates/stc_ts_file_analyzer/src/analyzer/expr/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/expr/mod.rs
@@ -3086,17 +3086,18 @@ impl Analyzer<'_, '_> {
         let mut ty = self.type_of_raw_var(i, type_mode)?;
         if type_mode == TypeOfMode::LValue && (ty.is_class_def() || ty.is_enum_type()) {
             if ty.is_enum_type() {
-                return Err(ErrorKind::CannotAssignToEnum { span });
+                return Err(ErrorKind::CannotAssignToEnum { span }.into());
             }
             if ty.is_class_def() {
-                return Err(ErrorKind::CannotAssignToClass { span });
+                return Err(ErrorKind::CannotAssignToClass { span }.into());
             }
 
             return Err(ErrorKind::NotVariable {
                 span,
                 left: span,
                 ty: Some(box ty.clone()),
-            });
+            }
+            .into());
         }
         ty.assert_valid();
         if let Some(type_args) = type_args {
@@ -3134,7 +3135,8 @@ impl Analyzer<'_, '_> {
                                 span,
                                 left: span,
                                 ty: Some(box ty.normalize().clone()),
-                            })
+                            }
+                            .into())
                         }
                         _ => {}
                     }

--- a/crates/stc_ts_file_analyzer/src/analyzer/expr/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/expr/mod.rs
@@ -417,7 +417,7 @@ impl Analyzer<'_, '_> {
                         })
                         .convert_err(|err| {
                             skip_right = true;
-                            match err {
+                            match &err {
                                 ErrorKind::CannotAssignToNonVariable { ty, .. } | ErrorKind::NotVariable { ty: Some(ty), .. } => {
                                     match ty.normalize() {
                                         Type::Module(..) => ErrorKind::CannotAssignToNamespace { span }.into(),

--- a/crates/stc_ts_file_analyzer/src/analyzer/expr/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/expr/mod.rs
@@ -13,7 +13,7 @@ use stc_ts_ast_rnode::{
     RTsEnumMemberId, RTsLit, RTsNonNullExpr, RUnaryExpr,
 };
 use stc_ts_base_type_ops::bindings::BindingKind;
-use stc_ts_errors::{debug::dump_type_as_string, DebugExt, Error, Errors};
+use stc_ts_errors::{debug::dump_type_as_string, DebugExt, ErrorKind, Errors};
 use stc_ts_generics::ExpandGenericOpts;
 use stc_ts_type_ops::{generalization::prevent_generalize, is_str_lit_or_union, Fix};
 pub use stc_ts_types::IdCtx;
@@ -132,13 +132,13 @@ impl Analyzer<'_, '_> {
                     let span = *span;
 
                     if self.ctx.in_static_property_initializer {
-                        self.storage.report(Error::ThisInStaticPropertyInitializer { span })
+                        self.storage.report(ErrorKind::ThisInStaticPropertyInitializer { span })
                     } else if self.ctx.in_constructor_param {
-                        self.storage.report(Error::ThisInConstructorParam { span })
+                        self.storage.report(ErrorKind::ThisInConstructorParam { span })
                     }
 
                     if self.scope.cannot_use_this_because_super_not_called() {
-                        self.storage.report(Error::ThisUsedBeforeCallingSuper { span })
+                        self.storage.report(ErrorKind::ThisUsedBeforeCallingSuper { span })
                     }
 
                     let is_ref_to_module = match self.scope.kind() {
@@ -150,7 +150,7 @@ impl Analyzer<'_, '_> {
                             _ => false,
                         });
                     if is_ref_to_module {
-                        self.storage.report(Error::ThisRefToModuleOrNamespace { span })
+                        self.storage.report(ErrorKind::ThisRefToModuleOrNamespace { span })
                     }
 
                     // Use globalThis
@@ -418,21 +418,21 @@ impl Analyzer<'_, '_> {
                         .convert_err(|err| {
                             skip_right = true;
                             match err.actual() {
-                                Error::CannotAssignToNonVariable { ty, .. } | Error::NotVariable { ty: Some(ty), .. } => {
+                                ErrorKind::CannotAssignToNonVariable { ty, .. } | ErrorKind::NotVariable { ty: Some(ty), .. } => {
                                     match ty.normalize() {
-                                        Type::Module(..) => Error::CannotAssignToNamespace { span },
-                                        Type::Namespace(..) => Error::CannotAssignToModule { span },
-                                        Type::ClassDef(..) => Error::CannotAssignToClass { span },
-                                        Type::Enum(..) => Error::CannotAssignToEnum { span },
-                                        Type::Function(..) => Error::CannotAssignToFunction { span },
+                                        Type::Module(..) => ErrorKind::CannotAssignToNamespace { span },
+                                        Type::Namespace(..) => ErrorKind::CannotAssignToModule { span },
+                                        Type::ClassDef(..) => ErrorKind::CannotAssignToClass { span },
+                                        Type::Enum(..) => ErrorKind::CannotAssignToEnum { span },
+                                        Type::Function(..) => ErrorKind::CannotAssignToFunction { span },
                                         _ => err,
                                     }
                                 }
-                                Error::CannotAssignToNamespace { .. }
-                                | Error::CannotAssignToModule { .. }
-                                | Error::CannotAssignToClass { .. }
-                                | Error::CannotAssignToEnum { .. }
-                                | Error::CannotAssignToFunction { .. } => err,
+                                ErrorKind::CannotAssignToNamespace { .. }
+                                | ErrorKind::CannotAssignToModule { .. }
+                                | ErrorKind::CannotAssignToClass { .. }
+                                | ErrorKind::CannotAssignToEnum { .. }
+                                | ErrorKind::CannotAssignToFunction { .. } => err,
                                 _ => {
                                     skip_right = false;
                                     err
@@ -581,7 +581,7 @@ impl Analyzer<'_, '_> {
             if !is_last {
                 match **e {
                     RExpr::Arrow(..) if !self.rule().allow_unreachable_code => {
-                        self.storage.report(Error::UselessSeqExpr { span });
+                        self.storage.report(ErrorKind::UselessSeqExpr { span });
                     }
                     RExpr::Ident(..)
                     | RExpr::Cond(..)
@@ -592,7 +592,7 @@ impl Analyzer<'_, '_> {
                     | RExpr::Unary(RUnaryExpr { op: op!("typeof"), .. })
                         if !self.rule().allow_unreachable_code =>
                     {
-                        self.storage.report(Error::UselessSeqExpr { span });
+                        self.storage.report(ErrorKind::UselessSeqExpr { span });
                     }
 
                     _ => {}
@@ -615,7 +615,7 @@ impl Analyzer<'_, '_> {
                 let mut a = self.with_ctx(ctx);
                 match e.validate_with_default(&mut *a) {
                     Ok(..) => {}
-                    Err(Error::ReferencedInInit { .. }) => {
+                    Err(ErrorKind::ReferencedInInit { .. }) => {
                         is_any = true;
                     }
                     Err(err) => a.storage.report(err),
@@ -849,7 +849,7 @@ impl Analyzer<'_, '_> {
                     match el {
                         TypeElement::Property(ref p) => {
                             if type_mode == TypeOfMode::LValue && p.readonly {
-                                return Err(Error::ReadOnly { span });
+                                return Err(ErrorKind::ReadOnly { span });
                             }
 
                             if let Some(ref type_ann) = p.type_ann {
@@ -1234,7 +1234,7 @@ impl Analyzer<'_, '_> {
                 let key_ty = self.normalize(Some(span), key_ty, Default::default())?;
 
                 if key_ty.is_fn_type() || key_ty.is_constructor() {
-                    Err(Error::CannotUseTypeAsIndexIndex { span })?
+                    Err(ErrorKind::CannotUseTypeAsIndexIndex { span })?
                 }
             };
 
@@ -1243,7 +1243,7 @@ impl Analyzer<'_, '_> {
 
         if self.ctx.in_opt_chain {
             if let Key::Private(p) = prop {
-                return Err(Error::OptionalChainCannotContainPrivateIdentifier { span: p.span });
+                return Err(ErrorKind::OptionalChainCannotContainPrivateIdentifier { span: p.span });
             }
         }
 
@@ -1277,7 +1277,7 @@ impl Analyzer<'_, '_> {
                             }
 
                             return res.convert_err(|err| match err.actual() {
-                                Error::NoSuchVar { span, name } => Error::NoSuchProperty {
+                                ErrorKind::NoSuchVar { span, name } => ErrorKind::NoSuchProperty {
                                     span: *span,
                                     obj: Some(box obj.clone()),
                                     prop: Some(box Key::Normal {
@@ -1294,7 +1294,7 @@ impl Analyzer<'_, '_> {
                                 .get_global_type(span, &sym)
                                 .context("tried to access a prperty of `globalThis`")
                                 .convert_err(|err| match err.actual() {
-                                    Error::NoSuchType { span, name } => Error::NoSuchProperty {
+                                    ErrorKind::NoSuchType { span, name } => ErrorKind::NoSuchProperty {
                                         span: *span,
                                         obj: Some(box obj.clone()),
                                         prop: Some(box Key::Normal {
@@ -1471,7 +1471,7 @@ impl Analyzer<'_, '_> {
                             }
                         }
 
-                        return Err(Error::NoSuchPropertyInClass {
+                        return Err(ErrorKind::NoSuchPropertyInClass {
                             span,
                             class_name: self.scope.get_this_class_name(),
                             prop: prop.clone(),
@@ -1552,7 +1552,7 @@ impl Analyzer<'_, '_> {
 
                     dbg!();
 
-                    return Err(Error::NoSuchProperty {
+                    return Err(ErrorKind::NoSuchProperty {
                         span: *span,
                         obj: Some(box obj.clone()),
                         prop: Some(box prop.clone()),
@@ -1669,7 +1669,7 @@ impl Analyzer<'_, '_> {
             }
 
             Type::Symbol(..) => {
-                return Err(Error::NoSuchProperty {
+                return Err(ErrorKind::NoSuchProperty {
                     span,
                     obj: Some(box obj.clone()),
                     prop: Some(box prop.clone()),
@@ -1686,7 +1686,7 @@ impl Analyzer<'_, '_> {
                             RTsEnumMemberId::Str(s) => s.value == *sym,
                         });
                         if !has_such_member {
-                            return Err(Error::NoSuchEnumVariant { span, name: sym.clone() });
+                            return Err(ErrorKind::NoSuchEnumVariant { span, name: sym.clone() });
                         }
 
                         // Computed values are not permitted in an enum with string valued members.
@@ -1718,7 +1718,7 @@ impl Analyzer<'_, '_> {
                         }
 
                         if type_mode == TypeOfMode::LValue {
-                            return Err(Error::EnumCannotBeLValue { span: prop.span() });
+                            return Err(ErrorKind::EnumCannotBeLValue { span: prop.span() });
                         }
 
                         return Ok(Type::EnumVariant(EnumVariant {
@@ -1760,7 +1760,7 @@ impl Analyzer<'_, '_> {
 
                     _ => {
                         if e.is_const {
-                            return Err(Error::ConstEnumNonIndexAccess { span: prop.span() });
+                            return Err(ErrorKind::ConstEnumNonIndexAccess { span: prop.span() });
                         }
 
                         // TODO(kdy1): Validate type of enum
@@ -1825,13 +1825,13 @@ impl Analyzer<'_, '_> {
                     match v {
                         ClassMember::Property(ref class_prop @ ClassProperty { is_static: false, .. }) => {
                             if class_prop.key.is_private() {
-                                self.storage.report(Error::CannotAccessPrivatePropertyFromOutside { span });
+                                self.storage.report(ErrorKind::CannotAccessPrivatePropertyFromOutside { span });
                                 return Ok(Type::any(span, Default::default()));
                             }
 
                             if let Some(declaring) = self.scope.declaring_prop.as_ref() {
                                 if class_prop.key == *declaring.sym() {
-                                    return Err(Error::ReferencedInInit { span });
+                                    return Err(ErrorKind::ReferencedInInit { span });
                                 }
                             }
 
@@ -1845,13 +1845,13 @@ impl Analyzer<'_, '_> {
                         }
                         ClassMember::Method(ref mtd @ Method { is_static: false, .. }) => {
                             if mtd.key.is_private() {
-                                self.storage.report(Error::CannotAccessPrivatePropertyFromOutside { span });
+                                self.storage.report(ErrorKind::CannotAccessPrivatePropertyFromOutside { span });
                                 return Ok(Type::any(span, Default::default()));
                             }
 
                             if self.key_matches(span, &mtd.key, prop, false) {
                                 if mtd.is_abstract {
-                                    self.storage.report(Error::CannotAccessAbstractMember { span });
+                                    self.storage.report(ErrorKind::CannotAccessAbstractMember { span });
                                     return Ok(Type::any(span, Default::default()));
                                 }
 
@@ -1937,7 +1937,7 @@ impl Analyzer<'_, '_> {
                     return Ok(Type::any(span, Default::default()));
                 }
 
-                return Err(Error::NoSuchPropertyInClass {
+                return Err(ErrorKind::NoSuchPropertyInClass {
                     span,
                     class_name: c.def.name.clone(),
                     prop: prop.clone(),
@@ -2063,7 +2063,7 @@ impl Analyzer<'_, '_> {
                 ..
             }) => {
                 debug_assert!(!span.is_dummy());
-                return Err(Error::Unknown { span });
+                return Err(ErrorKind::Unknown { span });
             }
 
             Type::Keyword(KeywordType { kind, .. }) if !self.is_builtin => {
@@ -2077,7 +2077,7 @@ impl Analyzer<'_, '_> {
                             }),
                         ) => {
                             if self.rule().no_implicit_any && !self.rule().suppress_implicit_any_index_errors {
-                                self.storage.report(Error::ImplicitAnyBecauseIndexTypeIsWrong { span });
+                                self.storage.report(ErrorKind::ImplicitAnyBecauseIndexTypeIsWrong { span });
                             }
 
                             return Ok(Type::any(span, Default::default()));
@@ -2094,7 +2094,7 @@ impl Analyzer<'_, '_> {
                     TsKeywordTypeKind::TsObjectKeyword => js_word!("Object"),
                     TsKeywordTypeKind::TsSymbolKeyword => js_word!("Symbol"),
                     _ => {
-                        return Err(Error::NoSuchProperty {
+                        return Err(ErrorKind::NoSuchProperty {
                             span: prop.span(),
                             obj: Some(box obj),
                             prop: Some(box prop.clone()),
@@ -2241,7 +2241,7 @@ impl Analyzer<'_, '_> {
                     return Ok(Type::any(span, Default::default()));
                 }
 
-                return Err(Error::NoSuchProperty {
+                return Err(ErrorKind::NoSuchProperty {
                     span,
                     obj: Some(box obj),
                     prop: Some(box prop.clone()),
@@ -2298,7 +2298,7 @@ impl Analyzer<'_, '_> {
                     }));
                 }
 
-                return Err(Error::NoSuchProperty {
+                return Err(ErrorKind::NoSuchProperty {
                     span,
                     obj: Some(box obj),
                     prop: Some(box prop.clone()),
@@ -2317,15 +2317,15 @@ impl Analyzer<'_, '_> {
                 // tsc is crazy. It uses different error code for these errors.
                 if !self.ctx.in_opt_chain && self.rule().strict_null_checks {
                     if has_null && has_undefined {
-                        return Err(Error::ObjectIsPossiblyNullOrUndefined { span });
+                        return Err(ErrorKind::ObjectIsPossiblyNullOrUndefined { span });
                     }
 
                     if has_null {
-                        return Err(Error::ObjectIsPossiblyNull { span });
+                        return Err(ErrorKind::ObjectIsPossiblyNull { span });
                     }
 
                     if has_undefined {
-                        return Err(Error::ObjectIsPossiblyUndefined { span });
+                        return Err(ErrorKind::ObjectIsPossiblyUndefined { span });
                     }
                 }
 
@@ -2359,7 +2359,7 @@ impl Analyzer<'_, '_> {
                 if type_mode == TypeOfMode::LValue {
                     if !errors.is_empty() {
                         assert_ne!(errors.len(), 0);
-                        return Err(Error::UnionError { span, errors });
+                        return Err(ErrorKind::UnionError { span, errors });
                     }
                 } else {
                     if !errors.is_empty() {
@@ -2375,7 +2375,7 @@ impl Analyzer<'_, '_> {
                             return Ok(ty);
                         }
 
-                        return Err(Error::NoSuchProperty {
+                        return Err(ErrorKind::NoSuchProperty {
                             span,
                             obj: Some(box obj),
                             prop: Some(box prop.clone()),
@@ -2397,7 +2397,7 @@ impl Analyzer<'_, '_> {
                         let v = n.value.round() as i64;
 
                         if v < 0 {
-                            return Err(Error::NegativeTupleIndex {
+                            return Err(ErrorKind::NegativeTupleIndex {
                                 span: n.span(),
                                 index: v,
                                 len: elems.len() as u64,
@@ -2445,7 +2445,7 @@ impl Analyzer<'_, '_> {
 
                             if let TypeOfMode::LValue = type_mode {
                                 self.storage.report(
-                                    Error::TupleIndexError {
+                                    ErrorKind::TupleIndexError {
                                         span: n.span(),
                                         index: v,
                                         len: elems.len() as u64,
@@ -2459,7 +2459,7 @@ impl Analyzer<'_, '_> {
                                 }));
                             }
 
-                            return Err(Error::TupleIndexError {
+                            return Err(ErrorKind::TupleIndexError {
                                 span: n.span(),
                                 index: v,
                                 len: elems.len() as u64,
@@ -2572,7 +2572,7 @@ impl Analyzer<'_, '_> {
                     return Ok(ty);
                 }
 
-                return Err(Error::NoSuchPropertyInClass {
+                return Err(ErrorKind::NoSuchPropertyInClass {
                     span,
                     class_name: cls.name.clone(),
                     prop: prop.clone(),
@@ -2615,7 +2615,7 @@ impl Analyzer<'_, '_> {
                 }
 
                 // No property found
-                return Err(Error::NoSuchPropertyInModule {
+                return Err(ErrorKind::NoSuchPropertyInModule {
                     span,
                     name: box name.clone(),
                 });
@@ -2625,7 +2625,7 @@ impl Analyzer<'_, '_> {
                 // TODO(kdy1): Use parent scope in computed property names.
                 if let Some(this) = self.scope.this().map(|this| this.into_owned()) {
                     if self.ctx.in_computed_prop_name {
-                        self.storage.report(Error::CannotReferenceThisInComputedPropName { span });
+                        self.storage.report(ErrorKind::CannotReferenceThisInComputedPropName { span });
                         // Return any to prevent other errors
                         return Ok(Type::any(span, Default::default()));
                     }
@@ -2943,7 +2943,7 @@ impl Analyzer<'_, '_> {
 
             Type::Optional(OptionalType { ty, .. }) => {
                 if self.rule().strict_null_checks {
-                    return Err(Error::ObjectIsPossiblyUndefined { span });
+                    return Err(ErrorKind::ObjectIsPossiblyUndefined { span });
                 }
 
                 return self.access_property(span, &ty, prop, type_mode, id_ctx, opts);
@@ -3086,13 +3086,13 @@ impl Analyzer<'_, '_> {
         let mut ty = self.type_of_raw_var(i, type_mode)?;
         if type_mode == TypeOfMode::LValue && (ty.is_class_def() || ty.is_enum_type()) {
             if ty.is_enum_type() {
-                return Err(Error::CannotAssignToEnum { span });
+                return Err(ErrorKind::CannotAssignToEnum { span });
             }
             if ty.is_class_def() {
-                return Err(Error::CannotAssignToClass { span });
+                return Err(ErrorKind::CannotAssignToClass { span });
             }
 
-            return Err(Error::NotVariable {
+            return Err(ErrorKind::NotVariable {
                 span,
                 left: span,
                 ty: Some(box ty.clone()),
@@ -3130,7 +3130,7 @@ impl Analyzer<'_, '_> {
                 for ty in types {
                     match ty.normalize() {
                         Type::Module(..) => {
-                            return Err(Error::NotVariable {
+                            return Err(ErrorKind::NotVariable {
                                 span,
                                 left: span,
                                 ty: Some(box ty.normalize().clone()),
@@ -3274,12 +3274,12 @@ impl Analyzer<'_, '_> {
                     let is_argument_defined_in_current_scope = self.scope.vars.contains_key(&i.clone().into());
 
                     if !self.scope.is_arguments_implicitly_defined() {
-                        self.storage.report(Error::InvalidUseOfArgumentsInEs3OrEs5 { span })
+                        self.storage.report(ErrorKind::InvalidUseOfArgumentsInEs3OrEs5 { span })
                     } else if arguments_point_to_arrow && !is_argument_defined_in_current_scope {
-                        self.storage.report(Error::InvalidUseOfArgumentsInEs3OrEs5 { span });
+                        self.storage.report(ErrorKind::InvalidUseOfArgumentsInEs3OrEs5 { span });
                         return Ok(Type::any(span, Default::default()));
                     } else if arguments_points_async_fn && !is_argument_defined_in_current_scope {
-                        self.storage.report(Error::ArgumentsCannotBeUsedInAsyncFnInEs3OrEs5 { span });
+                        self.storage.report(ErrorKind::ArgumentsCannotBeUsedInAsyncFnInEs3OrEs5 { span });
                         return Ok(Type::any(span, Default::default()));
                     }
                 }
@@ -3290,7 +3290,7 @@ impl Analyzer<'_, '_> {
         match i.sym {
             js_word!("undefined") => {
                 match type_mode {
-                    TypeOfMode::LValue => self.storage.report(Error::NotVariable {
+                    TypeOfMode::LValue => self.storage.report(ErrorKind::NotVariable {
                         span,
                         left: span,
                         ty: None,
@@ -3301,7 +3301,7 @@ impl Analyzer<'_, '_> {
             }
             js_word!("void") => return Ok(Type::any(span, Default::default())),
             js_word!("eval") => match type_mode {
-                TypeOfMode::LValue => return Err(Error::CannotAssignToFunction { span }),
+                TypeOfMode::LValue => return Err(ErrorKind::CannotAssignToFunction { span }),
                 _ => {}
             },
             _ => {}
@@ -3319,7 +3319,7 @@ impl Analyzer<'_, '_> {
         if let Some(v) = self.scope.vars.get(&i.into()) {
             if let VarKind::Fn = v.kind {
                 if let TypeOfMode::LValue = type_mode {
-                    return Err(Error::CannotAssignToFunction { span });
+                    return Err(ErrorKind::CannotAssignToFunction { span });
                 }
             }
 
@@ -3375,7 +3375,7 @@ impl Analyzer<'_, '_> {
         if !self.is_builtin {
             if let Ok(ty) = self.env.get_global_var(span, &i.sym) {
                 if self.ctx.report_error_for_non_local_vars {
-                    self.storage.report(Error::CannotExportNonLocalVar { span: i.span });
+                    self.storage.report(ErrorKind::CannotExportNonLocalVar { span: i.span });
                 }
 
                 return Ok(ty);
@@ -3416,17 +3416,17 @@ impl Analyzer<'_, '_> {
                     }
                 }
 
-                self.storage.report(Error::BlockScopedVarUsedBeforeInit { span })
+                self.storage.report(ErrorKind::BlockScopedVarUsedBeforeInit { span })
             })();
 
             if self.ctx.allow_ref_declaring {
                 if self.rule().no_implicit_any {
-                    self.storage.report(Error::ImplicitAnyBecauseOfSelfRef { span });
+                    self.storage.report(ErrorKind::ImplicitAnyBecauseOfSelfRef { span });
                 }
 
                 return Ok(Type::any(span, Default::default()));
             } else {
-                return Err(Error::ReferencedInInit { span });
+                return Err(ErrorKind::ReferencedInInit { span });
             }
         }
 
@@ -3449,11 +3449,11 @@ impl Analyzer<'_, '_> {
                         });
 
                     if !self.scope.is_arguments_implicitly_defined() || arguments_point_to_arrow {
-                        self.storage.report(Error::InvalidUseOfArgumentsInEs3OrEs5 { span })
+                        self.storage.report(ErrorKind::InvalidUseOfArgumentsInEs3OrEs5 { span })
                     }
                 } else {
                     if !self.scope.is_arguments_implicitly_defined() {
-                        self.storage.report(Error::NoSuchVar { span, name: i.into() })
+                        self.storage.report(ErrorKind::NoSuchVar { span, name: i.into() })
                     }
                 }
 
@@ -3472,7 +3472,7 @@ impl Analyzer<'_, '_> {
                     _ => {}
                 }
             }
-            Err(Error::TypeUsedAsVar {
+            Err(ErrorKind::TypeUsedAsVar {
                 span,
                 name: i.clone().into(),
             })
@@ -3484,7 +3484,7 @@ impl Analyzer<'_, '_> {
                 if let ScopeKind::ObjectLit = scope.kind() {
                     if let Some(declaring_prop) = self.scope.declaring_prop() {
                         if *declaring_prop.sym() == i.sym {
-                            return Err(Error::NoSuchVar {
+                            return Err(ErrorKind::NoSuchVar {
                                 span,
                                 name: i.clone().into(),
                             });
@@ -3512,18 +3512,18 @@ impl Analyzer<'_, '_> {
             }
 
             if !self.ctx.disallow_suggesting_property_on_no_var && self.this_has_property_named(&i.clone().into()) {
-                Err(Error::NoSuchVarButThisHasSuchProperty {
+                Err(ErrorKind::NoSuchVarButThisHasSuchProperty {
                     span,
                     name: i.clone().into(),
                 })
             } else {
                 if self.ctx.in_shorthand {
-                    Err(Error::NoSuchVarForShorthand {
+                    Err(ErrorKind::NoSuchVarForShorthand {
                         span,
                         name: i.clone().into(),
                     })
                 } else {
-                    Err(Error::NoSuchVar {
+                    Err(ErrorKind::NoSuchVar {
                         span,
                         name: i.clone().into(),
                     })
@@ -3617,7 +3617,7 @@ impl Analyzer<'_, '_> {
                                         }) => {
                                             params = self.instantiate_type_params_using_args(span, type_params, type_args).map(Some)?;
                                         }
-                                        _ => self.storage.report(Error::TypeParamsProvidedButCalleeIsNotGeneric { span }),
+                                        _ => self.storage.report(ErrorKind::TypeParamsProvidedButCalleeIsNotGeneric { span }),
                                     }
                                 }
                                 if let Some(params) = params {
@@ -3888,7 +3888,7 @@ impl Analyzer<'_, '_> {
         let mut obj_ty = match *obj {
             RSuper { span, .. } => {
                 if self.scope.cannot_use_this_because_super_not_called() {
-                    self.storage.report(Error::SuperUsedBeforeCallingSuper { span })
+                    self.storage.report(ErrorKind::SuperUsedBeforeCallingSuper { span })
                 }
 
                 self.report_error_for_super_reference_in_compute_keys(span, false);
@@ -3896,7 +3896,7 @@ impl Analyzer<'_, '_> {
                 if let Some(v) = self.scope.get_super_class() {
                     v.clone()
                 } else {
-                    self.storage.report(Error::SuperInClassWithoutSuper { span });
+                    self.storage.report(ErrorKind::SuperInClassWithoutSuper { span });
                     Type::any(span, Default::default())
                 }
             }
@@ -3998,7 +3998,7 @@ impl Analyzer<'_, '_> {
     pub(crate) fn report_error_for_super_refs_without_supers(&mut self, span: Span, is_super_call: bool) {
         let res: VResult<_> = try {
             if !self.ctx.in_class_with_super && self.ctx.super_references_super_class {
-                Err(Error::SuperInClassWithoutSuper { span })?
+                Err(ErrorKind::SuperInClassWithoutSuper { span })?
             }
         };
 
@@ -4030,7 +4030,7 @@ impl Analyzer<'_, '_> {
         {
             Some(ScopeKind::Class) => {
                 // Using proerties of super class in class property names are not allowed.
-                self.storage.report(Error::CannotReferenceSuperInComputedPropName { span })
+                self.storage.report(ErrorKind::CannotReferenceSuperInComputedPropName { span })
             }
 
             Some(ScopeKind::ArrowFn) => {
@@ -4038,7 +4038,7 @@ impl Analyzer<'_, '_> {
                     return;
                 }
 
-                self.storage.report(Error::CannotReferenceSuperInComputedPropName { span })
+                self.storage.report(ErrorKind::CannotReferenceSuperInComputedPropName { span })
             }
 
             kind => {
@@ -4131,16 +4131,16 @@ impl Analyzer<'_, '_> {
     }
 }
 
-fn is_valid_lhs(l: &RPatOrExpr) -> Result<(), Error> {
-    fn is_valid_lhs_expr(e: &RExpr) -> Result<(), Error> {
+fn is_valid_lhs(l: &RPatOrExpr) -> Result<(), ErrorKind> {
+    fn is_valid_lhs_expr(e: &RExpr) -> Result<(), ErrorKind> {
         // obj?.a["b"] += 1;
         if is_obj_opt_chaining(&e) {
-            return Err(Error::InvalidLhsOfAssignOptionalProp { span: e.span() });
+            return Err(ErrorKind::InvalidLhsOfAssignOptionalProp { span: e.span() });
         }
         match e {
             RExpr::Ident(..) | RExpr::Member(..) | RExpr::SuperProp(..) => Ok(()),
             RExpr::Paren(e) => is_valid_lhs_expr(&e.expr),
-            _ => Err(Error::InvalidLhsOfAssign { span: e.span() }),
+            _ => Err(ErrorKind::InvalidLhsOfAssign { span: e.span() }),
         }
     }
 

--- a/crates/stc_ts_file_analyzer/src/analyzer/expr/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/expr/mod.rs
@@ -1475,7 +1475,8 @@ impl Analyzer<'_, '_> {
                             span,
                             class_name: self.scope.get_this_class_name(),
                             prop: prop.clone(),
-                        });
+                        }
+                        .into());
                     }
 
                     if let Some(super_class) = self.scope.get_super_class() {
@@ -1556,7 +1557,8 @@ impl Analyzer<'_, '_> {
                         span: *span,
                         obj: Some(box obj.clone()),
                         prop: Some(box prop.clone()),
-                    });
+                    }
+                    .into());
                 }
 
                 _ => {}
@@ -2080,7 +2082,7 @@ impl Analyzer<'_, '_> {
                             }),
                         ) => {
                             if self.rule().no_implicit_any && !self.rule().suppress_implicit_any_index_errors {
-                                self.storage.report(ErrorKind::ImplicitAnyBecauseIndexTypeIsWrong { span });
+                                self.storage.report(ErrorKind::ImplicitAnyBecauseIndexTypeIsWrong { span }.into());
                             }
 
                             return Ok(Type::any(span, Default::default()));
@@ -2365,7 +2367,7 @@ impl Analyzer<'_, '_> {
                 if type_mode == TypeOfMode::LValue {
                     if !errors.is_empty() {
                         assert_ne!(errors.len(), 0);
-                        return Err(ErrorKind::UnionError { span, errors });
+                        return Err(ErrorKind::UnionError { span, errors }.into());
                     }
                 } else {
                     if !errors.is_empty() {

--- a/crates/stc_ts_file_analyzer/src/analyzer/expr/object.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/expr/object.rs
@@ -85,7 +85,7 @@ impl Analyzer<'_, '_> {
                     if let Some(prev) = keys.iter().find(|v| v.0.type_eq(key)) {
                         if *optional != prev.1 {
                             self.storage
-                                .report(ErrorKind::OptionalAndNonOptionalMethodPropertyMixed { span: key.span() });
+                                .report(ErrorKind::OptionalAndNonOptionalMethodPropertyMixed { span: key.span() }.into());
                             continue;
                         }
                     }

--- a/crates/stc_ts_file_analyzer/src/analyzer/expr/object.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/expr/object.rs
@@ -142,7 +142,7 @@ impl Analyzer<'_, '_> {
                                     prev_key.type_eq(&key)
                                 })
                             {
-                                self.storage.report(ErrorKind::DuplicateProperty { span })
+                                self.storage.report(ErrorKind::DuplicateProperty { span }.into())
                             } else {
                                 known_keys.push(key);
                             }

--- a/crates/stc_ts_file_analyzer/src/analyzer/expr/object.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/expr/object.rs
@@ -2,7 +2,7 @@ use std::{borrow::Cow, time::Instant};
 
 use rnode::VisitMutWith;
 use stc_ts_ast_rnode::{RObjectLit, RPropOrSpread, RSpreadElement};
-use stc_ts_errors::{DebugExt, Error};
+use stc_ts_errors::{DebugExt, ErrorKind};
 use stc_ts_file_analyzer_macros::validator;
 use stc_ts_type_ops::{union_normalization::UnionNormalizer, Fix};
 use stc_ts_types::{Accessor, Key, MethodSignature, PropertySignature, Type, TypeElement, TypeLit, Union, UnionMetadata};
@@ -85,7 +85,7 @@ impl Analyzer<'_, '_> {
                     if let Some(prev) = keys.iter().find(|v| v.0.type_eq(key)) {
                         if *optional != prev.1 {
                             self.storage
-                                .report(Error::OptionalAndNonOptionalMethodPropertyMixed { span: key.span() });
+                                .report(ErrorKind::OptionalAndNonOptionalMethodPropertyMixed { span: key.span() });
                             continue;
                         }
                     }
@@ -142,7 +142,7 @@ impl Analyzer<'_, '_> {
                                     prev_key.type_eq(&key)
                                 })
                             {
-                                self.storage.report(Error::DuplicateProperty { span })
+                                self.storage.report(ErrorKind::DuplicateProperty { span })
                             } else {
                                 known_keys.push(key);
                             }

--- a/crates/stc_ts_file_analyzer/src/analyzer/expr/type_cast.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/expr/type_cast.rs
@@ -225,10 +225,10 @@ impl Analyzer<'_, '_> {
                 if castable {
                     Ok(())
                 } else {
-                    Err(ErrorKind::NonOverlappingTypeCast { span })
+                    Err(ErrorKind::NonOverlappingTypeCast { span }.into())
                 }
             })
-            .convert_err(|err| ErrorKind::NonOverlappingTypeCast { span })
+            .convert_err(|err| ErrorKind::NonOverlappingTypeCast { span }.into())
     }
 
     pub(crate) fn has_overlap(&mut self, span: Span, l: &Type, r: &Type, opts: CastableOpts) -> VResult<bool> {

--- a/crates/stc_ts_file_analyzer/src/analyzer/expr/type_cast.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/expr/type_cast.rs
@@ -1,7 +1,7 @@
 use std::borrow::Cow;
 
 use stc_ts_ast_rnode::{RTsAsExpr, RTsLit, RTsTypeAssertion};
-use stc_ts_errors::{DebugExt, Error};
+use stc_ts_errors::{DebugExt, ErrorKind};
 use stc_ts_types::{Interface, KeywordType, LitType, TypeElement, TypeParamInstantiation};
 use stc_utils::cache::Freeze;
 use swc_common::{Span, Spanned, TypeEq};
@@ -136,7 +136,7 @@ impl Analyzer<'_, '_> {
                     Type::Tuple(ref rt) => {
                         //
                         if lt.elems.len() != rt.elems.len() {
-                            Err(Error::InvalidTupleCast {
+                            Err(ErrorKind::InvalidTupleCast {
                                 span,
                                 left: lt.span(),
                                 right: rt.span(),
@@ -225,10 +225,10 @@ impl Analyzer<'_, '_> {
                 if castable {
                     Ok(())
                 } else {
-                    Err(Error::NonOverlappingTypeCast { span })
+                    Err(ErrorKind::NonOverlappingTypeCast { span })
                 }
             })
-            .convert_err(|err| Error::NonOverlappingTypeCast { span })
+            .convert_err(|err| ErrorKind::NonOverlappingTypeCast { span })
     }
 
     pub(crate) fn has_overlap(&mut self, span: Span, l: &Type, r: &Type, opts: CastableOpts) -> VResult<bool> {

--- a/crates/stc_ts_file_analyzer/src/analyzer/expr/unary.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/expr/unary.rs
@@ -208,12 +208,10 @@ impl Analyzer<'_, '_> {
             })
             | RExpr::Member(expr) => {
                 if self.rule().strict_null_checks {
-                    let ty = self.type_of_member_expr(expr, TypeOfMode::RValue).convert_err(|err| match &*err {
+                    let ty = self.type_of_member_expr(expr, TypeOfMode::RValue).convert_err(|err| match err {
                         ErrorKind::ObjectIsPossiblyNull { span, .. }
                         | ErrorKind::ObjectIsPossiblyUndefined { span, .. }
-                        | ErrorKind::ObjectIsPossiblyNullOrUndefined { span, .. } => {
-                            ErrorKind::DeleteOperandMustBeOptional { span: *span }.into()
-                        }
+                        | ErrorKind::ObjectIsPossiblyNullOrUndefined { span, .. } => ErrorKind::DeleteOperandMustBeOptional { span }.into(),
                         _ => err,
                     })?;
                     if !self.can_be_undefined(span, &ty)? {

--- a/crates/stc_ts_file_analyzer/src/analyzer/expr/unary.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/expr/unary.rs
@@ -156,7 +156,7 @@ impl Analyzer<'_, '_> {
                 ..
             })) => {
                 debug_assert!(!arg.span().is_dummy());
-                return Err(ErrorKind::Unknown { span: arg.span() });
+                return Err(ErrorKind::Unknown { span: arg.span() }.into());
             }
             _ => {}
         }

--- a/crates/stc_ts_file_analyzer/src/analyzer/expr/update.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/expr/update.rs
@@ -20,7 +20,7 @@ impl Analyzer<'_, '_> {
         let span = e.span;
 
         match &*e.arg {
-            RExpr::New(..) => self.storage.report(ErrorKind::ExprInvalidForUpdateArg { span }),
+            RExpr::New(..) => self.storage.report(ErrorKind::ExprInvalidForUpdateArg { span }.into()),
             _ => {}
         }
 
@@ -55,7 +55,8 @@ impl Analyzer<'_, '_> {
                     Err(ErrorKind::TypeInvalidForUpdateArg {
                         span: e.arg.span(),
                         ty: box ty.clone(),
-                    })
+                    }
+                    .into())
                 }
 
                 _ if ty.is_global_this() => {
@@ -64,13 +65,14 @@ impl Analyzer<'_, '_> {
                     Err(ErrorKind::TypeInvalidForUpdateArg {
                         span: e.arg.span(),
                         ty: box ty.clone(),
-                    })
+                    }
+                    .into())
                 }
 
                 Type::Enum(..) => {
                     errored = true;
 
-                    Err(ErrorKind::CannotAssignToEnum { span: e.arg.span() })
+                    Err(ErrorKind::CannotAssignToEnum { span: e.arg.span() }.into())
                 }
 
                 Type::Lit(LitType {
@@ -82,7 +84,7 @@ impl Analyzer<'_, '_> {
                 }) => {
                     match &*e.arg {
                         RExpr::Lit(RLit::Num(..)) | RExpr::Call(..) | RExpr::Paren(..) => {
-                            self.storage.report(ErrorKind::ExprInvalidForUpdateArg { span });
+                            self.storage.report(ErrorKind::ExprInvalidForUpdateArg { span }.into());
                         }
 
                         _ => {}
@@ -96,7 +98,7 @@ impl Analyzer<'_, '_> {
 
         if let Some(ty) = ty {
             if let Some(false) = self.is_update_operand_valid(&ty).report(&mut self.storage) {
-                self.storage.report(ErrorKind::InvalidNumericOperand { span: e.arg.span() })
+                self.storage.report(ErrorKind::InvalidNumericOperand { span: e.arg.span() }.into())
             }
         } else {
             if !errored
@@ -108,7 +110,8 @@ impl Analyzer<'_, '_> {
                     _ => false,
                 }
             {
-                self.storage.report(ErrorKind::UpdateArgMustBeVariableOrPropertyAccess { span });
+                self.storage
+                    .report(ErrorKind::UpdateArgMustBeVariableOrPropertyAccess { span }.into());
             }
         }
 

--- a/crates/stc_ts_file_analyzer/src/analyzer/function/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/function/mod.rs
@@ -40,7 +40,7 @@ impl Analyzer<'_, '_> {
                 // TODO(kdy1): Make this efficient by report same error only once.
                 if v.len() >= 2 {
                     for &span in &*v {
-                        self.storage.report(ErrorKind::DuplicateFnImpl { span })
+                        self.storage.report(ErrorKind::DuplicateFnImpl { span }.into())
                     }
                 }
             }
@@ -67,7 +67,7 @@ impl Analyzer<'_, '_> {
                             })
                             | RPat::Rest(..) => {}
                             _ => {
-                                child.storage.report(ErrorKind::TS1016 { span: p.span() });
+                                child.storage.report(ErrorKind::TS1016 { span: p.span() }.into());
                             }
                         }
                     }
@@ -177,12 +177,12 @@ impl Analyzer<'_, '_> {
                         if f.is_generator && declared.is_kwd(TsKeywordTypeKind::TsVoidKeyword) {
                             child
                                 .storage
-                                .report(ErrorKind::GeneratorCannotHaveVoidAsReturnType { span: declared.span() })
+                                .report(ErrorKind::GeneratorCannotHaveVoidAsReturnType { span: declared.span() }.into())
                         }
                     } else {
                         if child.rule().no_implicit_any {
                             if child.is_implicitly_typed(&inferred_return_type) {
-                                child.storage.report(ErrorKind::ImplicitReturnType { span })
+                                child.storage.report(ErrorKind::ImplicitReturnType { span }.into())
                             }
                         }
 
@@ -213,7 +213,7 @@ impl Analyzer<'_, '_> {
                                 kind: TsKeywordTypeKind::TsNeverKeyword,
                                 ..
                             }) => {}
-                            _ => errors.push(ErrorKind::ReturnRequired { span }),
+                            _ => errors.push(ErrorKind::ReturnRequired { span }.into()),
                         }
                     }
 

--- a/crates/stc_ts_file_analyzer/src/analyzer/import.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/import.rs
@@ -29,7 +29,7 @@ impl Analyzer<'_, '_> {
         let dep_id = match dep_id {
             Some(v) => v,
             None => {
-                self.storage.report(ErrorKind::ModuleNotFound { span });
+                self.storage.report(ErrorKind::ModuleNotFound { span }.into());
 
                 return (ctxt, Type::any(span, Default::default()));
             }
@@ -37,7 +37,7 @@ impl Analyzer<'_, '_> {
         let data = match self.imports.get(&(ctxt, dep_id)).cloned() {
             Some(v) => v,
             None => {
-                self.storage.report(ErrorKind::ModuleNotFound { span });
+                self.storage.report(ErrorKind::ModuleNotFound { span }.into());
 
                 return (ctxt, Type::any(span, Default::default()));
             }
@@ -89,7 +89,7 @@ impl Analyzer<'_, '_> {
             let dep_id = match dep_id {
                 Some(v) => v,
                 None => {
-                    self.storage.report(ErrorKind::ModuleNotFound { span });
+                    self.storage.report(ErrorKind::ModuleNotFound { span }.into());
                     continue;
                 }
             };
@@ -177,7 +177,7 @@ impl Analyzer<'_, '_> {
             if ctxt != target {
                 // If import was successful but the entry is not found, the error should point
                 // the specifier.
-                self.storage.report(ErrorKind::ImportFailed { span, orig, id });
+                self.storage.report(ErrorKind::ImportFailed { span, orig, id }.into());
             }
         }
     }

--- a/crates/stc_ts_file_analyzer/src/analyzer/import.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/import.rs
@@ -3,7 +3,7 @@ use rnode::{Visit, VisitWith};
 use stc_ts_ast_rnode::{
     RCallExpr, RCallee, RExportAll, RExpr, RImportDecl, RImportSpecifier, RLit, RModuleItem, RNamedExport, RStr, RTsExternalModuleRef,
 };
-use stc_ts_errors::Error;
+use stc_ts_errors::ErrorKind;
 use stc_ts_file_analyzer_macros::extra_validator;
 use stc_ts_storage::Storage;
 use stc_ts_types::{Id, ModuleId, Type};
@@ -29,7 +29,7 @@ impl Analyzer<'_, '_> {
         let dep_id = match dep_id {
             Some(v) => v,
             None => {
-                self.storage.report(Error::ModuleNotFound { span });
+                self.storage.report(ErrorKind::ModuleNotFound { span });
 
                 return (ctxt, Type::any(span, Default::default()));
             }
@@ -37,7 +37,7 @@ impl Analyzer<'_, '_> {
         let data = match self.imports.get(&(ctxt, dep_id)).cloned() {
             Some(v) => v,
             None => {
-                self.storage.report(Error::ModuleNotFound { span });
+                self.storage.report(ErrorKind::ModuleNotFound { span });
 
                 return (ctxt, Type::any(span, Default::default()));
             }
@@ -89,7 +89,7 @@ impl Analyzer<'_, '_> {
             let dep_id = match dep_id {
                 Some(v) => v,
                 None => {
-                    self.storage.report(Error::ModuleNotFound { span });
+                    self.storage.report(ErrorKind::ModuleNotFound { span });
                     continue;
                 }
             };
@@ -177,7 +177,7 @@ impl Analyzer<'_, '_> {
             if ctxt != target {
                 // If import was successful but the entry is not found, the error should point
                 // the specifier.
-                self.storage.report(Error::ImportFailed { span, orig, id });
+                self.storage.report(ErrorKind::ImportFailed { span, orig, id });
             }
         }
     }

--- a/crates/stc_ts_file_analyzer/src/analyzer/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/mod.rs
@@ -14,7 +14,7 @@ use stc_ts_ast_rnode::{
 use stc_ts_base_type_ops::bindings::Bindings;
 use stc_ts_dts_mutations::Mutations;
 use stc_ts_env::{Env, Marks, ModuleConfig, Rule, StableEnv};
-use stc_ts_errors::{debug::debugger::Debugger, Error};
+use stc_ts_errors::{debug::debugger::Debugger, ErrorKind};
 use stc_ts_storage::{Builtin, Info, Storage};
 use stc_ts_type_cache::TypeCache;
 use stc_ts_types::{Id, IdCtx, ModuleId, ModuleTypeData, Namespace};
@@ -398,7 +398,7 @@ impl<'scope, 'b> Analyzer<'scope, 'b> {
         debugger: Option<Debugger>,
     ) -> Self {
         if env.rule().use_define_property_for_class_fields && env.target() == EsVersion::Es3 {
-            storage.report(Error::OptionInvalidForEs3 { span: DUMMY_SP })
+            storage.report(ErrorKind::OptionInvalidForEs3 { span: DUMMY_SP })
         }
 
         Self::new_inner(
@@ -780,7 +780,8 @@ impl Analyzer<'_, '_> {
                         self.export_equals_span = decl.span;
                     }
                     if !is_dts && has_normal_export {
-                        self.storage.report(Error::ExportEqualsMixedWithOtherExports { span: decl.span });
+                        self.storage
+                            .report(ErrorKind::ExportEqualsMixedWithOtherExports { span: decl.span });
                     }
 
                     //
@@ -793,7 +794,7 @@ impl Analyzer<'_, '_> {
                     | RModuleDecl::TsNamespaceExport(..) => {
                         has_normal_export = true;
                         if !is_dts && !self.export_equals_span.is_dummy() {
-                            self.storage.report(Error::ExportEqualsMixedWithOtherExports {
+                            self.storage.report(ErrorKind::ExportEqualsMixedWithOtherExports {
                                 span: self.export_equals_span,
                             });
                         }
@@ -1034,7 +1035,7 @@ impl Analyzer<'_, '_> {
                     if let Some(pos) = name.as_bytes().iter().position(|&c| c == b'*') {
                         if let Some(rpos) = name.as_bytes().iter().rposition(|&c| c == b'*') {
                             if pos != rpos {
-                                self.storage.report(Error::TooManyAsterisk { span: s.span });
+                                self.storage.report(ErrorKind::TooManyAsterisk { span: s.span });
                             }
                         }
                     }

--- a/crates/stc_ts_file_analyzer/src/analyzer/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/mod.rs
@@ -1038,7 +1038,7 @@ impl Analyzer<'_, '_> {
                     if let Some(pos) = name.as_bytes().iter().position(|&c| c == b'*') {
                         if let Some(rpos) = name.as_bytes().iter().rposition(|&c| c == b'*') {
                             if pos != rpos {
-                                self.storage.report(ErrorKind::TooManyAsterisk { span: s.span });
+                                self.storage.report(ErrorKind::TooManyAsterisk { span: s.span }.into());
                             }
                         }
                     }

--- a/crates/stc_ts_file_analyzer/src/analyzer/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/mod.rs
@@ -398,7 +398,7 @@ impl<'scope, 'b> Analyzer<'scope, 'b> {
         debugger: Option<Debugger>,
     ) -> Self {
         if env.rule().use_define_property_for_class_fields && env.target() == EsVersion::Es3 {
-            storage.report(ErrorKind::OptionInvalidForEs3 { span: DUMMY_SP })
+            storage.report(ErrorKind::OptionInvalidForEs3 { span: DUMMY_SP }.into())
         }
 
         Self::new_inner(
@@ -781,7 +781,7 @@ impl Analyzer<'_, '_> {
                     }
                     if !is_dts && has_normal_export {
                         self.storage
-                            .report(ErrorKind::ExportEqualsMixedWithOtherExports { span: decl.span });
+                            .report(ErrorKind::ExportEqualsMixedWithOtherExports { span: decl.span }.into());
                     }
 
                     //
@@ -794,9 +794,12 @@ impl Analyzer<'_, '_> {
                     | RModuleDecl::TsNamespaceExport(..) => {
                         has_normal_export = true;
                         if !is_dts && !self.export_equals_span.is_dummy() {
-                            self.storage.report(ErrorKind::ExportEqualsMixedWithOtherExports {
-                                span: self.export_equals_span,
-                            });
+                            self.storage.report(
+                                ErrorKind::ExportEqualsMixedWithOtherExports {
+                                    span: self.export_equals_span,
+                                }
+                                .into(),
+                            );
                         }
                     }
                     _ => {}

--- a/crates/stc_ts_file_analyzer/src/analyzer/pat.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/pat.rs
@@ -182,7 +182,7 @@ impl Analyzer<'_, '_> {
             match p {
                 RPat::Assign(p) => self
                     .storage
-                    .report(ErrorKind::InitializerDisallowedInAmbientContext { span: p.span }),
+                    .report(ErrorKind::InitializerDisallowedInAmbientContext { span: p.span }.into()),
                 _ => {}
             }
         }
@@ -191,7 +191,7 @@ impl Analyzer<'_, '_> {
             match p {
                 RPat::Array(RArrayPat { span, optional: true, .. }) | RPat::Object(RObjectPat { span, optional: true, .. }) => self
                     .storage
-                    .report(ErrorKind::OptionalBindingPatternInImplSignature { span: *span }),
+                    .report(ErrorKind::OptionalBindingPatternInImplSignature { span: *span }.into()),
                 _ => {}
             }
         }
@@ -520,7 +520,7 @@ impl Analyzer<'_, '_> {
                                         }
                                     }
 
-                                    self.storage.report(ErrorKind::TS2353 { span: prop.span() })
+                                    self.storage.report(ErrorKind::TS2353 { span: prop.span() }.into())
                                 }
                                 _ => {}
                             }

--- a/crates/stc_ts_file_analyzer/src/analyzer/pat.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/pat.rs
@@ -3,7 +3,7 @@ use stc_ts_ast_rnode::{
     RArrayPat, RAssignPat, RAssignPatProp, RBindingIdent, RExpr, RIdent, RKeyValuePatProp, RKeyValueProp, RObjectPat, RObjectPatProp,
     RParam, RPat, RProp, RPropOrSpread, RRestPat,
 };
-use stc_ts_errors::{Error, Errors};
+use stc_ts_errors::{ErrorKind, Errors};
 use stc_ts_type_ops::widen::Widen;
 use stc_ts_types::{
     Array, ArrayMetadata, CommonTypeMetadata, Instance, Key, KeywordType, PropertySignature, Tuple, TupleElement, TypeElMetadata,
@@ -180,16 +180,18 @@ impl Analyzer<'_, '_> {
 
         if self.ctx.in_declare {
             match p {
-                RPat::Assign(p) => self.storage.report(Error::InitializerDisallowedInAmbientContext { span: p.span }),
+                RPat::Assign(p) => self
+                    .storage
+                    .report(ErrorKind::InitializerDisallowedInAmbientContext { span: p.span }),
                 _ => {}
             }
         }
 
         if !self.ctx.in_declare && !self.ctx.in_fn_without_body {
             match p {
-                RPat::Array(RArrayPat { span, optional: true, .. }) | RPat::Object(RObjectPat { span, optional: true, .. }) => {
-                    self.storage.report(Error::OptionalBindingPatternInImplSignature { span: *span })
-                }
+                RPat::Array(RArrayPat { span, optional: true, .. }) | RPat::Object(RObjectPat { span, optional: true, .. }) => self
+                    .storage
+                    .report(ErrorKind::OptionalBindingPatternInImplSignature { span: *span }),
                 _ => {}
             }
         }
@@ -459,7 +461,7 @@ impl Analyzer<'_, '_> {
                         kind: TsKeywordTypeKind::TsAnyKeyword,
                         ..
                     }) => {}
-                    _ => Err(Error::TS2370 { span: p.dot3_token })?,
+                    _ => Err(ErrorKind::TS2370 { span: p.dot3_token })?,
                 }
             };
             res.store(&mut errors);
@@ -473,7 +475,7 @@ impl Analyzer<'_, '_> {
                         kind: TsKeywordTypeKind::TsAnyKeyword,
                         ..
                     }) => {}
-                    _ => Err(Error::TS2370 { span: p.dot3_token })?,
+                    _ => Err(ErrorKind::TS2370 { span: p.dot3_token })?,
                 }
             };
 
@@ -518,7 +520,7 @@ impl Analyzer<'_, '_> {
                                         }
                                     }
 
-                                    self.storage.report(Error::TS2353 { span: prop.span() })
+                                    self.storage.report(ErrorKind::TS2353 { span: prop.span() })
                                 }
                                 _ => {}
                             }

--- a/crates/stc_ts_file_analyzer/src/analyzer/props.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/props.rs
@@ -580,7 +580,7 @@ impl Analyzer<'_, '_> {
                         let ret_ty = child.visit_stmts_for_return(n.span, false, false, &body.stmts)?;
                         if let None = ret_ty {
                             // getter property must have return statements.
-                            child.storage.report(ErrorKind::TS2378 { span: n.key.span() });
+                            child.storage.report(ErrorKind::TS2378 { span: n.key.span() }.into());
                         }
 
                         return Ok(ret_ty);

--- a/crates/stc_ts_file_analyzer/src/analyzer/props.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/props.rs
@@ -100,7 +100,7 @@ impl Analyzer<'_, '_> {
                 Ok(ty) => ty,
                 Err(err) => {
                     check_for_symbol_form = false;
-                    match err {
+                    match *err {
                         ErrorKind::TS2585 { span } => Err(ErrorKind::TS2585 { span })?,
                         _ => {}
                     }
@@ -123,7 +123,7 @@ impl Analyzer<'_, '_> {
 
                     analyzer
                         .storage
-                        .report(ErrorKind::InvalidTypeForComputedProperty { span, ty: box ty.clone() });
+                        .report(ErrorKind::InvalidTypeForComputedProperty { span, ty: box ty.clone() }.into());
                 }
             }
 
@@ -145,7 +145,7 @@ impl Analyzer<'_, '_> {
                                 _ if ty.is_kwd(TsKeywordTypeKind::TsSymbolKeyword) || ty.is_unique_symbol() || ty.is_symbol() => {}
                                 _ => match mode {
                                     ComputedPropMode::Interface => {
-                                        errors.push(ErrorKind::TS1169 { span: node.span });
+                                        errors.push(ErrorKind::TS1169 { span: node.span }.into());
                                         check_for_symbol_form = false;
                                     }
                                     _ => {}
@@ -172,7 +172,9 @@ impl Analyzer<'_, '_> {
                     }) if ty.normalize_instance().is_kwd(TsKeywordTypeKind::TsSymbolKeyword) => {}
                     _ => {
                         //
-                        analyzer.storage.report(ErrorKind::NonSymbolComputedPropInFormOfSymbol { span });
+                        analyzer
+                            .storage
+                            .report(ErrorKind::NonSymbolComputedPropInFormOfSymbol { span }.into());
                     }
                 }
             }
@@ -253,7 +255,7 @@ impl Analyzer<'_, '_> {
                     ScopeKind::Class => {
                         if scope.declaring_type_params.contains(&used.name) {
                             self.storage
-                                .report(ErrorKind::DeclaringTypeParamReferencedByComputedPropName { span });
+                                .report(ErrorKind::DeclaringTypeParamReferencedByComputedPropName { span }.into());
                         }
                     }
                     _ => {

--- a/crates/stc_ts_file_analyzer/src/analyzer/scope/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/scope/mod.rs
@@ -13,7 +13,7 @@ use iter::once;
 use once_cell::sync::Lazy;
 use rnode::{Fold, FoldWith, VisitMut, VisitMutWith, VisitWith};
 use stc_ts_ast_rnode::{RPat, RTsEntityName, RTsQualifiedName};
-use stc_ts_errors::{debug::dump_type_as_string, DebugExt, ErrorKind};
+use stc_ts_errors::{debug::dump_type_as_string, DebugExt, Error};
 use stc_ts_generics::ExpandGenericOpts;
 use stc_ts_type_ops::{expansion::ExpansionPreventer, union_finder::UnionFinder, Fix};
 use stc_ts_types::{
@@ -767,7 +767,7 @@ impl Analyzer<'_, '_> {
 
         if v.len() >= 2 {
             for span in v.iter().copied() {
-                self.storage.report(ErrorKind::DuplicateName { span, name: id.clone() })
+                self.storage.report(Error::DuplicateName { span, name: id.clone() })
             }
         }
     }
@@ -793,9 +793,9 @@ impl Analyzer<'_, '_> {
                 self.data.exported_type_decls.entry(name.clone()).or_default().push(ty.span());
 
                 if let Some(spans) = self.data.local_type_decls.get(&name) {
-                    self.storage.report(ErrorKind::ExportMixedWithLocal { span: ty.span() });
+                    self.storage.report(Error::ExportMixedWithLocal { span: ty.span() });
                     for (i, span) in spans.iter().copied().enumerate() {
-                        self.storage.report(ErrorKind::ExportMixedWithLocal { span });
+                        self.storage.report(Error::ExportMixedWithLocal { span });
                         if i == 0 {
                             self.data.unmergable_type_decls.remove(&name);
                         }
@@ -805,10 +805,10 @@ impl Analyzer<'_, '_> {
                 self.data.local_type_decls.entry(name.clone()).or_default().push(ty.span());
 
                 if let Some(spans) = self.data.exported_type_decls.get(&name) {
-                    self.storage.report(ErrorKind::ExportMixedWithLocal { span: ty.span() });
+                    self.storage.report(Error::ExportMixedWithLocal { span: ty.span() });
 
                     for (i, span) in spans.iter().copied().enumerate() {
-                        self.storage.report(ErrorKind::ExportMixedWithLocal { span });
+                        self.storage.report(Error::ExportMixedWithLocal { span });
 
                         if i == 0 {
                             self.data.unmergable_type_decls.remove(&name);
@@ -1282,13 +1282,13 @@ impl Analyzer<'_, '_> {
                 let mut done = false;
                 for (_, span) in &**spans {
                     if matches!(kind, VarKind::Param | VarKind::Class) {
-                        self.storage.report(ErrorKind::DuplicateName {
+                        self.storage.report(Error::DuplicateName {
                             name: name.clone(),
                             span: *span,
                         });
                         done = true;
                     } else {
-                        self.storage.report(ErrorKind::DuplicateVar {
+                        self.storage.report(Error::DuplicateVar {
                             name: name.clone(),
                             span: *span,
                         });
@@ -1304,7 +1304,7 @@ impl Analyzer<'_, '_> {
         match kind {
             VarKind::Var(VarDeclKind::Let | VarDeclKind::Const) => {
                 if *name.sym() == js_word!("let") || *name.sym() == js_word!("const") {
-                    self.storage.report(ErrorKind::LetOrConstIsNotValidIdInLetOrConstVarDecls { span });
+                    self.storage.report(Error::LetOrConstIsNotValidIdInLetOrConstVarDecls { span });
                 }
             }
             _ => {}
@@ -1442,7 +1442,7 @@ impl Analyzer<'_, '_> {
                                     Type::Query(..) => {}
                                     // Allow overloading query type.
                                     Type::Function(..) => {}
-                                    Type::ClassDef(..) => return Err(ErrorKind::DuplicateName { name: name.clone(), span }),
+                                    Type::ClassDef(..) => return Err(Error::DuplicateName { name: name.clone(), span }),
                                     Type::Union(..) => {
                                         // TODO(kdy1): Check if all types are
                                         // query or
@@ -1463,7 +1463,7 @@ impl Analyzer<'_, '_> {
                                                 },
                                             )
                                             .context("tried to validate a varaible declared multiple times")
-                                            .convert_err(|err| ErrorKind::VarDeclNotCompatible {
+                                            .convert_err(|err| Error::VarDeclNotCompatible {
                                                 span: err.span(),
                                                 cause: box err,
                                             });
@@ -1563,7 +1563,7 @@ impl Analyzer<'_, '_> {
                             ..Default::default()
                         },
                     )
-                    .convert_err(|err| ErrorKind::ImcompatibleFnOverload {
+                    .convert_err(|err| Error::ImcompatibleFnOverload {
                         span: orig.span(),
                         cause: box err,
                     })
@@ -1963,7 +1963,7 @@ impl Expander<'_, '_, '_> {
 
                             ty @ Type::Enum(..) => {
                                 if let Some(..) = type_args {
-                                    Err(ErrorKind::NotGeneric { span })?;
+                                    Err(Error::NotGeneric { span })?;
                                 }
                                 verify!(ty);
                                 return Ok(Some(ty.clone()));
@@ -1971,7 +1971,7 @@ impl Expander<'_, '_, '_> {
 
                             ty @ Type::Param(..) => {
                                 if let Some(..) = type_args {
-                                    Err(ErrorKind::NotGeneric { span })?;
+                                    Err(Error::NotGeneric { span })?;
                                 }
 
                                 verify!(ty);

--- a/crates/stc_ts_file_analyzer/src/analyzer/scope/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/scope/mod.rs
@@ -767,7 +767,7 @@ impl Analyzer<'_, '_> {
 
         if v.len() >= 2 {
             for span in v.iter().copied() {
-                self.storage.report(Error::DuplicateName { span, name: id.clone() })
+                self.storage.report(ErrorKind::DuplicateName { span, name: id.clone() })
             }
         }
     }
@@ -793,9 +793,9 @@ impl Analyzer<'_, '_> {
                 self.data.exported_type_decls.entry(name.clone()).or_default().push(ty.span());
 
                 if let Some(spans) = self.data.local_type_decls.get(&name) {
-                    self.storage.report(Error::ExportMixedWithLocal { span: ty.span() });
+                    self.storage.report(ErrorKind::ExportMixedWithLocal { span: ty.span() });
                     for (i, span) in spans.iter().copied().enumerate() {
-                        self.storage.report(Error::ExportMixedWithLocal { span });
+                        self.storage.report(ErrorKind::ExportMixedWithLocal { span });
                         if i == 0 {
                             self.data.unmergable_type_decls.remove(&name);
                         }
@@ -805,10 +805,10 @@ impl Analyzer<'_, '_> {
                 self.data.local_type_decls.entry(name.clone()).or_default().push(ty.span());
 
                 if let Some(spans) = self.data.exported_type_decls.get(&name) {
-                    self.storage.report(Error::ExportMixedWithLocal { span: ty.span() });
+                    self.storage.report(ErrorKind::ExportMixedWithLocal { span: ty.span() });
 
                     for (i, span) in spans.iter().copied().enumerate() {
-                        self.storage.report(Error::ExportMixedWithLocal { span });
+                        self.storage.report(ErrorKind::ExportMixedWithLocal { span });
 
                         if i == 0 {
                             self.data.unmergable_type_decls.remove(&name);
@@ -1310,7 +1310,7 @@ impl Analyzer<'_, '_> {
         match kind {
             VarKind::Var(VarDeclKind::Let | VarDeclKind::Const) => {
                 if *name.sym() == js_word!("let") || *name.sym() == js_word!("const") {
-                    self.storage.report(Error::LetOrConstIsNotValidIdInLetOrConstVarDecls { span });
+                    self.storage.report(ErrorKind::LetOrConstIsNotValidIdInLetOrConstVarDecls { span });
                 }
             }
             _ => {}
@@ -1448,7 +1448,7 @@ impl Analyzer<'_, '_> {
                                     Type::Query(..) => {}
                                     // Allow overloading query type.
                                     Type::Function(..) => {}
-                                    Type::ClassDef(..) => return Err(Error::DuplicateName { name: name.clone(), span }),
+                                    Type::ClassDef(..) => return Err(ErrorKind::DuplicateName { name: name.clone(), span }),
                                     Type::Union(..) => {
                                         // TODO(kdy1): Check if all types are
                                         // query or
@@ -1469,7 +1469,7 @@ impl Analyzer<'_, '_> {
                                                 },
                                             )
                                             .context("tried to validate a varaible declared multiple times")
-                                            .convert_err(|err| Error::VarDeclNotCompatible {
+                                            .convert_err(|err| ErrorKind::VarDeclNotCompatible {
                                                 span: err.span(),
                                                 cause: box err,
                                             });
@@ -1481,7 +1481,7 @@ impl Analyzer<'_, '_> {
                                             return Ok(());
 
                                             // TODO(kdy1):
-                                            //  return Err(Error::
+                                            //  return Err(ErrorKind::
                                             //      RedeclaredVarWithDifferentType {
                                             //          span,
                                             //      }
@@ -1569,7 +1569,7 @@ impl Analyzer<'_, '_> {
                             ..Default::default()
                         },
                     )
-                    .convert_err(|err| Error::ImcompatibleFnOverload {
+                    .convert_err(|err| ErrorKind::ImcompatibleFnOverload {
                         span: orig.span(),
                         cause: box err,
                     })
@@ -1969,7 +1969,7 @@ impl Expander<'_, '_, '_> {
 
                             ty @ Type::Enum(..) => {
                                 if let Some(..) = type_args {
-                                    Err(Error::NotGeneric { span })?;
+                                    Err(ErrorKind::NotGeneric { span })?;
                                 }
                                 verify!(ty);
                                 return Ok(Some(ty.clone()));
@@ -1977,7 +1977,7 @@ impl Expander<'_, '_, '_> {
 
                             ty @ Type::Param(..) => {
                                 if let Some(..) = type_args {
-                                    Err(Error::NotGeneric { span })?;
+                                    Err(ErrorKind::NotGeneric { span })?;
                                 }
 
                                 verify!(ty);

--- a/crates/stc_ts_file_analyzer/src/analyzer/scope/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/scope/mod.rs
@@ -13,7 +13,7 @@ use iter::once;
 use once_cell::sync::Lazy;
 use rnode::{Fold, FoldWith, VisitMut, VisitMutWith, VisitWith};
 use stc_ts_ast_rnode::{RPat, RTsEntityName, RTsQualifiedName};
-use stc_ts_errors::{debug::dump_type_as_string, DebugExt, Error};
+use stc_ts_errors::{debug::dump_type_as_string, DebugExt, Error, ErrorKind};
 use stc_ts_generics::ExpandGenericOpts;
 use stc_ts_type_ops::{expansion::ExpansionPreventer, union_finder::UnionFinder, Fix};
 use stc_ts_types::{
@@ -1282,16 +1282,22 @@ impl Analyzer<'_, '_> {
                 let mut done = false;
                 for (_, span) in &**spans {
                     if matches!(kind, VarKind::Param | VarKind::Class) {
-                        self.storage.report(Error::DuplicateName {
-                            name: name.clone(),
-                            span: *span,
-                        });
+                        self.storage.report(
+                            ErrorKind::DuplicateName {
+                                name: name.clone(),
+                                span: *span,
+                            }
+                            .into(),
+                        );
                         done = true;
                     } else {
-                        self.storage.report(Error::DuplicateVar {
-                            name: name.clone(),
-                            span: *span,
-                        });
+                        self.storage.report(
+                            ErrorKind::DuplicateVar {
+                                name: name.clone(),
+                                span: *span,
+                            }
+                            .into(),
+                        );
                     }
                 }
 

--- a/crates/stc_ts_file_analyzer/src/analyzer/scope/vars.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/scope/vars.rs
@@ -270,7 +270,7 @@ impl Analyzer<'_, '_> {
 
                                     match result {
                                         Ok(ty) => Ok(ty.into_owned()),
-                                        Err(err) => match err.actual() {
+                                        Err(err) => match &err {
                                             ErrorKind::TupleIndexError { .. } => match elem {
                                                 RPat::Assign(p) => {
                                                     let type_ann = p.left.get_ty();
@@ -488,12 +488,12 @@ impl Analyzer<'_, '_> {
                                 }
 
                                 Err(err) => {
-                                    match err.actual() {
+                                    match &err {
                                         ErrorKind::NoSuchProperty { span, .. } | ErrorKind::NoSuchPropertyInClass { span, .. }
                                             if !should_use_no_such_property =>
                                         {
                                             if default_prop_ty.is_none() {
-                                                self.storage.report(ErrorKind::NoInitAndNoDefault { span: *span })
+                                                self.storage.report(ErrorKind::NoInitAndNoDefault { span: *span }.into())
                                             }
                                         }
                                         _ => self.storage.report(err),

--- a/crates/stc_ts_file_analyzer/src/analyzer/scope/vars.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/scope/vars.rs
@@ -270,7 +270,7 @@ impl Analyzer<'_, '_> {
 
                                     match result {
                                         Ok(ty) => Ok(ty.into_owned()),
-                                        Err(err) => match &err {
+                                        Err(err) => match &*err {
                                             ErrorKind::TupleIndexError { .. } => match elem {
                                                 RPat::Assign(p) => {
                                                     let type_ann = p.left.get_ty();
@@ -488,7 +488,7 @@ impl Analyzer<'_, '_> {
                                 }
 
                                 Err(err) => {
-                                    match &err {
+                                    match &*err {
                                         ErrorKind::NoSuchProperty { span, .. } | ErrorKind::NoSuchPropertyInClass { span, .. }
                                             if !should_use_no_such_property =>
                                         {
@@ -633,12 +633,12 @@ impl Analyzer<'_, '_> {
                                     }
                                 }
                                 Err(err) => {
-                                    match err.actual() {
+                                    match &*err {
                                         ErrorKind::NoSuchProperty { span, .. } | ErrorKind::NoSuchPropertyInClass { span, .. }
                                             if !should_use_no_such_property =>
                                         {
                                             if default_prop_ty.is_none() {
-                                                self.storage.report(ErrorKind::NoInitAndNoDefault { span: *span })
+                                                self.storage.report(ErrorKind::NoInitAndNoDefault { span: *span }.into())
                                             }
                                         }
                                         _ => self.storage.report(err),

--- a/crates/stc_ts_file_analyzer/src/analyzer/scope/vars.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/scope/vars.rs
@@ -3,7 +3,7 @@ use std::borrow::Cow;
 use itertools::Itertools;
 use rnode::{FoldWith, NodeId};
 use stc_ts_ast_rnode::{RBindingIdent, RExpr, RIdent, RNumber, RObjectPatProp, RPat, RStr, RTsEntityName, RTsLit};
-use stc_ts_errors::{debug::dump_type_as_string, DebugExt, Error};
+use stc_ts_errors::{debug::dump_type_as_string, DebugExt, ErrorKind};
 use stc_ts_type_ops::{widen::Widen, Fix};
 use stc_ts_types::{Array, Key, KeywordType, LitType, Ref, Tuple, Type, TypeLit, TypeParamInstantiation, Union};
 use stc_ts_utils::{run, PatExt};
@@ -271,7 +271,7 @@ impl Analyzer<'_, '_> {
                                     match result {
                                         Ok(ty) => Ok(ty.into_owned()),
                                         Err(err) => match err.actual() {
-                                            Error::TupleIndexError { .. } => match elem {
+                                            ErrorKind::TupleIndexError { .. } => match elem {
                                                 RPat::Assign(p) => {
                                                     let type_ann = p.left.get_ty();
                                                     let type_ann: Option<Type> =
@@ -489,11 +489,11 @@ impl Analyzer<'_, '_> {
 
                                 Err(err) => {
                                     match err.actual() {
-                                        Error::NoSuchProperty { span, .. } | Error::NoSuchPropertyInClass { span, .. }
+                                        ErrorKind::NoSuchProperty { span, .. } | ErrorKind::NoSuchPropertyInClass { span, .. }
                                             if !should_use_no_such_property =>
                                         {
                                             if default_prop_ty.is_none() {
-                                                self.storage.report(Error::NoInitAndNoDefault { span: *span })
+                                                self.storage.report(ErrorKind::NoInitAndNoDefault { span: *span })
                                             }
                                         }
                                         _ => self.storage.report(err),
@@ -634,11 +634,11 @@ impl Analyzer<'_, '_> {
                                 }
                                 Err(err) => {
                                     match err.actual() {
-                                        Error::NoSuchProperty { span, .. } | Error::NoSuchPropertyInClass { span, .. }
+                                        ErrorKind::NoSuchProperty { span, .. } | ErrorKind::NoSuchPropertyInClass { span, .. }
                                             if !should_use_no_such_property =>
                                         {
                                             if default_prop_ty.is_none() {
-                                                self.storage.report(Error::NoInitAndNoDefault { span: *span })
+                                                self.storage.report(ErrorKind::NoInitAndNoDefault { span: *span })
                                             }
                                         }
                                         _ => self.storage.report(err),

--- a/crates/stc_ts_file_analyzer/src/analyzer/stmt/loops.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/stmt/loops.rs
@@ -348,7 +348,7 @@ impl Analyzer<'_, '_> {
             let mut elem_ty = match kind {
                 ForHeadKind::Of { is_awaited: false } => child
                     .get_iterator_element_type(rhs.span(), Cow::Owned(rty), false, Default::default())
-                    .convert_err(|err| match *err {
+                    .convert_err(|err| match err {
                         ErrorKind::NotArrayType { span }
                             if match rhs {
                                 RExpr::Lit(..) => true,

--- a/crates/stc_ts_file_analyzer/src/analyzer/stmt/loops.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/stmt/loops.rs
@@ -127,7 +127,7 @@ impl Analyzer<'_, '_> {
                         match kind {
                             ForHeadKind::In => {
                                 if err.is_assign_failure() {
-                                    return ErrorKind::WrongTypeForLhsOfForInLoop { span: err.span() };
+                                    return ErrorKind::WrongTypeForLhsOfForInLoop { span: err.span() }.into();
                                 }
                             }
                             _ => {}
@@ -156,7 +156,7 @@ impl Analyzer<'_, '_> {
     fn validate_lhs_of_for_in_of_loop_pat(&mut self, p: &RPat, kind: ForHeadKind) -> VResult<()> {
         match p {
             RPat::Object(..) | RPat::Array(..) => match kind {
-                ForHeadKind::In => Err(ErrorKind::DestructuringBindingNotAllowedInLhsOfForIn { span: p.span() }),
+                ForHeadKind::In => Err(ErrorKind::DestructuringBindingNotAllowedInLhsOfForIn { span: p.span() }.into()),
                 ForHeadKind::Of { .. } => Ok(()),
             },
             RPat::Expr(e) => self.validate_lhs_of_for_in_of_loop_expr(e, kind),

--- a/crates/stc_ts_file_analyzer/src/analyzer/stmt/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/stmt/mod.rs
@@ -46,7 +46,7 @@ impl Analyzer<'_, '_> {
         let start = Instant::now();
 
         if self.rule().always_strict && !self.rule().allow_unreachable_code && self.ctx.in_unreachable {
-            self.storage.report(ErrorKind::UnreachableCode { span: s.span() });
+            self.storage.report(ErrorKind::UnreachableCode { span: s.span() }.into());
         }
 
         let old_in_conditional = self.scope.return_values.in_conditional;
@@ -122,7 +122,7 @@ impl Analyzer<'_, '_> {
 #[validator]
 impl Analyzer<'_, '_> {
     fn validate(&mut self, s: &RWithStmt) {
-        self.storage.report(ErrorKind::WithStmtNotSupported { span: s.span });
+        self.storage.report(ErrorKind::WithStmtNotSupported { span: s.span }.into());
 
         s.obj.visit_with(self);
 

--- a/crates/stc_ts_file_analyzer/src/analyzer/stmt/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/stmt/mod.rs
@@ -2,7 +2,7 @@ use std::time::Instant;
 
 use rnode::VisitWith;
 use stc_ts_ast_rnode::{RBlockStmt, RBool, RForStmt, RModuleItem, RStmt, RTsExprWithTypeArgs, RTsLit, RWithStmt};
-use stc_ts_errors::Error;
+use stc_ts_errors::ErrorKind;
 use stc_ts_types::{LitType, Type};
 use stc_utils::stack;
 use swc_common::{Spanned, DUMMY_SP};
@@ -46,7 +46,7 @@ impl Analyzer<'_, '_> {
         let start = Instant::now();
 
         if self.rule().always_strict && !self.rule().allow_unreachable_code && self.ctx.in_unreachable {
-            self.storage.report(Error::UnreachableCode { span: s.span() });
+            self.storage.report(ErrorKind::UnreachableCode { span: s.span() });
         }
 
         let old_in_conditional = self.scope.return_values.in_conditional;
@@ -122,7 +122,7 @@ impl Analyzer<'_, '_> {
 #[validator]
 impl Analyzer<'_, '_> {
     fn validate(&mut self, s: &RWithStmt) {
-        self.storage.report(Error::WithStmtNotSupported { span: s.span });
+        self.storage.report(ErrorKind::WithStmtNotSupported { span: s.span });
 
         s.obj.visit_with(self);
 

--- a/crates/stc_ts_file_analyzer/src/analyzer/stmt/return_type.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/stmt/return_type.rs
@@ -59,7 +59,7 @@ impl Analyzer<'_, '_> {
         is_async: bool,
         is_generator: bool,
         stmts: &Vec<RStmt>,
-    ) -> Result<Option<Type>, ErrorKind> {
+    ) -> VResult<Option<Type>> {
         let marks = self.marks();
 
         debug_assert_eq!(span.ctxt, SyntaxContext::empty());

--- a/crates/stc_ts_file_analyzer/src/analyzer/stmt/return_type.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/stmt/return_type.rs
@@ -482,10 +482,13 @@ impl Analyzer<'_, '_> {
                         }
                     }
                     Err(err) => {
-                        self.storage.report(ErrorKind::SimpleAssignFailed {
-                            span,
-                            cause: Some(box err),
-                        });
+                        self.storage.report(
+                            ErrorKind::SimpleAssignFailed {
+                                span,
+                                cause: Some(box err),
+                            }
+                            .into(),
+                        );
                         return Ok(Type::any(span, Default::default()));
                     }
                 }

--- a/crates/stc_ts_file_analyzer/src/analyzer/stmt/return_type.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/stmt/return_type.rs
@@ -2,7 +2,7 @@ use std::{borrow::Cow, mem::take, ops::AddAssign};
 
 use rnode::{Fold, FoldWith, Visit, VisitWith};
 use stc_ts_ast_rnode::{RBreakStmt, RIdent, RReturnStmt, RStmt, RStr, RThrowStmt, RTsEntityName, RTsLit, RYieldExpr};
-use stc_ts_errors::{DebugExt, Error};
+use stc_ts_errors::{DebugExt, ErrorKind};
 use stc_ts_simple_ast_validations::yield_check::YieldValueUsageFinder;
 use stc_ts_types::{
     CommonTypeMetadata, IndexedAccessType, Key, KeywordType, KeywordTypeMetadata, LitType, MethodSignature, Operator, PropertySignature,
@@ -59,7 +59,7 @@ impl Analyzer<'_, '_> {
         is_async: bool,
         is_generator: bool,
         stmts: &Vec<RStmt>,
-    ) -> Result<Option<Type>, Error> {
+    ) -> Result<Option<Type>, ErrorKind> {
         let marks = self.marks();
 
         debug_assert_eq!(span.ctxt, SyntaxContext::empty());
@@ -482,7 +482,7 @@ impl Analyzer<'_, '_> {
                         }
                     }
                     Err(err) => {
-                        self.storage.report(Error::SimpleAssignFailed {
+                        self.storage.report(ErrorKind::SimpleAssignFailed {
                             span,
                             cause: Some(box err),
                         });

--- a/crates/stc_ts_file_analyzer/src/analyzer/stmt/var_decl.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/stmt/var_decl.rs
@@ -4,7 +4,7 @@ use rnode::{FoldWith, Visit, VisitWith};
 use stc_ts_ast_rnode::{
     RArrayPat, RCallExpr, RCallee, RExpr, RIdent, RPat, RTsAsExpr, RTsEntityName, RTsTypeAssertion, RVarDecl, RVarDeclarator,
 };
-use stc_ts_errors::{debug::dump_type_as_string, DebugExt, Error, Errors};
+use stc_ts_errors::{debug::dump_type_as_string, DebugExt, ErrorKind, Errors};
 use stc_ts_type_ops::{generalization::prevent_generalize, Fix};
 use stc_ts_types::{
     Array, EnumVariant, Id, Instance, InstanceMetadata, KeywordType, KeywordTypeMetadata, Operator, OperatorMetadata, QueryExpr, QueryType,
@@ -596,12 +596,12 @@ impl Analyzer<'_, '_> {
                                         match v.name {
                                             RPat::Ident(ref i) => {
                                                 let span = i.id.span;
-                                                type_errors.push(Error::ImplicitAny { span }.context("tuple type widenning"));
+                                                type_errors.push(ErrorKind::ImplicitAny { span }.context("tuple type widenning"));
                                                 break;
                                             }
                                             RPat::Array(RArrayPat { ref elems, .. }) => {
                                                 let span = elems[i].span();
-                                                type_errors.push(Error::ImplicitAny { span }.context("tuple type widenning"));
+                                                type_errors.push(ErrorKind::ImplicitAny { span }.context("tuple type widenning"));
                                             }
                                             _ => {}
                                         }

--- a/crates/stc_ts_file_analyzer/src/analyzer/types/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/types/mod.rs
@@ -1671,7 +1671,8 @@ impl Analyzer<'_, '_> {
                     name: box name.into(),
                     ctxt: self.ctx.module_id,
                     type_args: type_args.cloned().map(Box::new),
-                })
+                }
+                .into())
             }
             RExpr::Ident(i) if &*i.sym == "globalThis" => return Ok(()),
             RExpr::Ident(_) => Err(ErrorKind::TypeNotFound {
@@ -1679,7 +1680,8 @@ impl Analyzer<'_, '_> {
                 name: box name.into(),
                 ctxt: self.ctx.module_id,
                 type_args: type_args.cloned().map(Box::new),
-            }),
+            }
+            .into()),
             _ => Ok(()),
         }
     }

--- a/crates/stc_ts_file_analyzer/src/analyzer/types/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/types/mod.rs
@@ -7,7 +7,7 @@ use stc_ts_ast_rnode::{RExpr, RIdent, RInvalid, RNumber, RStr, RTplElement, RTsE
 use stc_ts_base_type_ops::bindings::{collect_bindings, BindingCollector, KnownTypeVisitor};
 use stc_ts_errors::{
     debug::{dump_type_as_string, print_backtrace},
-    DebugExt, Error,
+    DebugExt, ErrorKind,
 };
 use stc_ts_generics::ExpandGenericOpts;
 use stc_ts_type_ops::{tuple_normalization::TupleNormalizer, Fix};
@@ -867,10 +867,10 @@ impl Analyzer<'_, '_> {
         }
 
         if ty.is_kwd(TsKeywordTypeKind::TsUndefinedKeyword) || ty.is_kwd(TsKeywordTypeKind::TsVoidKeyword) {
-            return Err(Error::ObjectIsPossiblyUndefined { span });
+            return Err(ErrorKind::ObjectIsPossiblyUndefined { span });
         }
         if ty.is_kwd(TsKeywordTypeKind::TsNullKeyword) {
-            return Err(Error::ObjectIsPossiblyNull { span });
+            return Err(ErrorKind::ObjectIsPossiblyNull { span });
         }
 
         match &*ty {
@@ -893,15 +893,15 @@ impl Analyzer<'_, '_> {
 
                 // tsc is crazy. It uses different error code for these errors.
                 if has_null && has_undefined {
-                    return Err(Error::ObjectIsPossiblyNullOrUndefined { span });
+                    return Err(ErrorKind::ObjectIsPossiblyNullOrUndefined { span });
                 }
 
                 if has_null {
-                    return Err(Error::ObjectIsPossiblyNull { span });
+                    return Err(ErrorKind::ObjectIsPossiblyNull { span });
                 }
 
                 if has_undefined {
-                    return Err(Error::ObjectIsPossiblyUndefined { span });
+                    return Err(ErrorKind::ObjectIsPossiblyUndefined { span });
                 }
 
                 Ok(())
@@ -910,7 +910,7 @@ impl Analyzer<'_, '_> {
                 if !self.rule().strict_null_checks {
                     return Ok(());
                 }
-                Err(Error::ObjectIsPossiblyUndefinedWithType {
+                Err(ErrorKind::ObjectIsPossiblyUndefinedWithType {
                     span,
                     ty: box ty.into_owned(),
                 })
@@ -1666,7 +1666,7 @@ impl Analyzer<'_, '_> {
                     }
                 }
 
-                Err(Error::NamspaceNotFound {
+                Err(ErrorKind::NamspaceNotFound {
                     span,
                     name: box name.into(),
                     ctxt: self.ctx.module_id,
@@ -1674,7 +1674,7 @@ impl Analyzer<'_, '_> {
                 })
             }
             RExpr::Ident(i) if &*i.sym == "globalThis" => return Ok(()),
-            RExpr::Ident(_) => Err(Error::TypeNotFound {
+            RExpr::Ident(_) => Err(ErrorKind::TypeNotFound {
                 span,
                 name: box name.into(),
                 ctxt: self.ctx.module_id,

--- a/crates/stc_ts_file_analyzer/src/analyzer/types/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/types/mod.rs
@@ -913,7 +913,8 @@ impl Analyzer<'_, '_> {
                 Err(ErrorKind::ObjectIsPossiblyUndefinedWithType {
                     span,
                     ty: box ty.into_owned(),
-                })
+                }
+                .into())
             }
         }
     }

--- a/crates/stc_ts_file_analyzer/src/analyzer/types/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/types/mod.rs
@@ -867,10 +867,10 @@ impl Analyzer<'_, '_> {
         }
 
         if ty.is_kwd(TsKeywordTypeKind::TsUndefinedKeyword) || ty.is_kwd(TsKeywordTypeKind::TsVoidKeyword) {
-            return Err(ErrorKind::ObjectIsPossiblyUndefined { span });
+            return Err(ErrorKind::ObjectIsPossiblyUndefined { span }.into());
         }
         if ty.is_kwd(TsKeywordTypeKind::TsNullKeyword) {
-            return Err(ErrorKind::ObjectIsPossiblyNull { span });
+            return Err(ErrorKind::ObjectIsPossiblyNull { span }.into());
         }
 
         match &*ty {
@@ -893,15 +893,15 @@ impl Analyzer<'_, '_> {
 
                 // tsc is crazy. It uses different error code for these errors.
                 if has_null && has_undefined {
-                    return Err(ErrorKind::ObjectIsPossiblyNullOrUndefined { span });
+                    return Err(ErrorKind::ObjectIsPossiblyNullOrUndefined { span }.into());
                 }
 
                 if has_null {
-                    return Err(ErrorKind::ObjectIsPossiblyNull { span });
+                    return Err(ErrorKind::ObjectIsPossiblyNull { span }.into());
                 }
 
                 if has_undefined {
-                    return Err(ErrorKind::ObjectIsPossiblyUndefined { span });
+                    return Err(ErrorKind::ObjectIsPossiblyUndefined { span }.into());
                 }
 
                 Ok(())

--- a/crates/stc_ts_file_analyzer/src/analyzer/util.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/util.rs
@@ -2,7 +2,7 @@ use std::{borrow::Cow, iter::once};
 
 use rnode::{Fold, FoldWith, Visit};
 use stc_ts_ast_rnode::{RExpr, RIdent, RPropName, RStr, RTsEntityName, RTsType};
-use stc_ts_errors::ErrorKind;
+use stc_ts_errors::{Error, ErrorKind};
 use stc_ts_storage::Storage;
 use stc_ts_type_ops::{is_str_lit_or_union, Fix};
 use stc_ts_types::{
@@ -288,10 +288,10 @@ impl Analyzer<'_, '_> {
     //    }
 }
 
-pub trait ResultExt<T>: Into<Result<T, ErrorKind>> {
+pub trait ResultExt<T>: Into<Result<T, Error>> {
     fn store<V>(self, to: &mut V) -> Option<T>
     where
-        V: Extend<ErrorKind>,
+        V: Extend<Error>,
     {
         match self.into() {
             Ok(val) => Some(val),
@@ -313,7 +313,7 @@ pub trait ResultExt<T>: Into<Result<T, ErrorKind>> {
     }
 }
 
-impl<T> ResultExt<T> for Result<T, ErrorKind> {}
+impl<T> ResultExt<T> for Result<T, Error> {}
 
 /// Simple utility to check (l, r) and (r, l) with same code.
 #[derive(Debug, Clone, Copy)]

--- a/crates/stc_ts_file_analyzer/src/analyzer/util.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/util.rs
@@ -58,7 +58,8 @@ impl Analyzer<'_, '_> {
         Err(ErrorKind::NoNewSignature {
             span,
             callee: box callee.clone(),
-        })
+        }
+        .into())
     }
 
     /// Make instance of `ty`. In case of error, error will be reported to user
@@ -76,7 +77,7 @@ impl Analyzer<'_, '_> {
         match res {
             Ok(ty) => ty,
             Err(err) => {
-                match err.actual() {
+                match &*err {
                     ErrorKind::NoNewSignature { .. } => {}
                     _ => {
                         self.storage.report(err);
@@ -161,7 +162,8 @@ impl Analyzer<'_, '_> {
         Err(ErrorKind::NoNewSignature {
             span,
             callee: box ty.clone(),
-        })
+        }
+        .into())
     }
 }
 

--- a/crates/stc_ts_file_analyzer/src/analyzer/util.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/util.rs
@@ -2,7 +2,7 @@ use std::{borrow::Cow, iter::once};
 
 use rnode::{Fold, FoldWith, Visit};
 use stc_ts_ast_rnode::{RExpr, RIdent, RPropName, RStr, RTsEntityName, RTsType};
-use stc_ts_errors::Error;
+use stc_ts_errors::ErrorKind;
 use stc_ts_storage::Storage;
 use stc_ts_type_ops::{is_str_lit_or_union, Fix};
 use stc_ts_types::{
@@ -55,7 +55,7 @@ impl Analyzer<'_, '_> {
             }
         }
 
-        Err(Error::NoNewSignature {
+        Err(ErrorKind::NoNewSignature {
             span,
             callee: box callee.clone(),
         })
@@ -77,7 +77,7 @@ impl Analyzer<'_, '_> {
             Ok(ty) => ty,
             Err(err) => {
                 match err.actual() {
-                    Error::NoNewSignature { .. } => {}
+                    ErrorKind::NoNewSignature { .. } => {}
                     _ => {
                         self.storage.report(err);
                     }
@@ -158,7 +158,7 @@ impl Analyzer<'_, '_> {
             _ => {}
         }
 
-        Err(Error::NoNewSignature {
+        Err(ErrorKind::NoNewSignature {
             span,
             callee: box ty.clone(),
         })
@@ -288,10 +288,10 @@ impl Analyzer<'_, '_> {
     //    }
 }
 
-pub trait ResultExt<T>: Into<Result<T, Error>> {
+pub trait ResultExt<T>: Into<Result<T, ErrorKind>> {
     fn store<V>(self, to: &mut V) -> Option<T>
     where
-        V: Extend<Error>,
+        V: Extend<ErrorKind>,
     {
         match self.into() {
             Ok(val) => Some(val),
@@ -313,7 +313,7 @@ pub trait ResultExt<T>: Into<Result<T, Error>> {
     }
 }
 
-impl<T> ResultExt<T> for Result<T, Error> {}
+impl<T> ResultExt<T> for Result<T, ErrorKind> {}
 
 /// Simple utility to check (l, r) and (r, l) with same code.
 #[derive(Debug, Clone, Copy)]

--- a/crates/stc_ts_file_analyzer/src/lib.rs
+++ b/crates/stc_ts_file_analyzer/src/lib.rs
@@ -34,7 +34,7 @@ pub mod util;
 pub mod validator;
 
 /// Validation result
-pub type VResult<T> = Result<T, ErrorKind>;
+pub type VResult<T> = Result<T, Error>;
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct DepInfo {

--- a/crates/stc_ts_file_analyzer/src/lib.rs
+++ b/crates/stc_ts_file_analyzer/src/lib.rs
@@ -17,7 +17,7 @@
 use std::path::PathBuf;
 
 use stc_ts_env::StableEnv;
-use stc_ts_errors::ErrorKind;
+use stc_ts_errors::Error;
 use stc_ts_file_analyzer_macros::validator;
 pub use stc_ts_types::{Id, ModuleTypeData};
 use swc_atoms::JsWord;

--- a/crates/stc_ts_file_analyzer/src/lib.rs
+++ b/crates/stc_ts_file_analyzer/src/lib.rs
@@ -17,7 +17,7 @@
 use std::path::PathBuf;
 
 use stc_ts_env::StableEnv;
-use stc_ts_errors::Error;
+use stc_ts_errors::ErrorKind;
 use stc_ts_file_analyzer_macros::validator;
 pub use stc_ts_types::{Id, ModuleTypeData};
 use swc_atoms::JsWord;
@@ -34,7 +34,7 @@ pub mod util;
 pub mod validator;
 
 /// Validation result
-pub type VResult<T> = Result<T, Error>;
+pub type VResult<T> = Result<T, ErrorKind>;
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct DepInfo {

--- a/crates/stc_ts_file_analyzer/tests/base.rs
+++ b/crates/stc_ts_file_analyzer/tests/base.rs
@@ -12,7 +12,7 @@ use stc_testing::logger;
 use stc_ts_ast_rnode::RModule;
 use stc_ts_builtin_types::Lib;
 use stc_ts_env::{Env, ModuleConfig, Rule};
-use stc_ts_errors::{debug::debugger::Debugger, Error};
+use stc_ts_errors::{debug::debugger::Debugger, ErrorKind};
 use stc_ts_file_analyzer::{
     analyzer::{Analyzer, NoopLoader},
     env::EnvFactory,
@@ -104,7 +104,7 @@ fn validate(input: &Path) -> Vec<StcError> {
                 module.visit_with(&mut analyzer);
             }
 
-            let errors = ::stc_ts_errors::Error::flatten(storage.info.errors.into_iter().collect());
+            let errors = ::stc_ts_errors::ErrorKind::flatten(storage.info.errors.into_iter().collect());
 
             GLOBALS.set(env.shared().swc_globals(), || {
                 for e in errors {
@@ -193,7 +193,7 @@ fn errors(input: PathBuf) {
             module.visit_with(&mut analyzer);
         }
 
-        let errors = ::stc_ts_errors::Error::flatten(storage.info.errors.into_iter().collect());
+        let errors = ::stc_ts_errors::ErrorKind::flatten(storage.info.errors.into_iter().collect());
 
         if errors.is_empty() {
             panic!("Should emit at least one error")
@@ -261,7 +261,7 @@ fn pass_only(input: PathBuf) {
             module.visit_with(&mut analyzer);
         }
 
-        let errors = ::stc_ts_errors::Error::flatten(storage.info.errors.into_iter().collect());
+        let errors = ::stc_ts_errors::ErrorKind::flatten(storage.info.errors.into_iter().collect());
         let ok = errors.is_empty();
 
         GLOBALS.set(env.shared().swc_globals(), || {
@@ -442,7 +442,7 @@ fn run_test(file_name: PathBuf, for_error: bool) -> Option<NormalizedOutput> {
 
             if for_error {
                 let errors = storage.take_errors();
-                let errors = Error::flatten(errors.into());
+                let errors = ErrorKind::flatten(errors.into());
 
                 for err in errors {
                     err.emit(&handler);

--- a/crates/stc_ts_file_analyzer_macros/src/lib.rs
+++ b/crates/stc_ts_file_analyzer_macros/src/lib.rs
@@ -104,7 +104,7 @@ pub fn extra_validator(_: proc_macro::TokenStream, item: proc_macro::TokenStream
             Quote::new_call_site()
                 .quote_with(smart_quote!(Vars { try_block: &try_block }, {
                     {
-                        let res: Result<_, Error> = try_block;
+                        let res: Result<_, stc_ts_errors::Error> = try_block;
 
                         match res {
                             Err(err) => {

--- a/crates/stc_ts_file_analyzer_macros/src/lib.rs
+++ b/crates/stc_ts_file_analyzer_macros/src/lib.rs
@@ -88,7 +88,7 @@ pub fn extra_validator(_: proc_macro::TokenStream, item: proc_macro::TokenStream
             Quote::new_call_site()
                 .quote_with(smart_quote!(Vars { try_block: &try_block }, {
                     {
-                        let res: Result<_, Error> = try_block;
+                        let res: Result<_, stc_ts_errors::Error> = try_block;
 
                         match res {
                             Ok(v) => Ok(v),

--- a/crates/stc_ts_passes/src/pass/mod.rs
+++ b/crates/stc_ts_passes/src/pass/mod.rs
@@ -1,9 +1,9 @@
 use rnode::Visit;
 use stc_ts_ast_rnode::{RModule, RProgram, RScript};
-use stc_ts_errors::Error;
+use stc_ts_errors::ErrorKind;
 
 pub trait Pass: Visit<RModule> + Visit<RScript> + Visit<RProgram> {
     fn name() -> &'static str;
 
-    fn take_errors(&mut self) -> Vec<Error>;
+    fn take_errors(&mut self) -> Vec<ErrorKind>;
 }

--- a/crates/stc_ts_simple_ast_validations/src/ambient_fn.rs
+++ b/crates/stc_ts_simple_ast_validations/src/ambient_fn.rs
@@ -1,6 +1,6 @@
 use rnode::{Visit, VisitWith};
 use stc_ts_ast_rnode::{RDecl, RFnDecl, RIdent, RStmt, RTsModuleDecl, RTsNamespaceDecl};
-use stc_ts_errors::Error;
+use stc_ts_errors::ErrorKind;
 use stc_ts_storage::Storage;
 
 /// Handles
@@ -19,7 +19,7 @@ pub struct AmbientFunctionHandler<'a, 'b> {
 impl AmbientFunctionHandler<'_, '_> {
     pub fn handle_missing_impl(&mut self) {
         if let Some(id) = self.last_ambient_name.take() {
-            self.errors.report(Error::FnImplMissingOrNotFollowedByDecl { span: id.span })
+            self.errors.report(ErrorKind::FnImplMissingOrNotFollowedByDecl { span: id.span })
         }
     }
 }
@@ -46,7 +46,7 @@ impl Visit<RFnDecl> for AmbientFunctionHandler<'_, '_> {
         if node.function.body.is_none() {
             if let Some(ref name) = self.last_ambient_name {
                 if node.ident.sym != name.sym {
-                    self.errors.report(Error::FnImplMissingOrNotFollowedByDecl { span: name.span });
+                    self.errors.report(ErrorKind::FnImplMissingOrNotFollowedByDecl { span: name.span });
                 }
             }
             self.last_ambient_name = Some(node.ident.clone());
@@ -55,7 +55,7 @@ impl Visit<RFnDecl> for AmbientFunctionHandler<'_, '_> {
                 if node.ident.sym == name.sym {
                     self.last_ambient_name = None;
                 } else {
-                    self.errors.report(Error::TS2389 { span: node.ident.span });
+                    self.errors.report(ErrorKind::TS2389 { span: node.ident.span });
                     self.last_ambient_name = None;
                 }
             }

--- a/crates/stc_ts_simple_ast_validations/src/ambient_fn.rs
+++ b/crates/stc_ts_simple_ast_validations/src/ambient_fn.rs
@@ -19,7 +19,8 @@ pub struct AmbientFunctionHandler<'a, 'b> {
 impl AmbientFunctionHandler<'_, '_> {
     pub fn handle_missing_impl(&mut self) {
         if let Some(id) = self.last_ambient_name.take() {
-            self.errors.report(ErrorKind::FnImplMissingOrNotFollowedByDecl { span: id.span })
+            self.errors
+                .report(ErrorKind::FnImplMissingOrNotFollowedByDecl { span: id.span }.into())
         }
     }
 }
@@ -46,7 +47,8 @@ impl Visit<RFnDecl> for AmbientFunctionHandler<'_, '_> {
         if node.function.body.is_none() {
             if let Some(ref name) = self.last_ambient_name {
                 if node.ident.sym != name.sym {
-                    self.errors.report(ErrorKind::FnImplMissingOrNotFollowedByDecl { span: name.span });
+                    self.errors
+                        .report(ErrorKind::FnImplMissingOrNotFollowedByDecl { span: name.span }.into());
                 }
             }
             self.last_ambient_name = Some(node.ident.clone());
@@ -55,7 +57,7 @@ impl Visit<RFnDecl> for AmbientFunctionHandler<'_, '_> {
                 if node.ident.sym == name.sym {
                     self.last_ambient_name = None;
                 } else {
-                    self.errors.report(ErrorKind::TS2389 { span: node.ident.span });
+                    self.errors.report(ErrorKind::TS2389 { span: node.ident.span }.into());
                     self.last_ambient_name = None;
                 }
             }

--- a/crates/stc_ts_storage/src/lib.rs
+++ b/crates/stc_ts_storage/src/lib.rs
@@ -4,7 +4,7 @@ use std::{collections::hash_map::Entry, mem::take, sync::Arc};
 
 use auto_impl::auto_impl;
 use fxhash::FxHashMap;
-use stc_ts_errors::{Error, Errors};
+use stc_ts_errors::{ErrorKind, Errors};
 use stc_ts_types::{Id, ModuleId, ModuleTypeData, Type};
 use stc_utils::cache::Freeze;
 use swc_atoms::JsWord;
@@ -20,7 +20,7 @@ pub type Storage<'b> = Box<dyn 'b + Mode>;
 
 #[auto_impl(&mut, Box)]
 pub trait ErrorStore {
-    fn report(&mut self, err: Error);
+    fn report(&mut self, err: ErrorKind);
     fn report_all(&mut self, err: Errors);
     fn take_errors(&mut self) -> Errors;
 }
@@ -74,7 +74,7 @@ pub struct Single<'a> {
 }
 
 impl ErrorStore for Single<'_> {
-    fn report(&mut self, err: Error) {
+    fn report(&mut self, err: ErrorKind) {
         self.info.errors.push(err.attach_context());
     }
 
@@ -134,7 +134,7 @@ impl TypeStore for Single<'_> {
             },
             None => {
                 dbg!();
-                self.report(Error::NoSuchVar { span, name: id })
+                self.report(ErrorKind::NoSuchVar { span, name: id })
             }
         }
     }
@@ -148,7 +148,7 @@ impl TypeStore for Single<'_> {
             }
             None => {
                 dbg!();
-                self.report(Error::NoSuchVar { span, name: id })
+                self.report(ErrorKind::NoSuchVar { span, name: id })
             }
         }
     }
@@ -239,7 +239,7 @@ pub struct Group<'a> {
 }
 
 impl ErrorStore for Group<'_> {
-    fn report(&mut self, err: Error) {
+    fn report(&mut self, err: ErrorKind) {
         self.errors.push(err.attach_context());
     }
 
@@ -287,7 +287,7 @@ impl TypeStore for Group<'_> {
             }
             None => {
                 dbg!();
-                self.report(Error::NoSuchVar { span, name: id })
+                self.report(ErrorKind::NoSuchVar { span, name: id })
             }
         }
     }
@@ -298,7 +298,7 @@ impl TypeStore for Group<'_> {
             Some(v) => {
                 e.types.insert(id.sym().clone(), v.clone());
             }
-            None => self.report(Error::NoSuchType { span, name: id }),
+            None => self.report(ErrorKind::NoSuchType { span, name: id }),
         }
     }
 
@@ -385,7 +385,7 @@ pub struct Builtin {
 }
 
 impl ErrorStore for Builtin {
-    fn report(&mut self, err: Error) {
+    fn report(&mut self, err: ErrorKind) {
         unreachable!("builtin error: {:?}", err);
     }
 

--- a/crates/stc_ts_storage/src/lib.rs
+++ b/crates/stc_ts_storage/src/lib.rs
@@ -4,7 +4,7 @@ use std::{collections::hash_map::Entry, mem::take, sync::Arc};
 
 use auto_impl::auto_impl;
 use fxhash::FxHashMap;
-use stc_ts_errors::{ErrorKind, Errors};
+use stc_ts_errors::{Error, Errors};
 use stc_ts_types::{Id, ModuleId, ModuleTypeData, Type};
 use stc_utils::cache::Freeze;
 use swc_atoms::JsWord;
@@ -20,7 +20,7 @@ pub type Storage<'b> = Box<dyn 'b + Mode>;
 
 #[auto_impl(&mut, Box)]
 pub trait ErrorStore {
-    fn report(&mut self, err: ErrorKind);
+    fn report(&mut self, err: Error);
     fn report_all(&mut self, err: Errors);
     fn take_errors(&mut self) -> Errors;
 }
@@ -74,12 +74,12 @@ pub struct Single<'a> {
 }
 
 impl ErrorStore for Single<'_> {
-    fn report(&mut self, err: ErrorKind) {
-        self.info.errors.push(err.attach_context());
+    fn report(&mut self, err: Error) {
+        self.info.errors.push(err);
     }
 
     fn report_all(&mut self, err: Errors) {
-        self.info.errors.extend(err.into_iter().map(|err| err.attach_context()));
+        self.info.errors.extend(err);
     }
 
     fn take_errors(&mut self) -> Errors {
@@ -134,7 +134,7 @@ impl TypeStore for Single<'_> {
             },
             None => {
                 dbg!();
-                self.report(ErrorKind::NoSuchVar { span, name: id })
+                self.report(Error::NoSuchVar { span, name: id })
             }
         }
     }
@@ -148,7 +148,7 @@ impl TypeStore for Single<'_> {
             }
             None => {
                 dbg!();
-                self.report(ErrorKind::NoSuchVar { span, name: id })
+                self.report(Error::NoSuchVar { span, name: id })
             }
         }
     }
@@ -239,7 +239,7 @@ pub struct Group<'a> {
 }
 
 impl ErrorStore for Group<'_> {
-    fn report(&mut self, err: ErrorKind) {
+    fn report(&mut self, err: Error) {
         self.errors.push(err.attach_context());
     }
 
@@ -287,7 +287,7 @@ impl TypeStore for Group<'_> {
             }
             None => {
                 dbg!();
-                self.report(ErrorKind::NoSuchVar { span, name: id })
+                self.report(Error::NoSuchVar { span, name: id })
             }
         }
     }
@@ -298,7 +298,7 @@ impl TypeStore for Group<'_> {
             Some(v) => {
                 e.types.insert(id.sym().clone(), v.clone());
             }
-            None => self.report(ErrorKind::NoSuchType { span, name: id }),
+            None => self.report(Error::NoSuchType { span, name: id }),
         }
     }
 
@@ -385,7 +385,7 @@ pub struct Builtin {
 }
 
 impl ErrorStore for Builtin {
-    fn report(&mut self, err: ErrorKind) {
+    fn report(&mut self, err: Error) {
         unreachable!("builtin error: {:?}", err);
     }
 

--- a/crates/stc_ts_storage/src/lib.rs
+++ b/crates/stc_ts_storage/src/lib.rs
@@ -4,7 +4,7 @@ use std::{collections::hash_map::Entry, mem::take, sync::Arc};
 
 use auto_impl::auto_impl;
 use fxhash::FxHashMap;
-use stc_ts_errors::{Error, Errors};
+use stc_ts_errors::{Error, ErrorKind, Errors};
 use stc_ts_types::{Id, ModuleId, ModuleTypeData, Type};
 use stc_utils::cache::Freeze;
 use swc_atoms::JsWord;
@@ -132,10 +132,7 @@ impl TypeStore for Single<'_> {
                 Some(..) => {}
                 None => {}
             },
-            None => {
-                dbg!();
-                self.report(Error::NoSuchVar { span, name: id })
-            }
+            None => self.report(ErrorKind::NoSuchVar { span, name: id }.into()),
         }
     }
 
@@ -146,10 +143,7 @@ impl TypeStore for Single<'_> {
             Some(ty) => {
                 *self.info.exports.types.entry(id.sym().clone()).or_default() = ty.clone();
             }
-            None => {
-                dbg!();
-                self.report(Error::NoSuchVar { span, name: id })
-            }
+            None => self.report(ErrorKind::NoSuchVar { span, name: id }.into()),
         }
     }
 
@@ -240,11 +234,11 @@ pub struct Group<'a> {
 
 impl ErrorStore for Group<'_> {
     fn report(&mut self, err: Error) {
-        self.errors.push(err.attach_context());
+        self.errors.push(err);
     }
 
     fn report_all(&mut self, err: Errors) {
-        self.errors.extend(err.into_iter().map(|err| err.attach_context()));
+        self.errors.extend(err);
     }
 
     fn take_errors(&mut self) -> Errors {
@@ -287,7 +281,7 @@ impl TypeStore for Group<'_> {
             }
             None => {
                 dbg!();
-                self.report(Error::NoSuchVar { span, name: id })
+                self.report(ErrorKind::NoSuchVar { span, name: id }.into())
             }
         }
     }
@@ -298,7 +292,7 @@ impl TypeStore for Group<'_> {
             Some(v) => {
                 e.types.insert(id.sym().clone(), v.clone());
             }
-            None => self.report(Error::NoSuchType { span, name: id }),
+            None => self.report(ErrorKind::NoSuchType { span, name: id }.into()),
         }
     }
 

--- a/crates/stc_ts_type_checker/src/lib.rs
+++ b/crates/stc_ts_type_checker/src/lib.rs
@@ -11,7 +11,7 @@ use rnode::{NodeIdGenerator, RNode, VisitWith};
 use stc_ts_ast_rnode::{RModule, RStr, RTsModuleName};
 use stc_ts_dts::{apply_mutations, cleanup_module_for_dts};
 use stc_ts_env::Env;
-use stc_ts_errors::{debug::debugger::Debugger, ErrorKind};
+use stc_ts_errors::{debug::debugger::Debugger, Error, ErrorKind};
 use stc_ts_file_analyzer::{analyzer::Analyzer, loader::Load, validator::ValidateWith, ModuleTypeData, VResult};
 use stc_ts_module_loader::ModuleGraph;
 use stc_ts_storage::{ErrorStore, File, Group, Single};
@@ -46,7 +46,7 @@ pub struct Checker {
     /// Modules which are being processed or analyzed.
     started: Arc<DashSet<ModuleId, FxBuildHasher>>,
 
-    errors: Mutex<Vec<ErrorKind>>,
+    errors: Mutex<Vec<Error>>,
 
     env: Env,
 
@@ -127,7 +127,7 @@ impl Checker {
         })
     }
 
-    pub fn take_errors(&mut self) -> Vec<ErrorKind> {
+    pub fn take_errors(&mut self) -> Vec<Error> {
         take(self.errors.get_mut())
     }
 

--- a/crates/stc_ts_type_checker/src/lib.rs
+++ b/crates/stc_ts_type_checker/src/lib.rs
@@ -11,7 +11,7 @@ use rnode::{NodeIdGenerator, RNode, VisitWith};
 use stc_ts_ast_rnode::{RModule, RStr, RTsModuleName};
 use stc_ts_dts::{apply_mutations, cleanup_module_for_dts};
 use stc_ts_env::Env;
-use stc_ts_errors::{debug::debugger::Debugger, Error};
+use stc_ts_errors::{debug::debugger::Debugger, ErrorKind};
 use stc_ts_file_analyzer::{analyzer::Analyzer, loader::Load, validator::ValidateWith, ModuleTypeData, VResult};
 use stc_ts_module_loader::ModuleGraph;
 use stc_ts_storage::{ErrorStore, File, Group, Single};
@@ -46,7 +46,7 @@ pub struct Checker {
     /// Modules which are being processed or analyzed.
     started: Arc<DashSet<ModuleId, FxBuildHasher>>,
 
-    errors: Mutex<Vec<Error>>,
+    errors: Mutex<Vec<ErrorKind>>,
 
     env: Env,
 
@@ -127,7 +127,7 @@ impl Checker {
         })
     }
 
-    pub fn take_errors(&mut self) -> Vec<Error> {
+    pub fn take_errors(&mut self) -> Vec<ErrorKind> {
         take(self.errors.get_mut())
     }
 

--- a/crates/stc_ts_type_checker/tests/conformance.pass.txt
+++ b/crates/stc_ts_type_checker/tests/conformance.pass.txt
@@ -344,7 +344,6 @@ es6/Symbols/symbolProperty20.ts
 es6/Symbols/symbolProperty21.ts
 es6/Symbols/symbolProperty22.ts
 es6/Symbols/symbolProperty23.ts
-es6/Symbols/symbolProperty25.ts
 es6/Symbols/symbolProperty26.ts
 es6/Symbols/symbolProperty27.ts
 es6/Symbols/symbolProperty28.ts

--- a/crates/stc_ts_type_checker/tests/conformance/controlFlow/controlFlowOptionalChain.ts.stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/conformance/controlFlow/controlFlowOptionalChain.ts.stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
-    required_error: 61,
-    matched_error: 0,
-    extra_error: 0,
-    panic: 1,
+    required_error: 19,
+    matched_error: 42,
+    extra_error: 76,
+    panic: 0,
 }

--- a/crates/stc_ts_type_checker/tests/conformance/es6/Symbols/symbolProperty25.ts.stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/conformance/es6/Symbols/symbolProperty25.ts.stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
-    required_error: 0,
-    matched_error: 1,
-    extra_error: 0,
+    required_error: 1,
+    matched_error: 0,
+    extra_error: 1,
     panic: 0,
 }

--- a/crates/stc_ts_type_checker/tests/conformance/interfaces/interfacesExtendingClasses/implementingAnInterfaceExtendingClassWithPrivates.ts.stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/conformance/interfaces/interfacesExtendingClasses/implementingAnInterfaceExtendingClassWithPrivates.ts.stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
-    required_error: 1,
-    matched_error: 3,
-    extra_error: 0,
+    required_error: 2,
+    matched_error: 2,
+    extra_error: 1,
     panic: 0,
 }

--- a/crates/stc_ts_type_checker/tests/conformance/interfaces/interfacesExtendingClasses/implementingAnInterfaceExtendingClassWithProtecteds.ts.stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/conformance/interfaces/interfacesExtendingClasses/implementingAnInterfaceExtendingClassWithProtecteds.ts.stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
-    required_error: 3,
-    matched_error: 3,
-    extra_error: 0,
+    required_error: 5,
+    matched_error: 1,
+    extra_error: 2,
     panic: 0,
 }

--- a/crates/stc_ts_type_checker/tests/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithObjectMembers5.ts.stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithObjectMembers5.ts.stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
-    required_error: 3,
-    matched_error: 3,
-    extra_error: 0,
+    required_error: 6,
+    matched_error: 0,
+    extra_error: 3,
     panic: 0,
 }

--- a/crates/stc_ts_type_checker/tests/dts.rs
+++ b/crates/stc_ts_type_checker/tests/dts.rs
@@ -84,7 +84,7 @@ fn do_test(file_name: &Path) -> Result<(), StdErr> {
 
         let id = checker.check(Arc::new(file_name.clone().into()));
 
-        let errors = ::stc_ts_errors::Error::flatten(checker.take_errors());
+        let errors = ::stc_ts_errors::ErrorKind::flatten(checker.take_errors());
 
         let expected_module = {
             let mut buf = vec![];

--- a/crates/stc_ts_type_checker/tests/error.rs
+++ b/crates/stc_ts_type_checker/tests/error.rs
@@ -66,7 +66,7 @@ fn do_test(file_name: &Path) -> Result<(), StdErr> {
             Arc::new(NodeResolver),
         );
         checker.check(Arc::new(FileName::Real(file_name.into())));
-        let errors = ::stc_ts_errors::Error::flatten(checker.take_errors());
+        let errors = ::stc_ts_errors::ErrorKind::flatten(checker.take_errors());
 
         checker.run(|| {
             for e in errors {

--- a/crates/stc_ts_type_checker/tests/pass.rs
+++ b/crates/stc_ts_type_checker/tests/pass.rs
@@ -66,7 +66,7 @@ fn do_test(file_name: &Path) -> Result<(), StdErr> {
         );
         checker.check(Arc::new(FileName::Real(file_name.into())));
 
-        let errors = ::stc_ts_errors::Error::flatten(checker.take_errors());
+        let errors = ::stc_ts_errors::ErrorKind::flatten(checker.take_errors());
 
         checker.run(|| {
             for e in errors {

--- a/crates/stc_ts_type_checker/tests/tsc-stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/tsc-stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
-    required_error: 4385,
-    matched_error: 5499,
-    extra_error: 968,
-    panic: 78,
+    required_error: 4350,
+    matched_error: 5534,
+    extra_error: 1051,
+    panic: 77,
 }

--- a/crates/stc_ts_type_checker/tests/tsc.rs
+++ b/crates/stc_ts_type_checker/tests/tsc.rs
@@ -280,7 +280,7 @@ fn load_expected_errors(ts_file: &Path) -> Result<Vec<RefError>, Error> {
 
         for err in &mut errors {
             let orig_code = err.code.replace("TS", "").parse().expect("failed to parse error code");
-            let code = stc_ts_errors::Error::normalize_error_code(orig_code);
+            let code = stc_ts_errors::ErrorKind::normalize_error_code(orig_code);
 
             if orig_code != code {
                 err.code = format!("TS{}", code);
@@ -610,7 +610,7 @@ fn do_test(file_name: &Path) -> Result<(), StdErr> {
 
                 time_of_check = end - start;
 
-                let errors = ::stc_ts_errors::Error::flatten(checker.take_errors());
+                let errors = ::stc_ts_errors::ErrorKind::flatten(checker.take_errors());
 
                 checker.run(|| {
                     for e in errors {

--- a/crates/stc_ts_type_checker/tests/types.rs
+++ b/crates/stc_ts_type_checker/tests/types.rs
@@ -228,7 +228,7 @@ fn do_test(path: &Path) -> Result<(), StdErr> {
 
             checker.check(Arc::new(FileName::Real(path.into())));
 
-            let errors = ::stc_ts_errors::Error::flatten(checker.take_errors());
+            let errors = ::stc_ts_errors::ErrorKind::flatten(checker.take_errors());
 
             checker.run(|| {
                 for e in errors {

--- a/crates/stc_ts_utils/src/lib.rs
+++ b/crates/stc_ts_utils/src/lib.rs
@@ -8,7 +8,7 @@ use stc_ts_ast_rnode::{
     RArrayPat, RAssignPat, RBindingIdent, RDecl, RExpr, RIdent, RModuleDecl, RModuleItem, RObjectPat, RPat, RPropName, RRestPat, RStmt,
     RTsEntityName, RTsType, RTsTypeAnn,
 };
-use stc_ts_errors::Error;
+use stc_ts_errors::ErrorKind;
 use swc_common::Spanned;
 
 pub use self::{comments::StcComments, map_with_mut::MapWithMut};
@@ -240,6 +240,6 @@ impl PatExt for RPat {
 }
 
 /// Type annotation
-pub fn run<Ret>(op: impl FnOnce() -> Result<Ret, Error>) -> Result<Ret, Error> {
+pub fn run<Ret>(op: impl FnOnce() -> Result<Ret, ErrorKind>) -> Result<Ret, ErrorKind> {
     op()
 }

--- a/crates/stc_ts_utils/src/lib.rs
+++ b/crates/stc_ts_utils/src/lib.rs
@@ -8,7 +8,7 @@ use stc_ts_ast_rnode::{
     RArrayPat, RAssignPat, RBindingIdent, RDecl, RExpr, RIdent, RModuleDecl, RModuleItem, RObjectPat, RPat, RPropName, RRestPat, RStmt,
     RTsEntityName, RTsType, RTsTypeAnn,
 };
-use stc_ts_errors::ErrorKind;
+use stc_ts_errors::Error;
 use swc_common::Spanned;
 
 pub use self::{comments::StcComments, map_with_mut::MapWithMut};
@@ -240,6 +240,6 @@ impl PatExt for RPat {
 }
 
 /// Type annotation
-pub fn run<Ret>(op: impl FnOnce() -> Result<Ret, ErrorKind>) -> Result<Ret, ErrorKind> {
+pub fn run<Ret>(op: impl FnOnce() -> Result<Ret, Error>) -> Result<Ret, Error> {
     op()
 }


### PR DESCRIPTION
**Description:**

 - `Error` is renamed to `ErrorKind`.
 - `Error` is still used for typings.
 - Contexts are stored in function stacks.
 - Contexts are attached to `Error` while converting an `ErrorKind` to an `Error`.
