### PR TITLE
feat(ts/analyzer): Pass more type annotations for function-like nodes

### DIFF
--- a/crates/stc_ts_file_analyzer/src/analyzer/expr/function.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/expr/function.rs
@@ -34,90 +34,7 @@ impl Analyzer<'_, '_> {
                     ..child.ctx
                 };
 
-                if let Some(ty) = &type_ann {
-                    // See functionExpressionContextualTyping1.ts
-                    //
-                    // If a type annotation of function is union and there are two or more
-                    // function types, the type becomes any implicitly.
-                    if ty.iter_union().filter(|ty| ty.is_fn_type()).count() == 1 {
-                        for ty in ty.iter_union() {
-                            if let Type::Function(ty) = ty.normalize() {
-                                // Handle rest in `ty.params`.
-                                // If a rest parameter is present, we should adjust offset
-
-                                // We do it by creating a tuple and calling access_property
-                                // TODO(kdy1): This is not efficient.
-                                let mut params_tuple_els = vec![];
-
-                                for param in ty.params.iter() {
-                                    match param.pat {
-                                        RPat::Rest(..) => {
-                                            params_tuple_els.push(TupleElement {
-                                                span: param.span,
-                                                label: None,
-                                                ty: box Type::Rest(RestType {
-                                                    span: param.span,
-                                                    ty: param.ty.clone(),
-                                                    metadata: Default::default(),
-                                                }),
-                                            });
-                                        }
-                                        _ => {
-                                            params_tuple_els.push(TupleElement {
-                                                span: param.span,
-                                                label: None,
-                                                ty: param.ty.clone(),
-                                            });
-                                        }
-                                    }
-                                }
-
-                                let params_tuple = Type::Tuple(Tuple {
-                                    span: ty.span,
-                                    elems: params_tuple_els,
-                                    metadata: Default::default(),
-                                });
-
-                                for (idx, param) in f.params.iter().enumerate() {
-                                    if let RPat::Rest(..) = param {
-                                        if let Ok(mut ty) = child.get_rest_elements(Some(param.span()), Cow::Borrowed(&params_tuple), idx) {
-                                            ty.make_clone_cheap();
-
-                                            if let Some(pat_node_id) = param.node_id() {
-                                                if let Some(m) = &mut child.mutations {
-                                                    m.for_pats.entry(pat_node_id).or_default().ty.get_or_insert_with(|| ty.into_owned());
-                                                }
-                                            }
-                                        }
-                                        continue;
-                                    }
-
-                                    if let Ok(ty) = child.access_property(
-                                        param.span(),
-                                        &params_tuple,
-                                        &Key::Num(RNumber {
-                                            span: param.span(),
-                                            value: idx as f64,
-                                            raw: None,
-                                        }),
-                                        TypeOfMode::RValue,
-                                        stc_ts_types::IdCtx::Var,
-                                        Default::default(),
-                                    ) {
-                                        // Store type information, so the pattern
-                                        // validator can use a correct
-                                        // type.
-                                        if let Some(pat_node_id) = param.node_id() {
-                                            if let Some(m) = &mut child.mutations {
-                                                m.for_pats.entry(pat_node_id).or_default().ty.get_or_insert_with(|| ty.clone());
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
+                child.apply_fn_type_ann(f.params.iter(), type_ann.as_deref());
 
                 for p in &f.params {
                     child.default_any_pat(p);
@@ -210,5 +127,94 @@ impl Analyzer<'_, '_> {
                 metadata: Default::default(),
             })
         })
+    }
+}
+
+impl Analyzer<'_, '_> {
+    pub(crate) fn apply_fn_type_ann<'a>(&mut self, params: impl Iterator<Item = &'a RPat> + Clone, type_ann: Option<&Type>) {
+        if let Some(ty) = &type_ann {
+            // See functionExpressionContextualTyping1.ts
+            //
+            // If a type annotation of function is union and there are two or more
+            // function types, the type becomes any implicitly.
+            if ty.iter_union().filter(|ty| ty.is_fn_type()).count() == 1 {
+                for ty in ty.iter_union() {
+                    if let Type::Function(ty) = ty.normalize() {
+                        // Handle rest in `ty.params`.
+                        // If a rest parameter is present, we should adjust offset
+
+                        // We do it by creating a tuple and calling access_property
+                        // TODO(kdy1): This is not efficient.
+                        let mut params_tuple_els = vec![];
+
+                        for param in ty.params.iter() {
+                            match param.pat {
+                                RPat::Rest(..) => {
+                                    params_tuple_els.push(TupleElement {
+                                        span: param.span,
+                                        label: None,
+                                        ty: box Type::Rest(RestType {
+                                            span: param.span,
+                                            ty: param.ty.clone(),
+                                            metadata: Default::default(),
+                                        }),
+                                    });
+                                }
+                                _ => {
+                                    params_tuple_els.push(TupleElement {
+                                        span: param.span,
+                                        label: None,
+                                        ty: param.ty.clone(),
+                                    });
+                                }
+                            }
+                        }
+
+                        let params_tuple = Type::Tuple(Tuple {
+                            span: ty.span,
+                            elems: params_tuple_els,
+                            metadata: Default::default(),
+                        });
+
+                        for (idx, param) in params.clone().enumerate() {
+                            if let RPat::Rest(..) = param {
+                                if let Ok(mut ty) = self.get_rest_elements(Some(param.span()), Cow::Borrowed(&params_tuple), idx) {
+                                    ty.make_clone_cheap();
+
+                                    if let Some(pat_node_id) = param.node_id() {
+                                        if let Some(m) = &mut self.mutations {
+                                            m.for_pats.entry(pat_node_id).or_default().ty.get_or_insert_with(|| ty.into_owned());
+                                        }
+                                    }
+                                }
+                                continue;
+                            }
+
+                            if let Ok(ty) = self.access_property(
+                                param.span(),
+                                &params_tuple,
+                                &Key::Num(RNumber {
+                                    span: param.span(),
+                                    value: idx as f64,
+                                    raw: None,
+                                }),
+                                TypeOfMode::RValue,
+                                stc_ts_types::IdCtx::Var,
+                                Default::default(),
+                            ) {
+                                // Store type information, so the pattern
+                                // validator can use a correct
+                                // type.
+                                if let Some(pat_node_id) = param.node_id() {
+                                    if let Some(m) = &mut self.mutations {
+                                        m.for_pats.entry(pat_node_id).or_default().ty.get_or_insert_with(|| ty.clone());
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
     }
 }

--- a/crates/stc_ts_file_analyzer/src/analyzer/props.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/props.rs
@@ -19,6 +19,7 @@ use crate::{
         Analyzer, Ctx,
     },
     ty::{MethodSignature, Operator, PropertySignature, Type, TypeElement, TypeExt},
+    type_facts::TypeFacts,
     validator,
     validator::ValidateWith,
     VResult,
@@ -387,8 +388,12 @@ impl Analyzer<'_, '_> {
                 let key = kv.key.validate_with(self)?;
                 let computed = matches!(kv.key, RPropName::Computed(_));
 
+                let object_type = object_type
+                    .cloned()
+                    .map(|ty| self.apply_type_facts_to_type(TypeFacts::NEUndefinedOrNull, ty));
+
                 let type_ann = object_type.and_then(|obj| {
-                    self.access_property(span, obj, &key, TypeOfMode::RValue, IdCtx::Var, Default::default())
+                    self.access_property(span, &obj, &key, TypeOfMode::RValue, IdCtx::Var, Default::default())
                         .ok()
                 });
 

--- a/crates/stc_ts_file_analyzer/src/analyzer/props.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/props.rs
@@ -19,7 +19,6 @@ use crate::{
         Analyzer, Ctx,
     },
     ty::{MethodSignature, Operator, PropertySignature, Type, TypeElement, TypeExt},
-    type_facts::TypeFacts,
     validator,
     validator::ValidateWith,
     VResult,
@@ -388,12 +387,8 @@ impl Analyzer<'_, '_> {
                 let key = kv.key.validate_with(self)?;
                 let computed = matches!(kv.key, RPropName::Computed(_));
 
-                let object_type = object_type
-                    .cloned()
-                    .map(|ty| self.apply_type_facts_to_type(TypeFacts::NEUndefinedOrNull, ty));
-
                 let type_ann = object_type.and_then(|obj| {
-                    self.access_property(span, &obj, &key, TypeOfMode::RValue, IdCtx::Var, Default::default())
+                    self.access_property(span, obj, &key, TypeOfMode::RValue, IdCtx::Var, Default::default())
                         .ok()
                 });
 

--- a/crates/stc_ts_file_analyzer/src/analyzer/props.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/props.rs
@@ -1,12 +1,10 @@
 use std::borrow::Cow;
 
-use itertools::{EitherOrBoth, Itertools};
 use rnode::{Visit, VisitWith};
 use stc_ts_ast_rnode::{RComputedPropName, RExpr, RGetterProp, RIdent, RMemberExpr, RPrivateName, RProp, RPropName};
 use stc_ts_errors::{ErrorKind, Errors};
 use stc_ts_file_analyzer_macros::extra_validator;
 use stc_ts_types::{Accessor, ComputedKey, Key, KeywordType, PrivateName, TypeParam};
-use stc_ts_utils::PatExt;
 use stc_utils::cache::Freeze;
 use swc_atoms::js_word;
 use swc_common::{Span, Spanned, SyntaxContext};
@@ -459,19 +457,7 @@ impl Analyzer<'_, '_> {
                         child.ctx.in_async = p.function.is_async;
                         child.ctx.in_generator = p.function.is_generator;
 
-                        if let Some(Type::Function(ty)) = method_type_ann.as_ref().map(|ty| ty.normalize()) {
-                            for p in p.function.params.iter().zip_longest(ty.params.iter()) {
-                                if let EitherOrBoth::Both(param, ty) = p {
-                                    // Store type infomations, so the pattern validator
-                                    // can use correct type.
-                                    if let Some(pat_node_id) = param.pat.node_id() {
-                                        if let Some(m) = &mut child.mutations {
-                                            m.for_pats.entry(pat_node_id).or_default().ty.get_or_insert_with(|| *ty.ty.clone());
-                                        }
-                                    }
-                                }
-                            }
-                        }
+                        child.apply_fn_type_ann(p.function.params.iter().map(|v| &v.pat), method_type_ann.as_ref());
 
                         // We mark as wip
                         if !computed {

--- a/crates/stc_ts_type_checker/tests/conformance.pass.txt
+++ b/crates/stc_ts_type_checker/tests/conformance.pass.txt
@@ -2234,6 +2234,7 @@ types/thisType/thisTypeInClasses.ts
 types/thisType/thisTypeInFunctions3.ts
 types/thisType/thisTypeInInterfaces.ts
 types/thisType/thisTypeInObjectLiterals.ts
+types/thisType/thisTypeInObjectLiterals2.ts
 types/thisType/thisTypeInTaggedTemplateCall.ts
 types/thisType/thisTypeInTuples.ts
 types/thisType/thisTypeInTypePredicate.ts

--- a/crates/stc_ts_type_checker/tests/conformance/controlFlow/dependentDestructuredVariables.ts.stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/conformance/controlFlow/dependentDestructuredVariables.ts.stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
     required_error: 2,
     matched_error: 0,
-    extra_error: 30,
+    extra_error: 22,
     panic: 0,
 }

--- a/crates/stc_ts_type_checker/tests/conformance/types/thisType/thisTypeInObjectLiterals2.ts.stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/conformance/types/thisType/thisTypeInObjectLiterals2.ts.stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
     required_error: 0,
     matched_error: 0,
-    extra_error: 9,
+    extra_error: 0,
     panic: 0,
 }

--- a/crates/stc_ts_type_checker/tests/tsc-stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/tsc-stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
     required_error: 4338,
     matched_error: 5546,
-    extra_error: 991,
+    extra_error: 974,
     panic: 74,
 }


### PR DESCRIPTION
**Description:**

 - Add `apply_fn_type_ann`.
 - Exclude `null` and `undefined` while determining type of methods.