### PR TITLE
feat(ts/analzer): Implement Intersection

### DIFF
--- a/crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs
@@ -1189,6 +1189,7 @@ impl Analyzer<'_, '_> {
                             rhs,
                             AssignOpts {
                                 allow_unknown_rhs: Some(true),
+                                allow_assignment_to_param_constraint: true,
                                 ..opts
                             },
                         )

--- a/crates/stc_ts_file_analyzer/src/analyzer/expr/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/expr/mod.rs
@@ -849,13 +849,14 @@ impl Analyzer<'_, '_> {
         opts: AccessPropertyOpts,
     ) -> VResult<Option<Type>> {
         let mut matching_elements = vec![];
+        let mut read_only_flag = false;
         for el in members.iter() {
             if let Some(key) = el.key() {
                 if self.key_matches(span, key, prop, true) {
                     match el {
                         TypeElement::Property(ref p) => {
                             if type_mode == TypeOfMode::LValue && p.readonly {
-                                return Err(ErrorKind::ReadOnly { span }.into());
+                                read_only_flag = true;
                             }
 
                             if let Some(ref type_ann) = p.type_ann {
@@ -945,6 +946,9 @@ impl Analyzer<'_, '_> {
         }
 
         if matching_elements.len() == 1 {
+            if read_only_flag {
+                return Err(ErrorKind::ReadOnly { span }.into());
+            }
             return Ok(matching_elements.pop());
         }
 

--- a/crates/stc_ts_file_analyzer/src/analyzer/types/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/types/mod.rs
@@ -1208,7 +1208,7 @@ impl Analyzer<'_, '_> {
                         return never!();
                     }
                 } else {
-                    Type::union(new_types).freezed()
+                    Type::new_union(span, new_types).freezed()
                 }
             }
             if let Type::Union(Union { types: u_types, .. }) = acc_type.normalize() {

--- a/crates/stc_ts_file_analyzer/src/analyzer/types/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/types/mod.rs
@@ -854,7 +854,7 @@ impl Analyzer<'_, '_> {
                 })))
             }};
         }
-        let mut normalize_types = vec![];
+        let mut normalized_types = vec![];
         // set normalize all
         for el in types.iter() {
             if let Ok(res) = self.normalize(
@@ -874,29 +874,29 @@ impl Analyzer<'_, '_> {
                     }) => {}
                     Type::Intersection(Intersection { types, .. }) => {
                         for ty in types {
-                            normalize_types.push(ty.to_owned());
+                            normalized_types.push(ty.to_owned());
                         }
                     }
                     _ => {
-                        normalize_types.push(result);
+                        normalized_types.push(result);
                     }
                 }
             }
         }
 
-        normalize_types.dedup_type();
+        normalized_types.dedup_type();
 
