### PR TITLE
feat(ts/analyzer): Support more LHS for `in`

### DIFF
--- a/crates/stc_ts_file_analyzer/src/analyzer/expr/bin.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/expr/bin.rs
@@ -685,9 +685,10 @@ impl Analyzer<'_, '_> {
                     let left = match &**left {
                         RExpr::Lit(RLit::Str(s)) => Some(s.value.clone()),
                         RExpr::Tpl(t) if t.quasis.len() == 1 => t.quasis[0].cooked.clone().map(|v| (&*v).into()),
-                        RExpr::Tpl(t) if t.quasis.len() == 1 => t.quasis[0].cooked.clone().map(|v| (&*v).into()),
-                        RExpr::Tpl(t) if t.quasis.len() == 1 => t.quasis[0].cooked.clone().map(|v| (&*v).into()),
-                        _ => None,
+                        _ => match &lt {
+                            Type::Lit(LitType { lit: RTsLit::Str(s), .. }) => Some(s.value.clone()),
+                            _ => None,
+                        },
                     };
                     let name = Name::try_from(&**right).ok();
 

--- a/crates/stc_ts_file_analyzer/src/analyzer/expr/bin.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/expr/bin.rs
@@ -685,7 +685,7 @@ impl Analyzer<'_, '_> {
                     let left = match &**left {
                         RExpr::Lit(RLit::Str(s)) => Some(s.value.clone()),
                         RExpr::Tpl(t) if t.quasis.len() == 1 => t.quasis[0].cooked.clone().map(|v| (&*v).into()),
-                        _ => match &lt {
+                        _ => match lt.normalize() {
                             Type::Lit(LitType { lit: RTsLit::Str(s), .. }) => Some(s.value.clone()),
                             _ => None,
                         },

--- a/crates/stc_ts_file_analyzer/src/analyzer/expr/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/expr/mod.rs
@@ -685,7 +685,11 @@ impl Analyzer<'_, '_> {
     #[cfg_attr(debug_assertions, tracing::instrument(skip_all))]
     pub(crate) fn key_matches(&mut self, span: Span, declared: &Key, cur: &Key, allow_union: bool) -> bool {
         match declared {
-            Key::Computed(..) => {}
+            Key::Computed(declared) => {
+                if self.check_if_type_matches_key(span, cur, &declared.ty, true) {
+                    return true;
+                }
+            }
             _ => {
                 if declared.type_eq(cur) {
                     return true;

--- a/crates/stc_ts_file_analyzer/src/analyzer/expr/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/expr/mod.rs
@@ -685,11 +685,7 @@ impl Analyzer<'_, '_> {
     #[cfg_attr(debug_assertions, tracing::instrument(skip_all))]
     pub(crate) fn key_matches(&mut self, span: Span, declared: &Key, cur: &Key, allow_union: bool) -> bool {
         match declared {
-            Key::Computed(declared) => {
-                if self.check_if_type_matches_key(span, cur, &declared.ty, true) {
-                    return true;
-                }
-            }
+            Key::Computed(..) => {}
             _ => {
                 if declared.type_eq(cur) {
                     return true;
@@ -731,6 +727,19 @@ impl Analyzer<'_, '_> {
             }
 
             _ => {}
+        }
+
+        match declared {
+            Key::Computed(declared) => {
+                if self.check_if_type_matches_key(span, cur, &declared.ty, true) {
+                    return true;
+                }
+            }
+            _ => {
+                if declared.type_eq(cur) {
+                    return true;
+                }
+            }
         }
 
         match cur {

--- a/crates/stc_ts_type_checker/tests/conformance.pass.txt
+++ b/crates/stc_ts_type_checker/tests/conformance.pass.txt
@@ -269,6 +269,7 @@ controlFlow/controlFlowElementAccess2.ts
 controlFlow/controlFlowForInStatement.ts
 controlFlow/controlFlowForInStatement2.ts
 controlFlow/controlFlowIfStatement.ts
+controlFlow/controlFlowInOperator.ts
 controlFlow/controlFlowInstanceOfGuardPrimitives.ts
 controlFlow/controlFlowInstanceofExtendsFunction.ts
 controlFlow/controlFlowIteration.ts

--- a/crates/stc_ts_type_checker/tests/conformance/controlFlow/controlFlowInOperator.ts.stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/conformance/controlFlow/controlFlowInOperator.ts.stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
     required_error: 0,
     matched_error: 0,
-    extra_error: 1,
+    extra_error: 0,
     panic: 0,
 }

--- a/crates/stc_ts_type_checker/tests/tsc-stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/tsc-stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
     required_error: 4349,
     matched_error: 5535,
-    extra_error: 1016,
+    extra_error: 1015,
     panic: 74,
 }


### PR DESCRIPTION
**Description:**

 - Support non-literal expressions for the LHS of an `in` expression.
 - `key_matches`: Handle more computed keys.