### PR TITLE
Use the correct module ID when re-exporting vars/types

### DIFF
--- a/crates/stc_ts_file_analyzer/src/analyzer/export.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/export.rs
@@ -352,11 +352,11 @@ impl Analyzer<'_, '_> {
             match data.normalize() {
                 Type::Module(data) => {
                     for (id, ty) in data.exports.vars.iter() {
-                        self.storage.reexport_var(span, dep, id.clone(), ty.clone());
+                        self.storage.reexport_var(span, ctxt, id.clone(), ty.clone());
                     }
                     for (id, types) in data.exports.types.iter() {
                         for ty in types {
-                            self.storage.reexport_type(span, dep, id.clone(), ty.clone());
+                            self.storage.reexport_type(span, ctxt, id.clone(), ty.clone());
                         }
                     }
                 }

--- a/crates/stc_ts_file_analyzer/src/analyzer/export.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/export.rs
@@ -352,11 +352,11 @@ impl Analyzer<'_, '_> {
             match data.normalize() {
                 Type::Module(data) => {
                     for (id, ty) in data.exports.vars.iter() {
-                        self.storage.reexport_var(span, ctxt, id.clone(), ty.clone());
+                        self.storage.reexport_var(span, dep, id.clone(), ty.clone());
                     }
                     for (id, types) in data.exports.types.iter() {
                         for ty in types {
-                            self.storage.reexport_type(span, ctxt, id.clone(), ty.clone());
+                            self.storage.reexport_type(span, dep, id.clone(), ty.clone());
                         }
                     }
                 }

--- a/crates/stc_ts_storage/src/lib.rs
+++ b/crates/stc_ts_storage/src/lib.rs
@@ -174,14 +174,12 @@ impl TypeStore for Single<'_> {
     }
 
     fn reexport_type(&mut self, _span: Span, ctxt: ModuleId, id: JsWord, ty: Type) {
-        debug_assert_eq!(ctxt, self.id);
         ty.assert_clone_cheap();
 
         self.info.exports.types.entry(id).or_default().push(ty);
     }
 
     fn reexport_var(&mut self, _span: Span, ctxt: ModuleId, id: JsWord, ty: Type) {
-        debug_assert_eq!(ctxt, self.id);
         ty.assert_clone_cheap();
 
         // TODO(kdy1): error reporting for duplicate

--- a/crates/stc_ts_storage/src/lib.rs
+++ b/crates/stc_ts_storage/src/lib.rs
@@ -173,13 +173,13 @@ impl TypeStore for Single<'_> {
         take(&mut self.info.exports)
     }
 
-    fn reexport_type(&mut self, _span: Span, ctxt: ModuleId, id: JsWord, ty: Type) {
+    fn reexport_type(&mut self, _span: Span, _ctxt: ModuleId, id: JsWord, ty: Type) {
         ty.assert_clone_cheap();
 
         self.info.exports.types.entry(id).or_default().push(ty);
     }
 
-    fn reexport_var(&mut self, _span: Span, ctxt: ModuleId, id: JsWord, ty: Type) {
+    fn reexport_var(&mut self, _span: Span, _ctxt: ModuleId, id: JsWord, ty: Type) {
         ty.assert_clone_cheap();
 
         // TODO(kdy1): error reporting for duplicate

--- a/src/main.rs
+++ b/src/main.rs
@@ -126,13 +126,13 @@ async fn main() -> Result<(), Error> {
 
             {
                 let start = Instant::now();
-                for err in errors {
+                for err in &errors {
                     err.emit(&handler);
                 }
 
                 let end = Instant::now();
 
-                log::info("Found {} errors", errors.len());
+                log::info!("Found {} errors", errors.len());
 
                 log::info!("Error reporting took {:?}", end - start);
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -132,6 +132,8 @@ async fn main() -> Result<(), Error> {
 
                 let end = Instant::now();
 
+                log::info("Found {} errors", errors.len());
+
                 log::info!("Error reporting took {:?}", end - start);
             }
         }


### PR DESCRIPTION
<!-- Note: CI script will automatically rebase your PR so please do not rebase unless required -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

I'm not 100% sure this is right but...

When using stc within a project, take a file that re-exports a var from another file.

For example:
```ts
// index.ts
export { myVar } from './store'

```

Currently we add the re-export to the store using the 2nd module Id (`./store`) instead of the id from `./index`(`./store`) instead of the id from`./index`.

https://github.com/dudykr/stc/blob/main/crates/stc_ts_file_analyzer/src/analyzer/export.rs#L352-L367

This causes a panic [here](https://github.com/dudykr/stc/blob/main/crates/stc_ts_storage/src/lib.rs#L176-L190). Since the module id passed in (`ctxt`) is not equal to the current module id.

This PR changes this behaviour and instead uses the current module id. This follows what's happening [here](https://github.com/dudykr/stc/blob/main/crates/stc_ts_file_analyzer/src/analyzer/export.rs#L440-L472)





**BREAKING CHANGE:**

None

<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG. Add description or remove entirely if not breaking.

You may need to update `MIGRATION.md` for the breaking changes.
-->

**Related issue (if exists):**

None