### PR TITLE
fix(ts/analyzer): Top-level throws return `never`

### DIFF
--- a/crates/stc_ts_file_analyzer/src/analyzer/stmt/return_type.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/stmt/return_type.rs
@@ -71,9 +71,10 @@ impl Analyzer<'_, '_> {
 
         let mut unconditional_throw = None;
         for stmt in stmts {
-            let RStmt::Throw(throws) = stmt else {continue};
-            unconditional_throw = Some(throws.span);
-            break;
+            if let RStmt::Throw(throws) = stmt {
+                unconditional_throw = Some(throws.span);
+                break;
+            }
         }
 
         let cannot_fallback_to_iterable_iterator = self.rule().strict_null_checks && {

--- a/crates/stc_ts_file_analyzer/tests/pass/fn/impl/1.swc-stderr
+++ b/crates/stc_ts_file_analyzer/tests/pass/fn/impl/1.swc-stderr
@@ -1,0 +1,38 @@
+
+  x Type
+   ,-[$DIR/tests/pass/fn/impl/1.ts:1:1]
+ 1 | undefined === function(): number {
+   : ^^^^^^^^^
+   `----
+
+Error: 
+  > undefined
+
+  x Type
+   ,-[$DIR/tests/pass/fn/impl/1.ts:2:3]
+ 2 | throw undefined
+   :       ^^^^^^^^^
+   `----
+
+Error: 
+  > undefined
+
+  x Type
+   ,-[$DIR/tests/pass/fn/impl/1.ts:1:1]
+ 1 | ,-> undefined === function(): number {
+ 2 | |     throw undefined
+ 3 | `-> }
+   `----
+
+Error: 
+  > () => number
+
+  x Type
+   ,-[$DIR/tests/pass/fn/impl/1.ts:1:1]
+ 1 | ,-> undefined === function(): number {
+ 2 | |     throw undefined
+ 3 | `-> }
+   `----
+
+Error: 
+  > boolean

--- a/crates/stc_ts_file_analyzer/tests/pass/fn/impl/1.ts
+++ b/crates/stc_ts_file_analyzer/tests/pass/fn/impl/1.ts
@@ -1,0 +1,3 @@
+undefined === function(): number {
+  throw undefined
+}

--- a/crates/stc_ts_type_checker/tests/conformance/functions/functionImplementationErrors.ts.stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/conformance/functions/functionImplementationErrors.ts.stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
     required_error: 3,
     matched_error: 1,
-    extra_error: 1,
+    extra_error: 0,
     panic: 0,
 }

--- a/crates/stc_ts_type_checker/tests/conformance/functions/functionImplementations.ts.stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/conformance/functions/functionImplementations.ts.stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
     required_error: 1,
     matched_error: 0,
-    extra_error: 4,
+    extra_error: 3,
     panic: 0,
 }

--- a/crates/stc_ts_type_checker/tests/conformance/types/typeRelationships/typeInference/keyofInferenceLowerPriorityThanReturn.ts.stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/conformance/types/typeRelationships/typeInference/keyofInferenceLowerPriorityThanReturn.ts.stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
     required_error: 0,
     matched_error: 0,
-    extra_error: 3,
+    extra_error: 2,
     panic: 0,
 }


### PR DESCRIPTION
<!-- Note: CI script will automatically rebase your PR so please do not rebase unless required -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Fixes type inference in this case:
```js
function(): number {
  throw undefined
}
```

Originally, `throw` statements do not contribute to return values, and hence fails type inference. Only top-level throws are considered for now.

**BREAKING CHANGE:**

<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG. Add description or remove entirely if not breaking.

You may need to update `MIGRATION.md` for the breaking changes.
-->

None known yet

**Related issue (if exists):**

None
