### PR TITLE
fix(ts/analyzer): Fix module declaration evaluation order

### DIFF
--- a/crates/stc_ts_file_analyzer/tests/pass/es6/module/conflictsWithClass/1.swc-stderr
+++ b/crates/stc_ts_file_analyzer/tests/pass/es6/module/conflictsWithClass/1.swc-stderr
@@ -1,0 +1,27 @@
+
+  x Type
+   ,-[$DIR/tests/pass/es6/module/conflictsWithClass/1.ts:8:3]
+ 8 | var inside = foo
+   :              ^^^
+   `----
+
+Error: 
+  > Foo
+
+  x Type
+   ,-[$DIR/tests/pass/es6/module/conflictsWithClass/1.ts:9:3]
+ 9 | var a = inside.a
+   :         ^^^^^^
+   `----
+
+Error: 
+  > Foo
+
+  x Type
+   ,-[$DIR/tests/pass/es6/module/conflictsWithClass/1.ts:9:3]
+ 9 | var a = inside.a
+   :         ^^^^^^^^
+   `----
+
+Error: 
+  > string

--- a/crates/stc_ts_file_analyzer/tests/pass/es6/module/conflictsWithClass/1.ts
+++ b/crates/stc_ts_file_analyzer/tests/pass/es6/module/conflictsWithClass/1.ts
@@ -1,0 +1,10 @@
+class Foo {
+  a = 'a'
+}
+
+var foo: Foo
+
+module Foo {
+  var inside = foo
+  var a = inside.a
+}

--- a/crates/stc_ts_ordering/src/stmt.rs
+++ b/crates/stc_ts_ordering/src/stmt.rs
@@ -137,13 +137,6 @@ fn ids_declared_by_decl(d: &RDecl) -> AHashMap<TypedId, AHashSet<TypedId>> {
         }) => {
             map.insert(
                 TypedId {
-                    kind: IdCtx::Type,
-                    id: i.clone().into(),
-                },
-                Default::default(),
-            );
-            map.insert(
-                TypedId {
                     kind: IdCtx::Var,
                     id: i.clone().into(),
                 },

--- a/crates/stc_ts_type_checker/tests/conformance.pass.txt
+++ b/crates/stc_ts_type_checker/tests/conformance.pass.txt
@@ -2366,6 +2366,7 @@ types/typeRelationships/bestCommonType/bestCommonTypeOfTuple.ts
 types/typeRelationships/bestCommonType/bestCommonTypeOfTuple2.ts
 types/typeRelationships/bestCommonType/functionWithMultipleReturnStatements.ts
 types/typeRelationships/bestCommonType/functionWithMultipleReturnStatements2.ts
+types/typeRelationships/bestCommonType/heterogeneousArrayLiterals.ts
 types/typeRelationships/comparable/equalityStrictNulls.ts
 types/typeRelationships/comparable/equalityWithIntersectionTypes01.ts
 types/typeRelationships/comparable/equalityWithUnionTypes01.ts

--- a/crates/stc_ts_type_checker/tests/conformance/types/typeRelationships/bestCommonType/heterogeneousArrayLiterals.ts.stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/conformance/types/typeRelationships/bestCommonType/heterogeneousArrayLiterals.ts.stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
     required_error: 0,
     matched_error: 0,
-    extra_error: 8,
+    extra_error: 0,
     panic: 0,
 }

--- a/crates/stc_ts_type_checker/tests/tsc-stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/tsc-stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
     required_error: 4267,
     matched_error: 5617,
-    extra_error: 753,
+    extra_error: 745,
     panic: 74,
 }


### PR DESCRIPTION
<!-- Note: CI script will automatically rebase your PR so please do not rebase unless required -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Fixes the following example:
```js
class Foo {}
var foo: Foo
module Foo {
  var inside = foo // 'foo' is not visible
}
```

While generating the dependency graph, `module Foo` used to be declared both as a type and a variable. This causes the module to be evaluated before the var-declaration, therefore making `foo` invisible to the module. However, it is [not currently valid to refer to modules in type annotations](https://www.typescriptlang.org/play?#code/LYewJgrgNgpgBAMRCOBvAUHLcYA8AOIATgC5wkCe+8SIAyiUQJYB2A5nALxwDOjrbdAF90ANwCGROADNkALkTI4AemVwWIMhKhMwYyTL7N2C2gDpaDYx1VwmJHjgLEHcSTAA0cABYgA7jCiMERAA), so they shouldn't be declared as one.

**BREAKING CHANGE:**

<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG. Add description or remove entirely if not breaking.

You may need to update `MIGRATION.md` for the breaking changes.
-->

None known yet

**Related issue (if exists):**

Partially addresses #361 
