### PR TITLE
fix(ts/analyzer): Fix handling of switch cases

### DIFF
--- a/crates/stc_ts_file_analyzer/src/analyzer/control_flow.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/control_flow.rs
@@ -593,6 +593,7 @@ impl Analyzer<'_, '_> {
                     in_cond: true,
                     in_switch_case_test: true,
                     should_store_truthy_for_access: true,
+                    checking_switch_discriminant_as_bin: true,
                     ..self.ctx
                 };
                 let mut a = self.with_ctx(ctx);

--- a/crates/stc_ts_file_analyzer/src/analyzer/convert/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/convert/mod.rs
@@ -11,7 +11,7 @@ use stc_ts_ast_rnode::{
     RTsTypeAnn, RTsTypeElement, RTsTypeLit, RTsTypeOperator, RTsTypeParam, RTsTypeParamDecl, RTsTypeParamInstantiation, RTsTypePredicate,
     RTsTypeQuery, RTsTypeQueryExpr, RTsTypeRef, RTsUnionOrIntersectionType, RTsUnionType,
 };
-use stc_ts_errors::ErrorKind;
+use stc_ts_errors::{ctx, ErrorKind};
 use stc_ts_file_analyzer_macros::extra_validator;
 use stc_ts_types::{
     type_id::SymbolId, Accessor, Alias, AliasMetadata, Array, CallSignature, CommonTypeMetadata, ComputedKey, Conditional,
@@ -1080,6 +1080,8 @@ impl Analyzer<'_, '_> {
         if self.is_builtin {
             return;
         }
+
+        let _ctx = ctx!("report_error_for_duplicate_params");
 
         let mut prev_ids: Vec<RIdent> = vec![];
         for param in params {

--- a/crates/stc_ts_file_analyzer/src/analyzer/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/mod.rs
@@ -201,6 +201,8 @@ pub(crate) struct Ctx {
     is_fn_param: bool,
 
     in_module: bool,
+
+    checking_switch_discriminant_as_bin: bool,
 }
 
 impl Ctx {
@@ -527,6 +529,7 @@ impl<'scope, 'b> Analyzer<'scope, 'b> {
                 is_not_topmost_type: false,
                 is_fn_param: false,
                 in_module: false,
+                checking_switch_discriminant_as_bin: false,
             },
             loader,
             is_builtin,

--- a/crates/stc_ts_file_analyzer/src/analyzer/scope/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/scope/mod.rs
@@ -1246,6 +1246,7 @@ impl Analyzer<'_, '_> {
             && !self.ctx.ignore_errors
             && !self.ctx.reevaluating()
             && !self.ctx.in_ts_fn_type
+            && !self.ctx.checking_switch_discriminant_as_bin
         {
             let spans = self.data.var_spans.entry(name.clone()).or_default();
             let err = !spans.is_empty();

--- a/crates/stc_ts_file_analyzer/src/analyzer/scope/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/scope/mod.rs
@@ -13,7 +13,7 @@ use iter::once;
 use once_cell::sync::Lazy;
 use rnode::{Fold, FoldWith, VisitMut, VisitMutWith, VisitWith};
 use stc_ts_ast_rnode::{RPat, RTsEntityName, RTsQualifiedName};
-use stc_ts_errors::{debug::dump_type_as_string, DebugExt, ErrorKind};
+use stc_ts_errors::{ctx, debug::dump_type_as_string, DebugExt, ErrorKind};
 use stc_ts_generics::ExpandGenericOpts;
 use stc_ts_type_ops::{expansion::ExpansionPreventer, union_finder::UnionFinder, Fix};
 use stc_ts_types::{
@@ -1199,6 +1199,8 @@ impl Analyzer<'_, '_> {
     ) -> VResult<()> {
         let marks = self.marks();
         let span = span.with_ctxt(SyntaxContext::empty());
+
+        let _ctx = ctx!(format!("declare_var: {:?}", name));
 
         if let Some(ty) = &ty {
             ty.assert_valid();

--- a/crates/stc_ts_type_checker/tests/conformance.pass.txt
+++ b/crates/stc_ts_type_checker/tests/conformance.pass.txt
@@ -1975,6 +1975,7 @@ statements/for-ofStatements/ES5for-of32.ts
 statements/forStatements/forStatements.ts
 statements/ifDoWhileStatements/ifDoWhileStatements.ts
 statements/returnStatements/returnStatements.ts
+statements/switchStatements/switchStatements.ts
 statements/throwStatements/throwInEnclosingStatements.ts
 statements/throwStatements/throwStatements.ts
 statements/tryStatements/tryStatements.ts

--- a/crates/stc_ts_type_checker/tests/conformance/statements/switchStatements/switchStatements.ts.stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/conformance/statements/switchStatements/switchStatements.ts.stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
     required_error: 0,
     matched_error: 1,
-    extra_error: 2,
+    extra_error: 0,
     panic: 0,
 }

--- a/crates/stc_ts_type_checker/tests/tsc-stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/tsc-stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
     required_error: 4348,
     matched_error: 5536,
-    extra_error: 1028,
+    extra_error: 1026,
     panic: 75,
 }


### PR DESCRIPTION
**Description:**

We evaluate case clauses twice, once as an expression and once as a binary expression with `===`. But it results in duplicate variables. This PR fixes it.