### PR TITLE
fix(ts/analyzer): Use correct logic for type narrowing with a property

### DIFF
--- a/crates/stc_ts_file_analyzer/src/analyzer/expr/bin.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/expr/bin.rs
@@ -1566,7 +1566,7 @@ impl Analyzer<'_, '_> {
                         Type::Keyword(KeywordType {
                             kind: TsKeywordTypeKind::TsNullKeyword | TsKeywordTypeKind::TsUndefinedKeyword,
                             ..
-                        }) => false,
+                        }) => prop_ty.type_eq(equals_to),
                         _ => self.castable(span, &prop_ty, equals_to, CastableOpts { ..Default::default() })?,
                     };
                     if possible {

--- a/crates/stc_ts_file_analyzer/src/analyzer/expr/bin.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/expr/bin.rs
@@ -1563,7 +1563,7 @@ impl Analyzer<'_, '_> {
                     let possible = match prop_ty.normalize() {
                         // Type parameters might have same value.
                         Type::Param(..) => true,
-                        _ => prop_ty.type_eq(equals_to),
+                        _ => self.castable(span, &prop_ty, equals_to, CastableOpts { ..Default::default() })?,
                     };
                     if possible {
                         candidates.push(ty.clone())

--- a/crates/stc_ts_file_analyzer/src/analyzer/expr/bin.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/expr/bin.rs
@@ -1563,6 +1563,10 @@ impl Analyzer<'_, '_> {
                     let possible = match prop_ty.normalize() {
                         // Type parameters might have same value.
                         Type::Param(..) => true,
+                        Type::Keyword(KeywordType {
+                            kind: TsKeywordTypeKind::TsNullKeyword | TsKeywordTypeKind::TsUndefinedKeyword,
+                            ..
+                        }) => false,
                         _ => self.castable(span, &prop_ty, equals_to, CastableOpts { ..Default::default() })?,
                     };
                     if possible {

--- a/crates/stc_ts_file_analyzer/src/analyzer/expr/bin.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/expr/bin.rs
@@ -1563,12 +1563,15 @@ impl Analyzer<'_, '_> {
                     let possible = match prop_ty.normalize() {
                         // Type parameters might have same value.
                         Type::Param(..) => true,
-                        Type::Keyword(KeywordType {
-                            kind: TsKeywordTypeKind::TsNullKeyword | TsKeywordTypeKind::TsUndefinedKeyword,
-                            ..
-                        }) => prop_ty.type_eq(equals_to),
-                        _ => self.castable(span, &prop_ty, equals_to, CastableOpts { ..Default::default() })?,
+                        _ => {
+                            if prop_ty.is_null_or_undefined() || equals_to.is_null_or_undefined() {
+                                prop_ty.type_eq(equals_to)
+                            } else {
+                                self.has_overlap(span, &prop_ty, equals_to, CastableOpts { ..Default::default() })?
+                            }
+                        }
                     };
+                    dbg!(possible);
                     if possible {
                         candidates.push(ty.clone())
                     }

--- a/crates/stc_ts_file_analyzer/src/analyzer/expr/type_cast.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/expr/type_cast.rs
@@ -251,6 +251,10 @@ impl Analyzer<'_, '_> {
         let from = from.normalize();
         let to = to.normalize();
 
+        if from.type_eq(to) {
+            return Ok(true);
+        }
+
         // Overlaps with all types.
         if from.is_any() || from.is_kwd(TsKeywordTypeKind::TsNullKeyword) || from.is_kwd(TsKeywordTypeKind::TsUndefinedKeyword) {
             return Ok(true);

--- a/crates/stc_ts_type_checker/tests/conformance/controlFlow/controlFlowOptionalChain.ts.stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/conformance/controlFlow/controlFlowOptionalChain.ts.stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
     required_error: 20,
     matched_error: 41,
-    extra_error: 67,
+    extra_error: 55,
     panic: 0,
 }

--- a/crates/stc_ts_type_checker/tests/conformance/controlFlow/controlFlowOptionalChain.ts.stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/conformance/controlFlow/controlFlowOptionalChain.ts.stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
     required_error: 20,
     matched_error: 41,
-    extra_error: 55,
+    extra_error: 52,
     panic: 0,
 }

--- a/crates/stc_ts_type_checker/tests/conformance/types/literal/templateLiteralTypes3.ts.stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/conformance/types/literal/templateLiteralTypes3.ts.stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
     required_error: 5,
     matched_error: 3,
-    extra_error: 2,
+    extra_error: 0,
     panic: 0,
 }

--- a/crates/stc_ts_type_checker/tests/conformance/types/literal/templateLiteralTypes3.ts.stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/conformance/types/literal/templateLiteralTypes3.ts.stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
     required_error: 5,
     matched_error: 3,
-    extra_error: 0,
+    extra_error: 1,
     panic: 0,
 }

--- a/crates/stc_ts_type_checker/tests/tsc-stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/tsc-stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
-    required_error: 4345,
-    matched_error: 5539,
-    extra_error: 1011,
+    required_error: 4344,
+    matched_error: 5538,
+    extra_error: 995,
     panic: 74,
 }


### PR DESCRIPTION
**Description:**

 - Use `castable` for candidate check.