-        if normalize_types.len() == 1 {
-            if let Some(ty) = normalize_types.pop() {
+        if normalized_types.len() == 1 {
+            if let Some(ty) = normalized_types.pop() {
                 return Ok(Some(ty));
             }
         }
         // has never; return never
-        if normalize_types.iter().any(|ty| ty.is_never()) {
+        if normalized_types.iter().any(|ty| ty.is_never()) {
             return never!();
         }
         // has any, return any
-        if normalize_types.iter().any(|ty| ty.is_any()) {
+        if normalized_types.iter().any(|ty| ty.is_any()) {
             return Ok(Some(Type::Keyword(KeywordType {
                 span,
                 kind: TsKeywordTypeKind::TsAnyKeyword,
@@ -905,14 +905,14 @@ impl Analyzer<'_, '_> {
             })));
         }
 
-        let is_symbol = normalize_types.iter().any(|ty| ty.is_symbol());
-        let is_str = normalize_types.iter().any(|ty| ty.is_str());
-        let is_num = normalize_types.iter().any(|ty| ty.is_num());
-        let is_bool = normalize_types.iter().any(|ty| ty.is_bool());
-        let is_null = normalize_types.iter().any(|ty| ty.is_null());
-        let is_undefined = normalize_types.iter().any(|ty| ty.is_undefined());
-        let is_void = normalize_types.iter().any(|ty| ty.is_kwd(TsKeywordTypeKind::TsVoidKeyword));
-        let is_object = normalize_types.iter().any(|ty| ty.is_kwd(TsKeywordTypeKind::TsObjectKeyword));
+        let is_symbol = normalized_types.iter().any(|ty| ty.is_symbol());
+        let is_str = normalized_types.iter().any(|ty| ty.is_str());
+        let is_num = normalized_types.iter().any(|ty| ty.is_num());
+        let is_bool = normalized_types.iter().any(|ty| ty.is_bool());
+        let is_null = normalized_types.iter().any(|ty| ty.is_null());
+        let is_undefined = normalized_types.iter().any(|ty| ty.is_undefined());
+        let is_void = normalized_types.iter().any(|ty| ty.is_kwd(TsKeywordTypeKind::TsVoidKeyword));
+        let is_object = normalized_types.iter().any(|ty| ty.is_kwd(TsKeywordTypeKind::TsObjectKeyword));
 
         let sum = u32::from(is_symbol)
             + u32::from(is_str)
@@ -1098,9 +1098,9 @@ impl Analyzer<'_, '_> {
         }
 
         {
-            let normalize_len = normalize_types.len();
-            normalize_types.make_clone_cheap();
-            let mut type_iter = normalize_types.clone().into_iter();
+            let normalize_len = normalized_types.len();
+            normalized_types.make_clone_cheap();
+            let mut type_iter = normalized_types.clone().into_iter();
             let mut acc_type = type_iter
                 .next()
                 .unwrap_or_else(|| {
@@ -1216,7 +1216,7 @@ impl Analyzer<'_, '_> {
                     return Ok(Some(
                         Type::Intersection(Intersection {
                             span,
-                            types: normalize_types,
+                            types: normalized_types,
                             metadata: Default::default(),
                             tracker: Default::default(),
                         })

--- a/crates/stc_ts_file_analyzer/src/analyzer/types/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/types/mod.rs
@@ -1103,12 +1103,14 @@ impl Analyzer<'_, '_> {
             let mut type_iter = normalize_types.clone().into_iter();
             let mut acc_type = type_iter
                 .next()
-                .unwrap_or(Type::Keyword(KeywordType {
-                    span,
-                    kind: TsKeywordTypeKind::TsNeverKeyword,
-                    metadata: KeywordTypeMetadata { ..Default::default() },
-                    tracker: Default::default(),
-                }))
+                .unwrap_or_else(|| {
+                    Type::Keyword(KeywordType {
+                        span,
+                        kind: TsKeywordTypeKind::TsNeverKeyword,
+                        metadata: KeywordTypeMetadata { ..Default::default() },
+                        tracker: Default::default(),
+                    })
+                })
                 .freezed();
 
             for elem in type_iter {
@@ -1222,7 +1224,7 @@ impl Analyzer<'_, '_> {
                     ));
                 }
             }
-            return Ok(Some(acc_type));
+            Ok(Some(acc_type))
         }
     }
 

--- a/crates/stc_ts_file_analyzer/tests/pass/controlFlow/typeGuards/typeGuardIntersectionTypes/1.swc-stderr
+++ b/crates/stc_ts_file_analyzer/tests/pass/controlFlow/typeGuards/typeGuardIntersectionTypes/1.swc-stderr
@@ -78,7 +78,7 @@ Error:
     `----
 
 Error: 
-  > ((undefined | number) & number)
+  > number
 
   x Type
     ,-[$DIR/tests/pass/controlFlow/typeGuards/typeGuardIntersectionTypes/1.ts:29:13]
@@ -87,7 +87,7 @@ Error:
     `----
 
 Error: 
-  > `manbearpig - ${((undefined | number) & number)} legs, no wings`
+  > `manbearpig - ${number} legs, no wings`
 
   x Type
     ,-[$DIR/tests/pass/controlFlow/typeGuards/typeGuardIntersectionTypes/1.ts:29:13]

--- a/crates/stc_ts_file_analyzer/tests/pass/types/intersection/intersectionWithUnionConstraint/2.swc-stderr
+++ b/crates/stc_ts_file_analyzer/tests/pass/types/intersection/intersectionWithUnionConstraint/2.swc-stderr
@@ -1,9 +1,18 @@
 
   x Type
-   ,-[$DIR/tests/pass/types/intersection/intersectionWithUnionConstraint/2.ts:4:5]
- 4 | let y2: string | null = x;       // Error
-   :                         ^
+   ,-[$DIR/tests/pass/types/intersection/intersectionWithUnionConstraint/2.ts:7:3]
+ 7 | x; // (T & U
+   : ^
    `----
 
 Error: 
-  > (T & U)
+  > (string | undefined)
+
+  x Type
+   ,-[$DIR/tests/pass/types/intersection/intersectionWithUnionConstraint/2.ts:8:3]
+ 8 | let _: string | undefined | number = x; // stirng | undefined
+   :                                      ^
+   `----
+
+Error: 
+  > (string | undefined)

--- a/crates/stc_ts_file_analyzer/tests/pass/types/intersection/intersectionWithUnionConstraint/2.ts
+++ b/crates/stc_ts_file_analyzer/tests/pass/types/intersection/intersectionWithUnionConstraint/2.ts
@@ -1,6 +1,9 @@
 //@strict: true
 
-function f2<T extends string | number | undefined, U extends string | null | undefined>(x: T & U) {
-    let y2: string | null = x;       // Error
+function f2<
+  T extends string | number | undefined,
+  U extends string | null | undefined,
+>(x: T & U) {
+  x; // (T & U
+  let _: string | undefined | number = x; // stirng | undefined
 }
-

--- a/crates/stc_ts_file_analyzer/tests/visualize/types/typeRelationShips/typeInference/lab/union-of-intersections-assignable.swc-stderr
+++ b/crates/stc_ts_file_analyzer/tests/visualize/types/typeRelationShips/typeInference/lab/union-of-intersections-assignable.swc-stderr
@@ -61,4 +61,4 @@ Error:
   |     c: bigint;
   | } & {
   |     d: boolean;
-  | }))
+  | }) | boolean)

--- a/crates/stc_ts_type_checker/tests/conformance.pass.txt
+++ b/crates/stc_ts_type_checker/tests/conformance.pass.txt
@@ -1540,6 +1540,7 @@ jsdoc/jsdocTwoLineTypedef.ts
 jsdoc/parseLinkTag.ts
 jsdoc/seeTag1.ts
 jsdoc/seeTag2.ts
+jsdoc/typeParameterExtendsUnionConstraintDistributed.ts
 parser/ecmascript2021/numericSeparators/parser.numericSeparators.binary.ts
 parser/ecmascript2021/numericSeparators/parser.numericSeparators.decimal.ts
 parser/ecmascript2021/numericSeparators/parser.numericSeparators.hex.ts

--- a/crates/stc_ts_type_checker/tests/conformance.pass.txt
+++ b/crates/stc_ts_type_checker/tests/conformance.pass.txt
@@ -1540,7 +1540,6 @@ jsdoc/jsdocTwoLineTypedef.ts
 jsdoc/parseLinkTag.ts
 jsdoc/seeTag1.ts
 jsdoc/seeTag2.ts
-jsdoc/typeParameterExtendsUnionConstraintDistributed.ts
 parser/ecmascript2021/numericSeparators/parser.numericSeparators.binary.ts
 parser/ecmascript2021/numericSeparators/parser.numericSeparators.decimal.ts
 parser/ecmascript2021/numericSeparators/parser.numericSeparators.hex.ts
@@ -2030,7 +2029,6 @@ types/forAwait/types.forAwait.es2018.3.ts
 types/intersection/contextualIntersectionType.ts
 types/intersection/intersectionMemberOfUnionNarrowsCorrectly.ts
 types/intersection/intersectionNarrowing.ts
-types/intersection/intersectionOfUnionNarrowing.ts
 types/intersection/intersectionOfUnionOfUnitTypes.ts
 types/intersection/intersectionThisTypes.ts
 types/intersection/intersectionTypeAssignment.ts
@@ -2039,6 +2037,7 @@ types/intersection/intersectionTypeInference.ts
 types/intersection/intersectionTypeInference2.ts
 types/intersection/intersectionTypeInference3.ts
 types/intersection/intersectionTypeMembers.ts
+types/intersection/intersectionWithUnionConstraint.ts
 types/intersection/operatorsAndIntersectionTypes.ts
 types/intersection/recursiveIntersectionTypes.ts
 types/keyof/keyofAndForIn.ts

--- a/crates/stc_ts_type_checker/tests/conformance/controlFlow/controlFlowBindingElement.ts.stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/conformance/controlFlow/controlFlowBindingElement.ts.stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
     required_error: 0,
     matched_error: 0,
-    extra_error: 6,
+    extra_error: 3,
     panic: 0,
 }

--- a/crates/stc_ts_type_checker/tests/conformance/jsdoc/typeParameterExtendsUnionConstraintDistributed.ts.stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/conformance/jsdoc/typeParameterExtendsUnionConstraintDistributed.ts.stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
     required_error: 0,
     matched_error: 0,
-    extra_error: 2,
+    extra_error: 0,
     panic: 0,
 }

--- a/crates/stc_ts_type_checker/tests/conformance/jsdoc/typeParameterExtendsUnionConstraintDistributed.ts.stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/conformance/jsdoc/typeParameterExtendsUnionConstraintDistributed.ts.stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
     required_error: 0,
     matched_error: 0,
-    extra_error: 0,
+    extra_error: 2,
     panic: 0,
 }

