### PR TITLE
refactor(ts/analyzer): Use `normalize` instead of recursion

### DIFF
--- a/crates/stc_ts_file_analyzer/src/analyzer/assign/cast.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/assign/cast.rs
@@ -4,13 +4,24 @@ use stc_ts_types::Type;
 use swc_common::Span;
 use swc_ecma_ast::TsKeywordTypeKind;
 
-use crate::analyzer::Analyzer;
+use crate::analyzer::{types::NormalizeTypeOpts, Analyzer};
 
 impl Analyzer<'_, '_> {
     /// Returns true if the type can be casted to number if it's in the rvalue
     /// position.
     pub(crate) fn can_be_casted_to_number_in_rhs(&mut self, span: Span, ty: &Type) -> bool {
-        let ty = ty.normalize();
+        let ty = match self.normalize(
+            Some(span),
+            Cow::Borrowed(ty),
+            NormalizeTypeOpts {
+                preserve_global_this: true,
+                preserve_union: true,
+                ..Default::default()
+            },
+        ) {
+            Ok(v) => v.into_owned(),
+            _ => return false,
+        };
 
         if ty.is_num() {
             return true;
@@ -22,14 +33,7 @@ impl Analyzer<'_, '_> {
             return true;
         }
 
-        match ty {
-            Type::Ref(..) => {
-                if let Ok(expanded) = self.expand_top_ref(span, Cow::Borrowed(ty), Default::default()) {
-                    return self.can_be_casted_to_number_in_rhs(span, &expanded);
-                }
-
-                false
-            }
+        match ty.normalize() {
             Type::EnumVariant(e) => {
                 // TODO(kdy1): Check if value is string
                 true

--- a/crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs
@@ -187,8 +187,22 @@ impl Analyzer<'_, '_> {
     pub(crate) fn assign_with_op(&mut self, span: Span, op: AssignOp, lhs: &Type, rhs: &Type) -> VResult<()> {
         debug_assert_ne!(op, op!("="));
 
-        let l = self.expand_top_ref(span, Cow::Borrowed(lhs), Default::default())?;
-        let r = self.expand_top_ref(span, Cow::Borrowed(rhs), Default::default())?;
+        let l = self.normalize(
+            Some(span),
+            Cow::Borrowed(lhs),
+            NormalizeTypeOpts {
+                preserve_global_this: true,
+                ..Default::default()
+            },
+        )?;
+        let r = self.normalize(
+            Some(span),
+            Cow::Borrowed(rhs),
+            NormalizeTypeOpts {
+                preserve_global_this: true,
+                ..Default::default()
+            },
+        )?;
 
         let lhs = l.normalize();
         let rhs = r.normalize();

--- a/crates/stc_ts_file_analyzer/src/analyzer/control_flow.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/control_flow.rs
@@ -1232,7 +1232,15 @@ impl Analyzer<'_, '_> {
         id.span.hi = span.hi;
 
         let obj = self.type_of_var(&id, TypeOfMode::RValue, None)?;
-        let obj = self.expand_top_ref(ty.span(), Cow::Owned(obj), Default::default())?;
+        let obj = self.normalize(
+            Some(span),
+            Cow::Owned(obj),
+            NormalizeTypeOpts {
+                preserve_global_this: true,
+                preserve_union: true,
+                ..Default::default()
+            },
+        )?;
 
         if let Type::Union(u) = obj.normalize() {
             if ids.len() == 2 {

--- a/crates/stc_ts_file_analyzer/src/analyzer/control_flow.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/control_flow.rs
@@ -1136,6 +1136,7 @@ impl Analyzer<'_, '_> {
             Cow::Borrowed(src),
             NormalizeTypeOpts {
                 preserve_union: true,
+                preserve_global_this: true,
                 ..Default::default()
             },
         )?;

--- a/crates/stc_ts_file_analyzer/src/analyzer/expr/array.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/expr/array.rs
@@ -594,7 +594,16 @@ impl Analyzer<'_, '_> {
         ty.assert_valid();
 
         let mut ty = self
-            .normalize(Some(span), ty, Default::default())
+            .normalize(
+                Some(span),
+                ty,
+                NormalizeTypeOpts {
+                    preserve_global_this: true,
+                    preserve_intersection: true,
+                    preserve_union: true,
+                    ..Default::default()
+                },
+            )
             .context("tried to normalize type to get iterator")?;
         ty.make_clone_cheap();
 
@@ -608,11 +617,6 @@ impl Analyzer<'_, '_> {
             }
 
             match ty.normalize() {
-                Type::Ref(..) => {
-                    let ty = self.expand_top_ref(span, ty, Default::default())?;
-                    return self.get_iterator(span, ty, opts);
-                }
-
                 Type::Keyword(KeywordType {
                     kind: TsKeywordTypeKind::TsNumberKeyword,
                     ..

--- a/crates/stc_ts_file_analyzer/src/analyzer/expr/bin.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/expr/bin.rs
@@ -1017,7 +1017,15 @@ impl Analyzer<'_, '_> {
     /// Note that `C extends D` and `D extends C` are true because both of `C`
     /// and `D` are empty classes.
     fn narrow_with_instanceof(&mut self, span: Span, ty: Cow<Type>, orig_ty: &Type) -> VResult<Type> {
-        let mut orig_ty = self.normalize(Some(span), Cow::Borrowed(orig_ty), Default::default())?;
+        let mut orig_ty = self.normalize(
+            Some(span),
+            Cow::Borrowed(orig_ty),
+            NormalizeTypeOpts {
+                preserve_global_this: true,
+                preserve_union: true,
+                ..Default::default()
+            },
+        )?;
         orig_ty.make_clone_cheap();
 
         let _stack = stack::track(span)?;

--- a/crates/stc_ts_file_analyzer/src/analyzer/expr/bin.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/expr/bin.rs
@@ -1534,7 +1534,7 @@ impl Analyzer<'_, '_> {
         };
 
         let ty = self.type_of_name(span, &name.as_ids()[..name.len() - 1], TypeOfMode::RValue, None)?;
-        let ty = self.expand_top_ref(span, Cow::Owned(ty), Default::default())?.into_owned();
+        let ty = self.normalize(Some(span), Cow::Owned(ty), Default::default())?.into_owned();
 
         if let Type::Union(u) = ty.normalize() {
             let mut candidates = vec![];
@@ -1542,7 +1542,7 @@ impl Analyzer<'_, '_> {
                 let prop_res = self.access_property(span, ty, &prop, TypeOfMode::RValue, IdCtx::Var, Default::default());
 
                 if let Ok(prop_ty) = prop_res {
-                    let prop_ty = self.expand_top_ref(prop_ty.span(), Cow::Owned(prop_ty), Default::default())?;
+                    let prop_ty = self.normalize(Some(prop_ty.span()), Cow::Owned(prop_ty), Default::default())?;
                     let possible = match prop_ty.normalize() {
                         // Type parameters might have same value.
                         Type::Param(..) => true,

--- a/crates/stc_ts_file_analyzer/src/analyzer/expr/bin.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/expr/bin.rs
@@ -669,7 +669,8 @@ impl Analyzer<'_, '_> {
                     check_for_invalid_operand(&lt);
                     check_for_invalid_operand(&rt);
 
-                    self.validate_relative_comparison_operands(span, op, &lt, &rt);
+                    self.validate_relative_comparison_operands(span, op, &lt, &rt)
+                        .report(&mut self.storage);
                 }
 
                 Ok(Type::Keyword(KeywordType {
@@ -1141,8 +1142,7 @@ impl Analyzer<'_, '_> {
         Ok(ty.into_owned())
     }
 
-    #[extra_validator]
-    fn validate_relative_comparison_operands(&mut self, span: Span, op: BinaryOp, l: &Type, r: &Type) {
+    fn validate_relative_comparison_operands(&mut self, span: Span, op: BinaryOp, l: &Type, r: &Type) -> VResult<()> {
         let marks = self.marks();
 
         let l = l.normalize();
@@ -1189,7 +1189,7 @@ impl Analyzer<'_, '_> {
                                     }
                                     .into(),
                                 );
-                                return;
+                                return Ok(());
                             }
                             _ => {}
                         }
@@ -1202,6 +1202,8 @@ impl Analyzer<'_, '_> {
         let l = l.clone().generalize_lit();
         let r = r.clone().generalize_lit();
         self.verify_rel_cmp_operands(span, op, &l, &r)?;
+
+        Ok(())
     }
 
     fn verify_rel_cmp_operands(&mut self, span: Span, op: BinaryOp, l: &Type, r: &Type) -> VResult<()> {

--- a/crates/stc_ts_file_analyzer/src/analyzer/expr/call_new.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/expr/call_new.rs
@@ -826,7 +826,9 @@ impl Analyzer<'_, '_> {
                 .context("tried to access property to call it")?;
 
             let callee_before_expanding = dump_type_as_string(&callee);
-            let callee = self.expand_top_ref(span, Cow::Owned(callee), Default::default())?.into_owned();
+            let callee = self
+                .normalize(Some(span), Cow::Owned(callee), NormalizeTypeOpts { ..Default::default() })?
+                .into_owned();
 
             if let Type::ClassDef(cls) = callee.normalize() {
                 if cls.is_abstract {

--- a/crates/stc_ts_file_analyzer/src/analyzer/expr/call_new.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/expr/call_new.rs
@@ -1184,7 +1184,14 @@ impl Analyzer<'_, '_> {
             for arg in arg_types {
                 if arg.spread.is_some() {
                     let arg_ty = self
-                        .expand_top_ref(arg.span(), Cow::Borrowed(&arg.ty), Default::default())
+                        .normalize(
+                            Some(arg.span()),
+                            Cow::Borrowed(&arg.ty),
+                            NormalizeTypeOpts {
+                                preserve_global_this: true,
+                                ..Default::default()
+                            },
+                        )
                         .context("tried to expand ref to handle a spread argument")?;
                     match arg_ty.normalize() {
                         Type::Tuple(arg_ty) => {

--- a/crates/stc_ts_file_analyzer/src/analyzer/expr/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/expr/mod.rs
@@ -953,9 +953,8 @@ impl Analyzer<'_, '_> {
                     || self.assign(span, &mut Default::default(), index_ty, &prop_ty).is_ok();
 
                 if indexed {
-                    if let Some(ref type_ann) = type_ann {
-                        let ty = self.expand_top_ref(span, Cow::Borrowed(type_ann), Default::default())?;
-                        return Ok(Some(ty.into_owned()));
+                    if let Some(type_ann) = type_ann {
+                        return Ok(Some(*type_ann.clone()));
                     }
 
                     return Ok(Some(Type::any(span, Default::default())));

--- a/crates/stc_ts_file_analyzer/src/analyzer/expr/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/expr/mod.rs
@@ -2604,8 +2604,7 @@ impl Analyzer<'_, '_> {
                 // TODO(kdy1): Verify if multiple type has field
                 let mut new = vec![];
                 for ty in types {
-                    let ty = self.expand_top_ref(span, Cow::Borrowed(ty), Default::default())?;
-                    if let Ok(v) = self.access_property(span, &ty, prop, type_mode, id_ctx, opts) {
+                    if let Ok(v) = self.access_property(span, ty, prop, type_mode, id_ctx, opts) {
                         new.push(v);
                     }
                 }

--- a/crates/stc_ts_file_analyzer/src/analyzer/expr/object.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/expr/object.rs
@@ -12,7 +12,7 @@ use swc_ecma_ast::TsKeywordTypeKind;
 use tracing::debug;
 
 use crate::{
-    analyzer::{Analyzer, ScopeKind},
+    analyzer::{Analyzer, NormalizeTypeOpts, ScopeKind},
     validator::ValidateWith,
     VResult,
 };
@@ -158,7 +158,7 @@ impl Analyzer<'_, '_> {
     /// `{ a: number } + ( {b: number} | { c: number } )` => `{ a: number, b:
     /// number } | { a: number, c: number }`
     #[cfg_attr(debug_assertions, tracing::instrument(skip_all))]
-    fn append_type(&mut self, to: Type, mut rhs: Type) -> VResult<Type> {
+    fn append_type(&mut self, to: Type, rhs: Type) -> VResult<Type> {
         if to.is_any() || to.is_unknown() {
             return Ok(to);
         }
@@ -170,6 +170,19 @@ impl Analyzer<'_, '_> {
             // functions result in { }
             return Ok(to);
         }
+
+        let mut rhs = self
+            .normalize(
+                Some(rhs.span()),
+                Cow::Owned(rhs),
+                NormalizeTypeOpts {
+                    preserve_intersection: true,
+                    preserve_union: true,
+                    preserve_global_this: true,
+                    ..Default::default()
+                },
+            )?
+            .into_owned();
 
         if rhs.is_any() || rhs.is_unknown() {
             return Ok(rhs);
@@ -187,11 +200,6 @@ impl Analyzer<'_, '_> {
         }
 
         match rhs.normalize() {
-            Type::Ref(..) => {
-                let rhs = self.expand_top_ref(rhs.span(), Cow::Owned(rhs), Default::default())?.into_owned();
-                return self.append_type(to, rhs);
-            }
-
             Type::Interface(..) | Type::Class(..) | Type::Intersection(..) | Type::Mapped(..) => {
                 // Append as a type literal.
                 if let Some(rhs) = self.convert_type_to_type_lit(rhs.span(), Cow::Borrowed(&rhs))? {

--- a/crates/stc_ts_file_analyzer/src/analyzer/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/mod.rs
@@ -24,7 +24,6 @@ use swc_atoms::{js_word, JsWord};
 use swc_common::{FileName, SourceMap, Span, Spanned, DUMMY_SP, GLOBALS};
 use swc_ecma_ast::*;
 
-pub(crate) use self::scope::ScopeKind;
 use self::{
     control_flow::{CondFacts, Facts},
     pat::PatMode,
@@ -32,6 +31,7 @@ use self::{
     scope::{Scope, VarKind},
     util::ResultExt,
 };
+pub(crate) use self::{scope::ScopeKind, types::NormalizeTypeOpts};
 use crate::{
     loader::{Load, ModuleInfo},
     ty,

--- a/crates/stc_ts_file_analyzer/src/analyzer/types/mapped.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/types/mapped.rs
@@ -248,12 +248,18 @@ impl Analyzer<'_, '_> {
         let ty = ty.normalize();
 
         match ty {
-            Type::Ref(..) => {
-                let ty = self.expand_top_ref(span, Cow::Borrowed(ty), Default::default())?;
+            Type::Ref(..) | Type::Alias(..) | Type::Query(..) => {
+                let ty = self.normalize(
+                    Some(span),
+                    Cow::Borrowed(ty),
+                    NormalizeTypeOpts {
+                        preserve_global_this: true,
+                        preserve_union: true,
+                        ..Default::default()
+                    },
+                )?;
                 self.convert_type_to_keys(span, &ty)
             }
-
-            Type::Alias(alias) => self.convert_type_to_keys(span, &alias.ty),
 
             Type::Lit(LitType { lit, .. }) => match lit {
                 RTsLit::BigInt(v) => Ok(Some(vec![Key::BigInt(v.clone())])),

--- a/crates/stc_ts_file_analyzer/src/ty/type_facts.rs
+++ b/crates/stc_ts_file_analyzer/src/ty/type_facts.rs
@@ -125,9 +125,8 @@ struct TypeFactsHandler<'a, 'b, 'c> {
 }
 
 impl TypeFactsHandler<'_, '_, '_> {
-    #[instrument(skip(self, ty))]
     fn can_be_primitive(&mut self, ty: &Type) -> bool {
-        let ty = if let Ok(ty) = self.analyzer.expand_top_ref(ty.span(), Cow::Borrowed(ty), Default::default()) {
+        let ty = if let Ok(ty) = self.analyzer.normalize(Some(ty.span()), Cow::Borrowed(ty), Default::default()) {
             ty
         } else {
             return true;

--- a/crates/stc_ts_file_analyzer/src/ty/type_facts.rs
+++ b/crates/stc_ts_file_analyzer/src/ty/type_facts.rs
@@ -14,7 +14,10 @@ use swc_common::{Span, Spanned, SyntaxContext, DUMMY_SP};
 use swc_ecma_ast::TsKeywordTypeKind;
 use tracing::{debug, instrument};
 
-use crate::{analyzer::Analyzer, type_facts::TypeFacts};
+use crate::{
+    analyzer::{Analyzer, NormalizeTypeOpts},
+    type_facts::TypeFacts,
+};
 
 impl Analyzer<'_, '_> {
     /// TODO(kdy1): Note: This method preserves [Type::Ref] in some cases.
@@ -126,7 +129,14 @@ struct TypeFactsHandler<'a, 'b, 'c> {
 
 impl TypeFactsHandler<'_, '_, '_> {
     fn can_be_primitive(&mut self, ty: &Type) -> bool {
-        let ty = if let Ok(ty) = self.analyzer.normalize(Some(ty.span()), Cow::Borrowed(ty), Default::default()) {
+        let ty = if let Ok(ty) = self.analyzer.normalize(
+            Some(ty.span()),
+            Cow::Borrowed(ty),
+            NormalizeTypeOpts {
+                preserve_global_this: true,
+                ..Default::default()
+            },
+        ) {
             ty
         } else {
             return true;

--- a/crates/stc_ts_type_checker/tests/conformance/classes/members/privateNames/privateNameAndObjectRestSpread.ts.stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/conformance/classes/members/privateNames/privateNameAndObjectRestSpread.ts.stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
     required_error: 4,
     matched_error: 0,
-    extra_error: 0,
-    panic: 1,
+    extra_error: 3,
+    panic: 0,
 }

--- a/crates/stc_ts_type_checker/tests/conformance/controlFlow/dependentDestructuredVariables.ts.stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/conformance/controlFlow/dependentDestructuredVariables.ts.stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
     required_error: 2,
     matched_error: 0,
-    extra_error: 32,
+    extra_error: 30,
     panic: 0,
 }

--- a/crates/stc_ts_type_checker/tests/conformance/types/rest/genericRestParameters3.ts.stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/conformance/types/rest/genericRestParameters3.ts.stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
     required_error: 7,
     matched_error: 6,
-    extra_error: 18,
+    extra_error: 17,
     panic: 0,
 }


### PR DESCRIPTION
**Description:**

 - Add `preserve_union` to `NormalizeTypeOpts`.
 - Use `normalize` instead of `expand_top_ref` for various functions.
 - `get_iterator`: Adjust options passed to `normalize`.
 - `convert_type_keys`: Support more types.