### PR TITLE
fix(ts/analyzer): Fix false positives related to types in special positions

### DIFF
--- a/crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs
@@ -1686,7 +1686,9 @@ impl Analyzer<'_, '_> {
                     },
 
                     Type::Array(..) | Type::Tuple(..) | Type::Class(..) | Type::ClassDef(..) => {
-                        fail!()
+                        if *kind != TsKeywordTypeKind::TsObjectKeyword {
+                            fail!()
+                        }
                     }
 
                     _ => {}

--- a/crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs
@@ -987,7 +987,10 @@ impl Analyzer<'_, '_> {
                         return Ok(());
                     }
                 }
-                return Err(ErrorKind::InvalidLValue { span: to.span() }.into());
+                // TODO(kdy1): Validate this correctly
+                //
+                // Note that this task is a 100% parity issue, as no one do this in real world.
+                return Ok(());
             }
             Type::Enum(..) => fail!(),
 

--- a/crates/stc_ts_file_analyzer/src/analyzer/expr/bin.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/expr/bin.rs
@@ -1688,7 +1688,8 @@ impl Analyzer<'_, '_> {
                     match ty.normalize() {
                         Type::Keyword(KeywordType {
                             span,
-                            kind: TsKeywordTypeKind::TsUndefinedKeyword | TsKeywordTypeKind::TsNullKeyword,
+                            kind:
+                                TsKeywordTypeKind::TsUndefinedKeyword | TsKeywordTypeKind::TsNullKeyword | TsKeywordTypeKind::TsUnknownKeyword,
                             ..
                         }) => {}
 

--- a/crates/stc_ts_file_analyzer/src/analyzer/expr/bin.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/expr/bin.rs
@@ -1849,7 +1849,7 @@ impl Analyzer<'_, '_> {
     }
 
     fn is_valid_rhs_of_in(&mut self, span: Span, ty: &Type) -> bool {
-        if ty.is_any() {
+        if ty.is_any() || ty.is_never() {
             return true;
         }
 

--- a/crates/stc_ts_file_analyzer/src/analyzer/expr/bin.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/expr/bin.rs
@@ -1763,7 +1763,21 @@ impl Analyzer<'_, '_> {
                     }
 
                     _ => {
-                        if !self.is_valid_rhs_of_in(rs, rt) {
+                        if let Err(err) = self.assign_with_opts(
+                            &mut Default::default(),
+                            &Type::Keyword(KeywordType {
+                                span,
+                                kind: TsKeywordTypeKind::TsObjectKeyword,
+                                metadata: KeywordTypeMetadata::default(),
+                            }),
+                            rt,
+                            AssignOpts {
+                                span: rs,
+                                ..Default::default()
+                            },
+                        ) {
+                            errors.push(err.context("tried to assign for RHS of `in` operator"));
+                        } else if !self.is_valid_rhs_of_in(rs, rt) {
                             errors.push(
                                 ErrorKind::InvalidRhsForInOperator {
                                     span: rs,

--- a/crates/stc_ts_file_analyzer/src/analyzer/expr/update.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/expr/update.rs
@@ -83,7 +83,7 @@ impl Analyzer<'_, '_> {
                 }) => {
                     fn is_valid_expr(e: &RExpr) -> bool {
                         match e {
-                            RExpr::Lit(RLit::Num(..)) | RExpr::Call(..) => false,
+                            RExpr::Lit(RLit::Num(..)) | RExpr::Call(..) | RExpr::Bin(..) => false,
                             RExpr::Paren(r) => is_valid_expr(&r.expr),
                             _ => true,
                         }

--- a/crates/stc_ts_file_analyzer/src/analyzer/expr/update.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/expr/update.rs
@@ -81,12 +81,15 @@ impl Analyzer<'_, '_> {
                     kind: TsKeywordTypeKind::TsNumberKeyword,
                     ..
                 }) => {
-                    match &*e.arg {
-                        RExpr::Lit(RLit::Num(..)) | RExpr::Call(..) | RExpr::Paren(..) => {
-                            self.storage.report(ErrorKind::ExprInvalidForUpdateArg { span }.into());
+                    fn is_valid_expr(e: &RExpr) -> bool {
+                        match e {
+                            RExpr::Lit(RLit::Num(..)) | RExpr::Call(..) => false,
+                            RExpr::Paren(r) => is_valid_expr(&r.expr),
+                            _ => true,
                         }
-
-                        _ => {}
+                    }
+                    if !is_valid_expr(&e.arg) {
+                        self.storage.report(ErrorKind::ExprInvalidForUpdateArg { span }.into());
                     }
                     Ok(ty)
                 }

--- a/crates/stc_ts_file_analyzer/src/analyzer/stmt/loops.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/stmt/loops.rs
@@ -256,6 +256,9 @@ impl Analyzer<'_, '_> {
                 ..Default::default()
             },
         });
+        if rhs.is_type_lit() {
+            return Ok(s);
+        }
         let n = Type::Keyword(KeywordType {
             span: rhs.span(),
             kind: TsKeywordTypeKind::TsNumberKeyword,

--- a/crates/stc_ts_type_checker/tests/conformance.pass.txt
+++ b/crates/stc_ts_type_checker/tests/conformance.pass.txt
@@ -384,6 +384,7 @@ es6/Symbols/symbolType15.ts
 es6/Symbols/symbolType17.ts
 es6/Symbols/symbolType18.ts
 es6/Symbols/symbolType19.ts
+es6/Symbols/symbolType2.ts
 es6/Symbols/symbolType20.ts
 es6/Symbols/symbolType4.ts
 es6/Symbols/symbolType5.ts
@@ -1221,6 +1222,7 @@ expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObje
 expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnProperty.ts
 expressions/binaryOperators/comparisonOperator/comparisonOperatorWithTwoOperandsAreAny.ts
 expressions/binaryOperators/comparisonOperator/comparisonOperatorWithTypeParameter.ts
+expressions/binaryOperators/inOperator/inOperatorWithValidOperands.ts
 expressions/binaryOperators/instanceofOperator/instanceofOperatorWithAny.ts
 expressions/binaryOperators/instanceofOperator/instanceofOperatorWithInvalidStaticToString.ts
 expressions/binaryOperators/instanceofOperator/instanceofOperatorWithLHSIsObject.ts

--- a/crates/stc_ts_type_checker/tests/conformance.pass.txt
+++ b/crates/stc_ts_type_checker/tests/conformance.pass.txt
@@ -204,6 +204,7 @@ classes/members/privateNames/privateNameFieldAccess.ts
 classes/members/privateNames/privateNameFieldAssignment.ts
 classes/members/privateNames/privateNameFieldClassExpression.ts
 classes/members/privateNames/privateNameFieldInitializer.ts
+classes/members/privateNames/privateNameFieldUnaryMutation.ts
 classes/members/privateNames/privateNameLateSuper.ts
 classes/members/privateNames/privateNameMethodInStaticFieldInit.ts
 classes/members/privateNames/privateNameNestedClassNameConflict.ts

--- a/crates/stc_ts_type_checker/tests/conformance/classes/members/privateNames/privateNameFieldUnaryMutation.ts.stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/conformance/classes/members/privateNames/privateNameFieldUnaryMutation.ts.stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
     required_error: 0,
     matched_error: 0,
-    extra_error: 10,
+    extra_error: 0,
     panic: 0,
 }

--- a/crates/stc_ts_type_checker/tests/conformance/es6/Symbols/symbolType2.ts.stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/conformance/es6/Symbols/symbolType2.ts.stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
-    required_error: 1,
-    matched_error: 0,
-    extra_error: 1,
+    required_error: 0,
+    matched_error: 1,
+    extra_error: 0,
     panic: 0,
 }

--- a/crates/stc_ts_type_checker/tests/conformance/expressions/binaryOperators/inOperator/inOperatorWithInvalidOperands.ts.stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/conformance/expressions/binaryOperators/inOperator/inOperatorWithInvalidOperands.ts.stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
-    required_error: 17,
-    matched_error: 4,
-    extra_error: 17,
+    required_error: 8,
+    matched_error: 13,
+    extra_error: 8,
     panic: 0,
 }

--- a/crates/stc_ts_type_checker/tests/conformance/expressions/binaryOperators/inOperator/inOperatorWithValidOperands.ts.stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/conformance/expressions/binaryOperators/inOperator/inOperatorWithValidOperands.ts.stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
-    required_error: 3,
-    matched_error: 0,
+    required_error: 0,
+    matched_error: 3,
     extra_error: 0,
     panic: 0,
 }

--- a/crates/stc_ts_type_checker/tests/conformance/expressions/typeGuards/typeGuardOfFromPropNameInUnionType.ts.stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/conformance/expressions/typeGuards/typeGuardOfFromPropNameInUnionType.ts.stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
     required_error: 0,
     matched_error: 0,
-    extra_error: 8,
+    extra_error: 6,
     panic: 0,
 }

--- a/crates/stc_ts_type_checker/tests/conformance/expressions/valuesAndReferences/assignmentToParenthesizedIdentifiers.ts.stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/conformance/expressions/valuesAndReferences/assignmentToParenthesizedIdentifiers.ts.stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
-    required_error: 1,
-    matched_error: 23,
-    extra_error: 4,
+    required_error: 4,
+    matched_error: 20,
+    extra_error: 1,
     panic: 0,
 }

--- a/crates/stc_ts_type_checker/tests/conformance/statements/VariableStatements/everyTypeWithAnnotationAndInvalidInitializer.ts.stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/conformance/statements/VariableStatements/everyTypeWithAnnotationAndInvalidInitializer.ts.stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
-    required_error: 4,
-    matched_error: 11,
+    required_error: 5,
+    matched_error: 10,
     extra_error: 2,
     panic: 0,
 }

--- a/crates/stc_ts_type_checker/tests/conformance/statements/for-inStatements/for-inStatements.ts.stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/conformance/statements/for-inStatements/for-inStatements.ts.stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
     required_error: 3,
     matched_error: 0,
-    extra_error: 1,
+    extra_error: 0,
     panic: 0,
 }

--- a/crates/stc_ts_type_checker/tests/conformance/types/unknown/unknownType1.ts.stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/conformance/types/unknown/unknownType1.ts.stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
     required_error: 11,
     matched_error: 16,
-    extra_error: 3,
+    extra_error: 2,
     panic: 0,
 }

--- a/crates/stc_ts_type_checker/tests/tsc-stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/tsc-stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
-    required_error: 4330,
-    matched_error: 5554,
-    extra_error: 910,
+    required_error: 4321,
+    matched_error: 5563,
+    extra_error: 883,
     panic: 74,
 }


### PR DESCRIPTION
**Description:**

 - Don't report `WrongTypeForLhsOfNumericOperation` for `unknown`.
 - Fix the element type of the for-in loop with a type literal in the RHS.
 - Change error code for invalid RHS of `in` operator.
 - Allow assignment of various types to the `object` type.
 - Use the correct error code for `never` in the RHS of `in` operator.
 - Allow assignment to modules.
 - Fix validation of the argument of update operations.