### PR TITLE
fix(ts/analyzer): should use NoSuchProperty for globalThis.name

### DIFF
--- a/crates/stc_ts_file_analyzer/tests/pass/es6/arrowFunction/emitArrowFunctionThisCapturingES6/1.swc-stderr
+++ b/crates/stc_ts_file_analyzer/tests/pass/es6/arrowFunction/emitArrowFunctionThisCapturingES6/1.swc-stderr
@@ -1,0 +1,46 @@
+
+  x Type
+   ,-[$DIR/tests/pass/es6/arrowFunction/emitArrowFunctionThisCapturingES6/1.ts:2:5]
+ 2 | this.name = x
+   : ^^^^
+   `----
+
+Error: 
+  > typeof globalThis
+
+  x Type
+   ,-[$DIR/tests/pass/es6/arrowFunction/emitArrowFunctionThisCapturingES6/1.ts:2:5]
+ 2 | this.name = x
+   : ^^^^^^^^^
+   `----
+
+Error: 
+  > any
+
+  x Type
+   ,-[$DIR/tests/pass/es6/arrowFunction/emitArrowFunctionThisCapturingES6/1.ts:2:5]
+ 2 | this.name = x
+   :             ^
+   `----
+
+Error: 
+  > string
+
+  x Type
+   ,-[$DIR/tests/pass/es6/arrowFunction/emitArrowFunctionThisCapturingES6/1.ts:2:5]
+ 2 | this.name = x
+   : ^^^^^^^^^^^^^
+   `----
+
+Error: 
+  > string
+
+  x Type
+   ,-[$DIR/tests/pass/es6/arrowFunction/emitArrowFunctionThisCapturingES6/1.ts:1:1]
+ 1 | ,-> (x: string) => {
+ 2 | |       this.name = x
+ 3 | `-> }
+   `----
+
+Error: 
+  > (x: string) => void

--- a/crates/stc_ts_file_analyzer/tests/pass/es6/arrowFunction/emitArrowFunctionThisCapturingES6/1.ts
+++ b/crates/stc_ts_file_analyzer/tests/pass/es6/arrowFunction/emitArrowFunctionThisCapturingES6/1.ts
@@ -1,0 +1,3 @@
+(x: string) => {
+    this.name = x
+}

--- a/crates/stc_ts_type_checker/tests/conformance.pass.txt
+++ b/crates/stc_ts_type_checker/tests/conformance.pass.txt
@@ -1846,6 +1846,7 @@ parser/ecmascript5/parserUsingConstructorAsIdentifier.ts
 parser/ecmascript5/parserVoidExpression1.ts
 parser/ecmascript5/parservoidInQualifiedName0.ts
 parser/ecmascript5/parservoidInQualifiedName2.ts
+parser/ecmascript6/ComputedPropertyNames/parserCambient/ambientDeclarationsPatterns_tooManyAsterisks.ts
 parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName12.ts
 parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName17.ts
 parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName2.ts

--- a/crates/stc_ts_type_checker/tests/conformance/es6/arrowFunction/emitArrowFunctionThisCapturing.ts.stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/conformance/es6/arrowFunction/emitArrowFunctionThisCapturing.ts.stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
     required_error: 1,
     matched_error: 0,
-    extra_error: 1,
+    extra_error: 0,
     panic: 0,
 }

--- a/crates/stc_ts_type_checker/tests/conformance/es6/arrowFunction/emitArrowFunctionThisCapturingES6.ts.stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/conformance/es6/arrowFunction/emitArrowFunctionThisCapturingES6.ts.stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
     required_error: 1,
     matched_error: 0,
-    extra_error: 1,
+    extra_error: 0,
     panic: 0,
 }

--- a/crates/stc_ts_type_checker/tests/tsc-stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/tsc-stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
     required_error: 4334,
     matched_error: 5550,
-    extra_error: 942,
+    extra_error: 940,
     panic: 74,
 }


### PR DESCRIPTION
<!-- Note: CI script will automatically rebase your PR so please do not rebase unless required -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**BREAKING CHANGE:**

<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG. Add description or remove entirely if not breaking.

You may need to update `MIGRATION.md` for the breaking changes.
-->

**Related issue (if exists):**

Fix #337 