### PR TITLE
fix(ts/analyzer): allow assigning to a mapped type that takes itself as arg

### DIFF
--- a/crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs
@@ -1470,6 +1470,20 @@ impl Analyzer<'_, '_> {
 
                 match to.normalize() {
                     Type::Union(..) => {}
+                    Type::Mapped(m) => {
+                        if let Some(
+                            constraint @ Type::Operator(Operator {
+                                op: TsTypeOperatorOp::KeyOf,
+                                ty,
+                                ..
+                            }),
+                        ) = m.type_param.constraint.as_deref().map(|ty| ty.normalize())
+                        {
+                            if rhs.type_eq(ty) {
+                                return Ok(());
+                            }
+                        }
+                    }
                     _ => {
                         fail!()
                     }

--- a/crates/stc_ts_type_checker/tests/conformance/types/mapped/mappedTypeRelationships.ts.stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/conformance/types/mapped/mappedTypeRelationships.ts.stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
     required_error: 27,
     matched_error: 1,
-    extra_error: 22,
+    extra_error: 21,
     panic: 0,
 }

--- a/crates/stc_ts_type_checker/tests/conformance/types/mapped/mappedTypeRelationships.ts.stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/conformance/types/mapped/mappedTypeRelationships.ts.stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
     required_error: 27,
     matched_error: 1,
-    extra_error: 25,
+    extra_error: 22,
     panic: 0,
 }

--- a/crates/stc_ts_type_checker/tests/conformance/types/mapped/mappedTypes6.ts.stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/conformance/types/mapped/mappedTypes6.ts.stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
-    required_error: 9,
-    matched_error: 10,
+    required_error: 6,
+    matched_error: 13,
     extra_error: 11,
     panic: 0,
 }

--- a/crates/stc_ts_type_checker/tests/conformance/types/mapped/mappedTypes6.ts.stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/conformance/types/mapped/mappedTypes6.ts.stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
-    required_error: 6,
-    matched_error: 13,
-    extra_error: 15,
+    required_error: 9,
+    matched_error: 10,
+    extra_error: 11,
     panic: 0,
 }

--- a/crates/stc_ts_type_checker/tests/conformance/types/mapped/mappedTypes6.ts.stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/conformance/types/mapped/mappedTypes6.ts.stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
     required_error: 6,
     matched_error: 13,
-    extra_error: 11,
+    extra_error: 6,
     panic: 0,
 }

--- a/crates/stc_ts_type_checker/tests/tsc-stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/tsc-stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
-    required_error: 4268,
-    matched_error: 5616,
-    extra_error: 758,
+    required_error: 4265,
+    matched_error: 5619,
+    extra_error: 752,
     panic: 72,
 }

--- a/crates/stc_ts_type_checker/tests/tsc-stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/tsc-stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
-    required_error: 4265,
-    matched_error: 5619,
-    extra_error: 765,
+    required_error: 4268,
+    matched_error: 5616,
+    extra_error: 758,
     panic: 72,
 }


### PR DESCRIPTION

<!-- Note: CI script will automatically rebase your PR so please do not rebase unless required -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**
handle these cases.
```
function f1<T>(x: Required<T>, y: T) {
    y = x
    x = y // error because `Require` has -? modifiers
}

function f2<T>(x: Partial<T>, y: T) {
    y = x; // error because `Partial` has +? or ? modifiers
    x = y;
}
```

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**BREAKING CHANGE:**

<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG. Add description or remove entirely if not breaking.

You may need to update `MIGRATION.md` for the breaking changes.
-->

**Related issue (if exists):**