--- a/crates/stc_ts_type_checker/tests/conformance/salsa/typeFromPropertyAssignment31.ts.stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/conformance/salsa/typeFromPropertyAssignment31.ts.stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
-    required_error: 0,
-    matched_error: 2,
+    required_error: 2,
+    matched_error: 0,
     extra_error: 1,
     panic: 0,
 }

--- a/crates/stc_ts_type_checker/tests/conformance/types/intersection/intersectionOfUnionNarrowing.ts.stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/conformance/types/intersection/intersectionOfUnionNarrowing.ts.stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
     required_error: 0,
     matched_error: 0,
-    extra_error: 0,
+    extra_error: 2,
     panic: 0,
 }

--- a/crates/stc_ts_type_checker/tests/conformance/types/intersection/intersectionWithUnionConstraint.ts.stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/conformance/types/intersection/intersectionWithUnionConstraint.ts.stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
-    required_error: 3,
-    matched_error: 2,
-    extra_error: 8,
+    required_error: 0,
+    matched_error: 5,
+    extra_error: 0,
     panic: 0,
 }

--- a/crates/stc_ts_type_checker/tests/conformance/types/typeRelationships/typeInference/unionTypeInference.ts.stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/conformance/types/typeRelationships/typeInference/unionTypeInference.ts.stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
     required_error: 0,
     matched_error: 2,
