### PR TITLE
fix(ts/analyzer): FIx types of vars declared with rest patterns

### DIFF
--- a/crates/stc_ts_file_analyzer/src/analyzer/scope/vars.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/scope/vars.rs
@@ -67,7 +67,7 @@ impl Analyzer<'_, '_> {
         default: Option<Type>,
         opts: DeclareVarsOpts,
     ) -> VResult<()> {
-        let _ctx = ctx!("add_vars");
+        let _ctx = ctx!(format!("add_vars: {:?}", opts));
 
         if let Some(ty) = &ty {
             ty.assert_valid();

--- a/crates/stc_ts_file_analyzer/tests/pass/vars/destructuring/declarationsAndAssignments/1.swc-stderr
+++ b/crates/stc_ts_file_analyzer/tests/pass/vars/destructuring/declarationsAndAssignments/1.swc-stderr
@@ -1,0 +1,108 @@
+
+  x Type
+   ,-[$DIR/tests/pass/vars/destructuring/declarationsAndAssignments/1.ts:9:5]
+ 9 | var [...a0] = v;
+   :               ^
+   `----
+
+Error: 
+  > [number, string, boolean]
+
+  x Type
+    ,-[$DIR/tests/pass/vars/destructuring/declarationsAndAssignments/1.ts:10:5]
+ 10 | var [x, ...a1] = v;
+    :                  ^
+    `----
+
+Error: 
+  > [number, string, boolean]
+
+  x Type
+    ,-[$DIR/tests/pass/vars/destructuring/declarationsAndAssignments/1.ts:11:5]
+ 11 | var [x, y, ...a2] = v;
+    :                     ^
+    `----
+
+Error: 
+  > [number, string, boolean]
+
+  x Type
+    ,-[$DIR/tests/pass/vars/destructuring/declarationsAndAssignments/1.ts:12:5]
+ 12 | var [x, y, z, ...a3] = v;
+    :                        ^
+    `----
+
+Error: 
+  > [number, string, boolean]
+
+  x Type
+    ,-[$DIR/tests/pass/vars/destructuring/declarationsAndAssignments/1.ts:13:5]
+ 13 | [...a0] = v;
+    :           ^
+    `----
+
+Error: 
+  > [number, string, boolean]
+
+  x Type
+    ,-[$DIR/tests/pass/vars/destructuring/declarationsAndAssignments/1.ts:13:5]
+ 13 | [...a0] = v;
+    : ^^^^^^^^^^^
+    `----
+
+Error: 
+  > [number, string, boolean]
+
+  x Type
+    ,-[$DIR/tests/pass/vars/destructuring/declarationsAndAssignments/1.ts:14:5]
+ 14 | [x, ...a1] = v;
+    :              ^
+    `----
+
+Error: 
+  > [number, string, boolean]
+
+  x Type
+    ,-[$DIR/tests/pass/vars/destructuring/declarationsAndAssignments/1.ts:14:5]
+ 14 | [x, ...a1] = v;
+    : ^^^^^^^^^^^^^^
+    `----
+
+Error: 
+  > [number, string, boolean]
+
+  x Type
+    ,-[$DIR/tests/pass/vars/destructuring/declarationsAndAssignments/1.ts:15:5]
+ 15 | [x, y, ...a2] = v;
+    :                 ^
+    `----
+
+Error: 
+  > [number, string, boolean]
+
+  x Type
+    ,-[$DIR/tests/pass/vars/destructuring/declarationsAndAssignments/1.ts:15:5]
+ 15 | [x, y, ...a2] = v;
+    : ^^^^^^^^^^^^^^^^^
+    `----
+
+Error: 
+  > [number, string, boolean]
+
+  x Type
+    ,-[$DIR/tests/pass/vars/destructuring/declarationsAndAssignments/1.ts:16:5]
+ 16 | [x, y, z, ...a3] = v;
+    :                    ^
+    `----
+
+Error: 
+  > [number, string, boolean]
+
+  x Type
+    ,-[$DIR/tests/pass/vars/destructuring/declarationsAndAssignments/1.ts:16:5]
+ 16 | [x, y, z, ...a3] = v;
+    : ^^^^^^^^^^^^^^^^^^^^
+    `----
+
+Error: 
+  > [number, string, boolean]

--- a/crates/stc_ts_file_analyzer/tests/pass/vars/destructuring/declarationsAndAssignments/1.ts
+++ b/crates/stc_ts_file_analyzer/tests/pass/vars/destructuring/declarationsAndAssignments/1.ts
@@ -1,0 +1,17 @@
+export function f21(v: [number, string, boolean]) {
+    var x: number;
+    var y: string;
+    var z: boolean;
+    var a0: [number, string, boolean];
+    var a1: [string, boolean];
+    var a2: [boolean];
+    var a3: [];
+    var [...a0] = v;
+    var [x, ...a1] = v;
+    var [x, y, ...a2] = v;
+    var [x, y, z, ...a3] = v;
+    [...a0] = v;
+    [x, ...a1] = v;
+    [x, y, ...a2] = v;
+    [x, y, z, ...a3] = v;
+}

--- a/crates/stc_ts_type_checker/tests/conformance/es6/destructuring/declarationsAndAssignments.ts.stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/conformance/es6/destructuring/declarationsAndAssignments.ts.stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
     required_error: 11,
     matched_error: 9,
-    extra_error: 5,
+    extra_error: 3,
     panic: 0,
 }

--- a/crates/stc_ts_type_checker/tests/tsc-stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/tsc-stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
     required_error: 4304,
     matched_error: 5580,
-    extra_error: 829,
+    extra_error: 827,
     panic: 74,
 }


### PR DESCRIPTION
**Description:**


**Related issue:**

 - Closes https://github.com/dudykr/stc/issues/186.