### PR TITLE
fix(ts/analyzer): Fix assignment of `Type::Enum`

### DIFF
--- a/crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs
@@ -527,7 +527,6 @@ impl Analyzer<'_, '_> {
                         Some(span),
                         Cow::Borrowed(ty),
                         NormalizeTypeOpts {
-                            expand_enum_def: true,
                             merge_union_elements: true,
                             ..Default::default()
                         },
@@ -782,6 +781,24 @@ impl Analyzer<'_, '_> {
 
         if opts.allow_assignment_of_param {
             if rhs.is_type_param() {
+                return Ok(());
+            }
+        }
+
+        if rhs.is_enum_type() {
+            let rhs = self
+                .normalize(
+                    Some(span),
+                    Cow::Borrowed(rhs),
+                    NormalizeTypeOpts {
+                        expand_enum_def: true,
+                        ..Default::default()
+                    },
+                )?
+                .freezed()
+                .into_owned()
+                .freezed();
+            if self.assign_inner(data, to, &rhs, opts).is_ok() {
                 return Ok(());
             }
         }

--- a/crates/stc_ts_file_analyzer/src/analyzer/assign/type_el.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/assign/type_el.rs
@@ -65,12 +65,12 @@ impl Analyzer<'_, '_> {
             let numeric_keyed_ty = numeric_keyed_ty.unwrap_or(&any);
 
             match *rhs.normalize() {
-                Type::Array(Array { ref elem_type, .. }) => return self.assign_without_wrapping(data, numeric_keyed_ty, elem_type, opts),
+                Type::Array(Array { ref elem_type, .. }) => return self.assign_inner(data, numeric_keyed_ty, elem_type, opts),
 
                 Type::Tuple(Tuple { ref elems, .. }) => {
                     let mut errors = Errors::default();
                     for el in elems {
-                        self.assign_without_wrapping(
+                        self.assign_inner(
                             data,
                             numeric_keyed_ty,
                             &el.ty,
@@ -1119,7 +1119,7 @@ impl Analyzer<'_, '_> {
                                                 }
                                             }
 
-                                            self.assign_without_wrapping(
+                                            self.assign_inner(
                                                 data,
                                                 lp.type_ann.as_deref().unwrap_or(&Type::any(span, Default::default())),
                                                 rp.type_ann.as_deref().unwrap_or(&Type::any(span, Default::default())),

--- a/crates/stc_ts_file_analyzer/src/analyzer/assign/type_el.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/assign/type_el.rs
@@ -65,12 +65,12 @@ impl Analyzer<'_, '_> {
             let numeric_keyed_ty = numeric_keyed_ty.unwrap_or(&any);
 
             match *rhs.normalize() {
-                Type::Array(Array { ref elem_type, .. }) => return self.assign_inner(data, numeric_keyed_ty, elem_type, opts),
+                Type::Array(Array { ref elem_type, .. }) => return self.assign_without_wrapping(data, numeric_keyed_ty, elem_type, opts),
 
                 Type::Tuple(Tuple { ref elems, .. }) => {
                     let mut errors = Errors::default();
                     for el in elems {
-                        self.assign_inner(
+                        self.assign_without_wrapping(
                             data,
                             numeric_keyed_ty,
                             &el.ty,
@@ -1119,7 +1119,7 @@ impl Analyzer<'_, '_> {
                                                 }
                                             }
 
-                                            self.assign_inner(
+                                            self.assign_without_wrapping(
                                                 data,
                                                 lp.type_ann.as_deref().unwrap_or(&Type::any(span, Default::default())),
                                                 rp.type_ann.as_deref().unwrap_or(&Type::any(span, Default::default())),

--- a/crates/stc_ts_file_analyzer/src/analyzer/enums.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/enums.rs
@@ -572,6 +572,7 @@ impl Analyzer<'_, '_> {
         Ok(ty)
     }
 
+    /// Expands an enum variant as a literal.
     pub(super) fn expand_enum_variant(&self, ty: Type) -> VResult<Type> {
         if let Type::EnumVariant(ref ev) = ty.normalize() {
             if let Some(variant_name) = &ev.name {

--- a/crates/stc_ts_file_analyzer/src/analyzer/types/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/types/mod.rs
@@ -2,8 +2,10 @@ use std::{borrow::Cow, collections::HashMap, fmt::Debug};
 
 use fxhash::FxHashMap;
 use itertools::Itertools;
-use rnode::{VisitMutWith, VisitWith};
-use stc_ts_ast_rnode::{RExpr, RIdent, RInvalid, RLit, RNumber, RStr, RTplElement, RTsEntityName, RTsEnumMemberId, RTsLit};
+use rnode::{NodeId, VisitMutWith, VisitWith};
+use stc_ts_ast_rnode::{
+    RBindingIdent, RExpr, RIdent, RInvalid, RLit, RNumber, RPat, RStr, RTplElement, RTsEntityName, RTsEnumMemberId, RTsLit,
+};
 use stc_ts_base_type_ops::bindings::{collect_bindings, BindingCollector, KnownTypeVisitor};
 use stc_ts_errors::{
     debug::{dump_type_as_string, force_dump_type_as_string, print_backtrace},
@@ -13,9 +15,10 @@ use stc_ts_generics::ExpandGenericOpts;
 use stc_ts_type_ops::{tuple_normalization::TupleNormalizer, Fix};
 use stc_ts_types::{
     name::Name, Accessor, Array, Class, ClassDef, ClassMember, ClassMetadata, ComputedKey, Conditional, ConditionalMetadata,
-    ConstructorSignature, EnumVariant, Id, IdCtx, IndexedAccessType, Instance, InstanceMetadata, Intersection, Intrinsic, IntrinsicKind,
-    Key, KeywordType, KeywordTypeMetadata, LitType, LitTypeMetadata, MethodSignature, Operator, PropertySignature, QueryExpr, QueryType,
-    Ref, ThisType, ThisTypeMetadata, TplType, Type, TypeElement, TypeLit, TypeLitMetadata, TypeParam, TypeParamInstantiation, Union,
+    ConstructorSignature, EnumVariant, FnParam, Id, IdCtx, IndexSignature, IndexedAccessType, Instance, InstanceMetadata, Intersection,
+    Intrinsic, IntrinsicKind, Key, KeywordType, KeywordTypeMetadata, LitType, LitTypeMetadata, MethodSignature, Operator,
+    PropertySignature, QueryExpr, QueryType, Ref, ThisType, ThisTypeMetadata, TplType, Type, TypeElement, TypeLit, TypeLitMetadata,
+    TypeParam, TypeParamInstantiation, Union,
 };
 use stc_ts_utils::run;
 use stc_utils::{
@@ -59,8 +62,16 @@ pub(crate) struct NormalizeTypeOpts {
     /// Should we preserve [Type::Union]?
     pub preserve_union: bool,
 
+    /// If `true`, `true | false` becomes `boolean` and `E.**` of enum will be
+    /// merged as `E` if E and all variants are selected.
+    pub merge_union_elements: bool,
+
     //// If `true`, we will not expand generics.
     pub process_only_key: bool,
+
+    /// If `true`, [Type::Enum] will be expanded as a union of `string` and
+    /// [Type::EnumVariant].
+    pub expand_enum_def: bool,
 }
 
 impl Analyzer<'_, '_> {
@@ -103,7 +114,6 @@ impl Analyzer<'_, '_> {
             | Type::Function(..)
             | Type::Constructor(..)
             | Type::EnumVariant(..)
-            | Type::Enum(..)
             | Type::Param(_)
             | Type::Module(_)
             | Type::Tpl(..) => return Ok(ty),
@@ -125,7 +135,7 @@ impl Analyzer<'_, '_> {
 
             if matches!(
                 ty.normalize(),
-                Type::Conditional(..) | Type::Array(..) | Type::IndexedAccessType(..) | Type::Mapped(..)
+                Type::Conditional(..) | Type::Array(..) | Type::IndexedAccessType(..) | Type::Mapped(..) | Type::Union(..)
             ) {
                 ty.make_clone_cheap();
             }
@@ -227,6 +237,108 @@ impl Analyzer<'_, '_> {
                     Type::Infer(_) | Type::StaticThis(_) | Type::This(_) => {}
 
                     Type::Union(ty) => {
+                        if opts.merge_union_elements {
+                            let mut enum_counts = FxHashMap::<_, i32>::default();
+                            let mut new_types = vec![];
+
+                            for elem in ty.types.iter() {
+                                // TODO(kdy1): Cache the result of normalize
+
+                                let elem = self
+                                    .normalize(
+                                        span,
+                                        Cow::Borrowed(elem),
+                                        NormalizeTypeOpts {
+                                            preserve_mapped: true,
+                                            preserve_typeof: false,
+                                            normalize_keywords: false,
+                                            preserve_global_this: true,
+                                            preserve_intersection: true,
+                                            preserve_union: true,
+                                            merge_union_elements: false,
+                                            process_only_key: false,
+                                            expand_enum_def: false,
+                                        },
+                                    )?
+                                    .into_owned();
+
+                                if let Type::EnumVariant(EnumVariant {
+                                    name: Some(..), enum_name, ..
+                                }) = elem.normalize()
+                                {
+                                    *enum_counts.entry(enum_name.clone()).or_insert(0) += 1;
+                                }
+                            }
+
+                            for (enum_name, cnt) in enum_counts.iter_mut() {
+                                if let Some(types) = self.find_type(enum_name)? {
+                                    for ty in types {
+                                        if let Type::Enum(e) = ty.normalize() {
+                                            *cnt -= e.members.len() as i32;
+
+                                            if *cnt == 0 {
+                                                new_types.push(Type::EnumVariant(EnumVariant {
+                                                    span: e.span,
+                                                    enum_name: e.id.clone().into(),
+                                                    name: None,
+                                                    metadata: Default::default(),
+                                                    tracker: Default::default(),
+                                                }));
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+
+                            // If the count is 0, it means all variants exist in
+                            // the union.
+                            if enum_counts.values().any(|count| *count == 0) {
+                                for elem in ty.types.iter() {
+                                    let elem = self
+                                        .normalize(
+                                            span,
+                                            Cow::Borrowed(elem),
+                                            NormalizeTypeOpts {
+                                                preserve_mapped: true,
+                                                preserve_typeof: false,
+                                                normalize_keywords: false,
+                                                preserve_global_this: true,
+                                                preserve_intersection: true,
+                                                preserve_union: true,
+                                                merge_union_elements: false,
+                                                process_only_key: false,
+                                                expand_enum_def: false,
+                                            },
+                                        )?
+                                        .into_owned();
+
+                                    if let Type::EnumVariant(EnumVariant {
+                                        span,
+                                        name: Some(..),
+                                        enum_name,
+                                        ..
+                                    }) = elem.normalize()
+                                    {
+                                        if let Some(0) = enum_counts.get(enum_name) {
+                                            // This enum is going to be added to union directly, so we skip the variants.
+                                            continue;
+                                        }
+                                    }
+
+                                    new_types.push(elem);
+                                }
+
+                                return self.normalize(
+                                    span,
+                                    Cow::Owned(Type::new_union(actual_span, new_types)),
+                                    NormalizeTypeOpts {
+                                        merge_union_elements: false,
+                                        ..opts
+                                    },
+                                );
+                            }
+                        }
+
                         if !opts.preserve_union {
                             let mut types = vec![];
 
@@ -556,6 +668,61 @@ impl Analyzer<'_, '_> {
                             .context("tried to get keys of a type as a part of normalization")?;
                         keys_ty.assert_valid();
                         return Ok(Cow::Owned(keys_ty));
+                    }
+
+                    Type::Enum(e) => {
+                        // E => { [k: string]: string | E }
+                        if opts.expand_enum_def {
+                            let actual_span = actual_span.with_ctxt(SyntaxContext::empty());
+                            let string = Type::Keyword(KeywordType {
+                                span: e.span,
+                                kind: TsKeywordTypeKind::TsStringKeyword,
+                                metadata: Default::default(),
+                                tracker: Default::default(),
+                            });
+
+                            let variant = Type::EnumVariant(EnumVariant {
+                                span: e.span,
+                                enum_name: e.id.clone().into(),
+                                name: None,
+                                metadata: Default::default(),
+                                tracker: Default::default(),
+                            });
+
+                            let index_param = FnParam {
+                                span: actual_span,
+                                required: true,
+                                pat: RPat::Ident(RBindingIdent {
+                                    node_id: NodeId::invalid(),
+                                    id: RIdent {
+                                        node_id: NodeId::invalid(),
+                                        span: actual_span,
+                                        sym: "__v".into(),
+                                        optional: false,
+                                    },
+                                    type_ann: None,
+                                }),
+                                ty: box Type::Keyword(KeywordType {
+                                    span: e.span,
+                                    kind: TsKeywordTypeKind::TsStringKeyword,
+                                    metadata: Default::default(),
+                                    tracker: Default::default(),
+                                }),
+                            };
+                            let index = TypeElement::Index(IndexSignature {
+                                span: actual_span,
+                                params: vec![index_param],
+                                type_ann: Some(box Type::new_union(actual_span, vec![string, variant])),
+                                readonly: false,
+                                is_static: false,
+                            });
+                            return Ok(Cow::Owned(Type::TypeLit(TypeLit {
+                                span: actual_span,
+                                members: vec![index],
+                                metadata: Default::default(),
+                                tracker: Default::default(),
+                            })));
+                        }
                     }
 
                     Type::Operator(_) => {

--- a/crates/stc_ts_file_analyzer/src/ty/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/ty/mod.rs
@@ -15,6 +15,17 @@ pub trait TypeExt: Into<Type> {
     fn generalize_tuple(self) -> Type {
         self.into().fold_with(&mut TupleToArray)
     }
+
+    fn drop_enum_variant_name(self) -> Type {
+        let ty: Type = self.into();
+
+        if ty.is_enum_variant() {
+            let e = ty.expect_enum_variant();
+            Type::EnumVariant(EnumVariant { name: None, ..e })
+        } else {
+            ty
+        }
+    }
 }
 
 impl<T> TypeExt for T where T: Into<Type> {}

--- a/crates/stc_ts_file_analyzer/tests/pass-only/assign/enum-declaration/1.ts
+++ b/crates/stc_ts_file_analyzer/tests/pass-only/assign/enum-declaration/1.ts
@@ -1,0 +1,10 @@
+
+export enum E {
+    A, B
+}
+
+export declare let a: { [s: string]: string | E }
+export declare function call(t: { [s: string]: string | E });
+
+a = E
+call(E)

--- a/crates/stc_ts_file_analyzer/tests/pass-only/assign/enum-declaration/2.ts
+++ b/crates/stc_ts_file_analyzer/tests/pass-only/assign/enum-declaration/2.ts
@@ -1,0 +1,10 @@
+
+export enum E {
+    A, B
+}
+
+export declare let a: { [s: string]: string | E.A | E.B }
+export declare function call(t: { [s: string]: string | E.A | E.B });
+
+a = E
+call(E)

--- a/crates/stc_ts_type_checker/tests/conformance/types/typeAliases/interfaceDoesNotDependOnBaseTypes.ts.stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/conformance/types/typeAliases/interfaceDoesNotDependOnBaseTypes.ts.stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
     required_error: 0,
     matched_error: 0,
-    extra_error: 1,
+    extra_error: 2,
     panic: 0,
 }

--- a/crates/stc_ts_type_checker/tests/tsc-stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/tsc-stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
     required_error: 4249,
     matched_error: 5635,
-    extra_error: 745,
+    extra_error: 746,
     panic: 72,
 }

--- a/crates/stc_ts_types/src/lib.rs
+++ b/crates/stc_ts_types/src/lib.rs
@@ -739,6 +739,7 @@ pub struct Module {
 #[cfg(target_pointer_width = "64")]
 assert_eq_size!(Module, [u8; 72]);
 
+/// Enum **definition**.
 #[derive(Debug, Clone, PartialEq, Spanned, EqIgnoreSpan, TypeEq, Visit, Serialize, Deserialize)]
 pub struct Enum {
     pub span: Span,
@@ -1105,11 +1106,12 @@ pub struct MethodSignature {
 
 #[derive(Debug, Clone, PartialEq, Spanned, EqIgnoreSpan, TypeEq, Visit, Serialize, Deserialize)]
 pub struct IndexSignature {
+    pub span: Span,
+
     pub params: Vec<FnParam>,
     pub type_ann: Option<Box<Type>>,
 
     pub readonly: bool,
-    pub span: Span,
 
     pub is_static: bool,
 }
@@ -2170,6 +2172,22 @@ impl<'a> Iterator for Iter<'a> {
 impl FusedIterator for Iter<'_> {}
 
 impl Type {
+    /// Returns true if `self` is a [Type::Ref] pointing to `name` or a builtin
+    /// interface with `name` as the name.
+    pub fn is_builtin_interface(&self, name: &str) -> bool {
+        match self.normalize_instance() {
+            Type::Ref(ref r) => {
+                if let RTsEntityName::Ident(ident) = &r.type_name {
+                    &*ident.sym == name
+                } else {
+                    false
+                }
+            }
+            Type::Interface(i) => i.name == name,
+            _ => false,
+        }
+    }
+
     /// Returns true if `self` is a `string` or a string literal.
     pub fn is_str(&self) -> bool {
         matches!(

--- a/cspell.json
+++ b/cspell.json
@@ -29,6 +29,7 @@
         "nonminimal",
         "opentelemetry",
         "pmutil",
+        "Postprocess",
         "qself",
         "quasis",
         "Redeclared",
@@ -44,6 +45,7 @@
         "subpat",
         "triomphe",
         "Uncapitalize",
+        "upcasted",
         "varargs"
     ],
     "ignorePaths": [


### PR DESCRIPTION
**Description:**

 - Improve assignment logic for keyword types.
 - Use `string | EnumVariant` for `Type::Enum` while assigning. 
 - Merge enum variants from `normalize`.