### PR TITLE
fix(ts/analyzer): Add error when performing unary op on unknown type

### DIFF
--- a/crates/stc_ts_file_analyzer/src/analyzer/expr/unary.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/expr/unary.rs
@@ -270,7 +270,7 @@ impl Analyzer<'_, '_> {
                 }) => {}
 
                 Type::Keyword(KeywordType {
-                    kind: TsKeywordTypeKind::TsNullKeyword,
+                    kind: TsKeywordTypeKind::TsNullKeyword | TsKeywordTypeKind::TsUnknownKeyword,
                     ..
                 }) => errors.push(ErrorKind::TS2531 { span: arg.span() }.into()),
 

--- a/crates/stc_ts_type_checker/tests/conformance/types/unknown/unknownType1.ts.stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/conformance/types/unknown/unknownType1.ts.stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
-    required_error: 11,
-    matched_error: 16,
+    required_error: 9,
+    matched_error: 18,
     extra_error: 1,
     panic: 0,
 }

--- a/crates/stc_ts_type_checker/tests/tsc-stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/tsc-stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
-    required_error: 4251,
-    matched_error: 5633,
+    required_error: 4249,
+    matched_error: 5635,
     extra_error: 745,
     panic: 72,
 }


### PR DESCRIPTION
<!-- Note: CI script will automatically rebase your PR so please do not rebase unless required -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

Errors when performing unary op on unknown type.

e..g.
```ts
var x: unknown;

+x;  // Error
-x;  // Error
```

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**BREAKING CHANGE:**

<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG. Add description or remove entirely if not breaking.

You may need to update `MIGRATION.md` for the breaking changes.
-->

None

**Related issue (if exists):**


None