-    extra_error: 3,
+    extra_error: 5,
     panic: 0,
 }

--- a/crates/stc_ts_type_checker/tests/tsc-stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/tsc-stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
-    required_error: 4246,
-    matched_error: 5638,
-    extra_error: 748,
+    required_error: 4245,
+    matched_error: 5639,
+    extra_error: 743,
     panic: 72,
 }

--- a/crates/stc_ts_type_checker/tests/tsc-stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/tsc-stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
     required_error: 4245,
     matched_error: 5639,
-    extra_error: 743,
+    extra_error: 741,
     panic: 72,
 }


### PR DESCRIPTION
**Description:**

 - Improve normalization of intersections.
 - Improve assignment to intersection types.


---

implement intersection(`&`)

but, The code related to type param is ambiguous.
[https://www.typescriptlang.org/play?jsx=0#code/GYVwdgxgLglg9mABMATAHgFCMQFUQUwA8p8wATAZ0QqgCcYwBzRAH0TBAFsAjfW1xODL5gDfGQA0WRAFUCxUpWp0GzNhwA2GgUJFjJGAHwAKQgC5ciAGSyAlIgDe0wgG5EAeneJjeGzNvSGvhQiAD6FjT0TDrkemDiAhw8fIgAvIiuHl40MLTRbLqi8WQYAL5AA](https://www.typescriptlang.org/play?jsx=0#code/GYVwdgxgLglg9mABMATAHgFCMQFUQUwA8p8wATAZ0QqgCcYwBzRAH0TBAFsAjfW1xODL5gDfGQA0WRAFUCxUpWp0GzNhwA2GgUJFjJGAHwAKQgC5ciAGSyAlIgDe0wgG5EAeneJjeGzNvSGvhQiAD6FjT0TDrkemDiAhw8fIgAvIiuHl40MLTRbLqi8WQYAL5AA)