### PR TITLE
Update(ts/analzer): line_col should display end_column

### DIFF
--- a/crates/stc_ts_file_analyzer/src/analyzer/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/mod.rs
@@ -659,7 +659,8 @@ impl<'scope, 'b> Analyzer<'scope, 'b> {
             return "".into();
         }
         let loc = self.cm.lookup_char_pos(span.lo);
-        format!("({}:{})", loc.line, loc.col_display)
+        let hic = self.cm.lookup_char_pos(span.hi);
+        format!("({}:{}-{:?})", loc.line, loc.col_display + 1, hic.col_display + 1)
     }
 
     fn validate_with<F>(&mut self, op: F)


### PR DESCRIPTION
**BREAKING CHANGE:**

Until now, when we look at the log, we have identified the location of the ts file.
However, only the column start position for that location was received, and the end position could not be obtained.

So I modified that part.

```rs
fn line_col(&self, span: Span) -> String {
    if span.is_dummy() {
        return "".into();
    }
    let loc = self.cm.lookup_char_pos(span.lo);
    let hic = self.cm.lookup_char_pos(span.hi);
    format!("({}:{}-{:?})", loc.line, loc.col_display + 1, hic.col_display + 1)
}
```

**Related issue (if exists):**
None