### PR TITLE
feat(ts/analyzer): Improve handling of type facts

### DIFF
--- a/crates/stc_ts_file_analyzer/src/analyzer/expr/bin.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/expr/bin.rs
@@ -880,6 +880,13 @@ impl Analyzer<'_, '_> {
             _ => None,
         }) {
             Some((Ok(name), (Some(t), Some(f)))) => {
+                // If typeof foo.bar is `string`, `foo` cannot be undefined nor null
+                for idx in 1..name.as_ids().len() {
+                    let sub = Name::from(&name.as_ids()[..idx]);
+
+                    self.cur_facts.true_facts.facts.insert(sub.clone(), TypeFacts::NEUndefinedOrNull);
+                }
+
                 // Add type facts
                 self.cur_facts.true_facts.facts.insert(name.clone(), t);
                 self.cur_facts.false_facts.facts.insert(name.clone(), f);

--- a/crates/stc_ts_file_analyzer/src/analyzer/expr/bin.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/expr/bin.rs
@@ -881,10 +881,12 @@ impl Analyzer<'_, '_> {
         }) {
             Some((Ok(name), (Some(t), Some(f)))) => {
                 // If typeof foo.bar is `string`, `foo` cannot be undefined nor null
-                for idx in 1..name.as_ids().len() {
-                    let sub = Name::from(&name.as_ids()[..idx]);
+                if t != TypeFacts::EQUndefined {
+                    for idx in 1..name.as_ids().len() {
+                        let sub = Name::from(&name.as_ids()[..idx]);
 
-                    self.cur_facts.true_facts.facts.insert(sub.clone(), TypeFacts::NEUndefinedOrNull);
+                        self.cur_facts.true_facts.facts.insert(sub.clone(), TypeFacts::NEUndefinedOrNull);
+                    }
                 }
 
                 // Add type facts

--- a/crates/stc_ts_file_analyzer/src/analyzer/expr/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/expr/mod.rs
@@ -3980,7 +3980,7 @@ impl Analyzer<'_, '_> {
         let ty = self
             .with_ctx(prop_access_ctx)
             .access_property(span, &obj_ty, &prop, type_mode, IdCtx::Var, Default::default())
-            .context("tried to access property of an object to calculate type of a super propertt expression")?;
+            .context("tried to access property of an object to calculate type of a super property expression")?;
 
         if should_be_optional {
             Ok(Type::union(vec![Type::undefined(span, Default::default()), ty]))

--- a/crates/stc_ts_file_analyzer/src/analyzer/expr/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/expr/mod.rs
@@ -1224,10 +1224,6 @@ impl Analyzer<'_, '_> {
             debug!("access_property: obj = {}", dump_type_as_string(&self.cm, &obj));
         }
 
-        if obj.is_undefined() && self.rule().strict_null_checks {
-            return Err(ErrorKind::ObjectIsPossiblyUndefined { span }.into());
-        }
-
         let _stack = stack::track(span)?;
 
         let marks = self.marks();

--- a/crates/stc_ts_file_analyzer/src/analyzer/expr/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/expr/mod.rs
@@ -3980,7 +3980,7 @@ impl Analyzer<'_, '_> {
         let ty = self
             .with_ctx(prop_access_ctx)
             .access_property(span, &obj_ty, &prop, type_mode, IdCtx::Var, Default::default())
-            .context("tried to access property of an object to calculate type of a member expression")?;
+            .context("tried to access property of an object to calculate type of a super propertt expression")?;
 
         if should_be_optional {
             Ok(Type::union(vec![Type::undefined(span, Default::default()), ty]))

--- a/crates/stc_ts_file_analyzer/src/analyzer/expr/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/expr/mod.rs
@@ -1227,12 +1227,6 @@ impl Analyzer<'_, '_> {
             debug!("access_property: obj = {}", dump_type_as_string(&self.cm, &obj));
         }
 
-        if opts.check_for_undefined_or_null && self.rule().strict_null_checks {
-            if obj.is_undefined() {
-                return Err(ErrorKind::ObjectIsPossiblyUndefined { span }.into());
-            }
-        }
-
         let _stack = stack::track(span)?;
 
         let marks = self.marks();
@@ -1377,6 +1371,10 @@ impl Analyzer<'_, '_> {
             }
 
             unimplemented!("access_property_inner: global_this: {:?}", prop);
+        }
+
+        if opts.check_for_undefined_or_null && self.rule().strict_null_checks {
+            self.deny_null_or_undefined(span, obj)?
         }
 
         if id_ctx == IdCtx::Var {

--- a/crates/stc_ts_file_analyzer/src/analyzer/expr/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/expr/mod.rs
@@ -1224,6 +1224,10 @@ impl Analyzer<'_, '_> {
             debug!("access_property: obj = {}", dump_type_as_string(&self.cm, &obj));
         }
 
+        if obj.is_undefined() && self.rule().strict_null_checks {
+            return Err(ErrorKind::ObjectIsPossiblyUndefined { span }.into());
+        }
+
         let _stack = stack::track(span)?;
 
         let marks = self.marks();

--- a/crates/stc_ts_file_analyzer/src/ty/type_facts.rs
+++ b/crates/stc_ts_file_analyzer/src/ty/type_facts.rs
@@ -195,8 +195,10 @@ impl Fold<KeywordType> for TypeFactsHandler<'_, '_, '_> {
             }
         }
 
-        if (self.facts.contains(TypeFacts::NEUndefined) && ty.kind == TsKeywordTypeKind::TsUndefinedKeyword)
-            || (self.facts.contains(TypeFacts::NENull) && ty.kind == TsKeywordTypeKind::TsNullKeyword)
+        if ((self.facts.contains(TypeFacts::NEUndefined) || self.facts.contains(TypeFacts::NEUndefinedOrNull))
+            && ty.kind == TsKeywordTypeKind::TsUndefinedKeyword)
+            || ((self.facts.contains(TypeFacts::NENull) || self.facts.contains(TypeFacts::NEUndefinedOrNull))
+                && ty.kind == TsKeywordTypeKind::TsNullKeyword)
         {
             return KeywordType {
                 span: ty.span,

--- a/crates/stc_ts_file_analyzer/src/ty/type_facts.rs
+++ b/crates/stc_ts_file_analyzer/src/ty/type_facts.rs
@@ -195,6 +195,16 @@ impl Fold<KeywordType> for TypeFactsHandler<'_, '_, '_> {
             }
         }
 
+        if (self.facts.contains(TypeFacts::NEUndefined) && ty.kind == TsKeywordTypeKind::TsUndefinedKeyword)
+            || (self.facts.contains(TypeFacts::NENull) && ty.kind == TsKeywordTypeKind::TsNullKeyword)
+        {
+            return KeywordType {
+                span: ty.span,
+                kind: TsKeywordTypeKind::TsNeverKeyword,
+                metadata: ty.metadata,
+            };
+        }
+
         if ty.kind == TsKeywordTypeKind::TsNullKeyword && self.facts.contains(TypeFacts::NENull) {
             return KeywordType {
                 kind: TsKeywordTypeKind::TsNeverKeyword,

--- a/crates/stc_ts_file_analyzer/tests/pass/controlFlow/controlFlowOptionalChain/2.swc-stderr
+++ b/crates/stc_ts_file_analyzer/tests/pass/controlFlow/controlFlowOptionalChain/2.swc-stderr
@@ -1,0 +1,93 @@
+
+  x Type
+   ,-[$DIR/tests/pass/controlFlow/controlFlowOptionalChain/2.ts:7:5]
+ 7 | switch (typeof o?.foo) {
+   :                ^
+   `----
+
+Error: 
+  > ({
+  |     foo: (string | number);
+  |     bar(): number;
+  |     baz: object;
+  | } | undefined)
+
+  x Type
+   ,-[$DIR/tests/pass/controlFlow/controlFlowOptionalChain/2.ts:7:5]
+ 7 | switch (typeof o?.foo) {
+   :                ^^^^^^
+   `----
+
+Error: 
+  > (undefined | string | number)
+
+  x Type
+   ,-[$DIR/tests/pass/controlFlow/controlFlowOptionalChain/2.ts:7:5]
+ 7 | switch (typeof o?.foo) {
+   :         ^^^^^^^^^^^^^
+   `----
+
+Error: 
+  > string
+
+  x Type
+   ,-[$DIR/tests/pass/controlFlow/controlFlowOptionalChain/2.ts:8:9]
+ 8 | case "string":
+   :      ^^^^^^^^
+   `----
+
+Error: 
+  > boolean
+
+  x Type
+   ,-[$DIR/tests/pass/controlFlow/controlFlowOptionalChain/2.ts:9:13]
+ 9 | o.foo;
+   : ^
+   `----
+
+Error: 
+  > {
+  |     foo: (string | number);
+  |     bar(): number;
+  |     baz: object;
+  | }
+
+  x Type
+   ,-[$DIR/tests/pass/controlFlow/controlFlowOptionalChain/2.ts:9:13]
+ 9 | o.foo;
+   : ^^^^^
+   `----
+
+Error: 
+  > string
+
+  x Type
+    ,-[$DIR/tests/pass/controlFlow/controlFlowOptionalChain/2.ts:11:9]
+ 11 | case "number":
+    :      ^^^^^^^^
+    `----
+
+Error: 
+  > boolean
+
+  x Type
+    ,-[$DIR/tests/pass/controlFlow/controlFlowOptionalChain/2.ts:12:13]
+ 12 | o.foo;
+    : ^
+    `----
+
+Error: 
+  > {
+  |     foo: (string | number);
+  |     bar(): number;
+  |     baz: object;
+  | }
+
+  x Type
+    ,-[$DIR/tests/pass/controlFlow/controlFlowOptionalChain/2.ts:12:13]
+ 12 | o.foo;
+    : ^^^^^
+    `----
+
+Error: 
+  > number

--- a/crates/stc_ts_file_analyzer/tests/pass/controlFlow/controlFlowOptionalChain/2.ts
+++ b/crates/stc_ts_file_analyzer/tests/pass/controlFlow/controlFlowOptionalChain/2.ts
@@ -11,12 +11,6 @@ function f41(o: Thing | undefined) {
         case "number":
             o.foo;
             break;
-        case "undefined":
-            o.foo;  // Error
-            break;
-        default:
-            o.foo;  // Error
-            break;
     }
 }
 

--- a/crates/stc_ts_file_analyzer/tests/pass/controlFlow/controlFlowOptionalChain/2.ts
+++ b/crates/stc_ts_file_analyzer/tests/pass/controlFlow/controlFlowOptionalChain/2.ts
@@ -1,0 +1,23 @@
+//@strict: true
+//@allowUnreachableCode: false
+
+type Thing = { foo: string | number, bar(): number, baz: object };
+
+function f41(o: Thing | undefined) {
+    switch (typeof o?.foo) {
+        case "string":
+            o.foo;
+            break;
+        case "number":
+            o.foo;
+            break;
+        case "undefined":
+            o.foo;  // Error
+            break;
+        default:
+            o.foo;  // Error
+            break;
+    }
+}
+
+export { }

--- a/crates/stc_ts_type_checker/tests/conformance/controlFlow/controlFlowOptionalChain.ts.stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/conformance/controlFlow/controlFlowOptionalChain.ts.stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
-    required_error: 19,
-    matched_error: 42,
-    extra_error: 76,
+    required_error: 18,
+    matched_error: 43,
+    extra_error: 75,
     panic: 0,
 }

--- a/crates/stc_ts_type_checker/tests/conformance/controlFlow/controlFlowOptionalChain.ts.stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/conformance/controlFlow/controlFlowOptionalChain.ts.stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
-    required_error: 18,
-    matched_error: 43,
-    extra_error: 75,
+    required_error: 20,
+    matched_error: 41,
+    extra_error: 65,
     panic: 0,
 }

--- a/crates/stc_ts_type_checker/tests/conformance/controlFlow/controlFlowOptionalChain.ts.stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/conformance/controlFlow/controlFlowOptionalChain.ts.stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
     required_error: 20,
     matched_error: 41,
-    extra_error: 65,
+    extra_error: 67,
     panic: 0,
 }

--- a/crates/stc_ts_type_checker/tests/conformance/types/specifyingTypes/typeQueries/typeofThis.ts.stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/conformance/types/specifyingTypes/typeQueries/typeofThis.ts.stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
     required_error: 8,
     matched_error: 0,
-    extra_error: 24,
+    extra_error: 26,
     panic: 0,
 }

--- a/crates/stc_ts_type_checker/tests/tsc-stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/tsc-stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
-    required_error: 4350,
-    matched_error: 5534,
-    extra_error: 1049,
+    required_error: 4351,
+    matched_error: 5533,
+    extra_error: 1042,
     panic: 77,
 }


### PR DESCRIPTION
**Description:**

 - `access_property`: Handle `undefined`.
 - Add `TypeFacts::NEUndefinedOrNull` for member accesses.
 - Support `TypeFacts::NENull` and `TypeFacts::NEUndefined`.
