### PR TITLE
feat: add vscode debugging config

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -24,7 +24,7 @@ jobs:
 
       - run: yarn
 
-      - run: npx cspell '**/*'
+      - run: npx cspell --no-progress '**/*'
 
   cargo-fmt:
     name: Cargo fmt

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ core
 *.log
 
 !.vscode/settings.json
+.vscode/launch.json
 
 /.idea
 *.iml

--- a/.vscode/launch.template.json
+++ b/.vscode/launch.template.json
@@ -1,0 +1,22 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug type checker",
+            "cargo": {
+                "args": [
+                    "run",
+                    "--example",
+                    "file",
+                    "-p",
+                    "stc_ts_file_analyzer",
+                ],
+            },
+            // "args": ["path/to/.ts file"],
+            "cwd": "${workspaceFolder}"
+        },
+
+    ]
+}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,6 +45,15 @@ You can use filename, too and with it you can run single test.
 
 See [the readme of the file analyzer](./crates/stc_ts_file_analyzer/) for more details.
 
+### Debugging with VScode Debugger
+
+Please copy `.vscode/launch.template.json` and rename it to
+`.vscode/launch.json`.
+
+In `launch.json`, you can pass the path of the `.ts` file you want to check to the
+`args` field. Then, you can run the typechecker with debugger from the
+debugger panel.
+
 ### Debugging tips
 
 #### `print_backtrace()`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,7 +51,7 @@ Please copy `.vscode/launch.template.json` and rename it to
 `.vscode/launch.json`.
 
 In `launch.json`, you can pass the path of the `.ts` file you want to check to the
-`args` field. Then, you can run the typechecker with debugger from the
+`args` field. Then, you can run the type checker with debugger from the
 debugger panel.
 
 ### Debugging tips


### PR DESCRIPTION
**Description:**
I'm not sure if this is the best approach, but I believe it could be beneficial for new contributors. 

This PR adds a vscode debugging configuration to make it easier to check and learn how to run the type checker while developing. 

Currently, we usually use `./scripts/test.sh` to check a single file, but it takes a lot of time due to regression checking and generates enormous logs. Additionally, it can be difficult to run the type checker with the debugger. 



<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**BREAKING CHANGE:**

<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG. Add description or remove entirely if not breaking.

You may need to update `MIGRATION.md` for the breaking changes.
-->

**Related issue (if exists):**
