### PR TITLE
fix(ts/analyzer): Report error when assigning null/undefined to never

### DIFF
--- a/crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs
@@ -888,6 +888,13 @@ impl Analyzer<'_, '_> {
             }
         }
 
+        // never -> never is ok, but T -> never is not.
+        if to.is_kwd(TsKeywordTypeKind::TsNeverKeyword) {
+            if !rhs.is_kwd(TsKeywordTypeKind::TsNeverKeyword) {
+                fail!()
+            }
+        }
+
         // Allow v = null and v = undefined if strict null check is false
         if !self.rule().strict_null_checks {
             match rhs {

--- a/crates/stc_ts_type_checker/tests/conformance.pass.txt
+++ b/crates/stc_ts_type_checker/tests/conformance.pass.txt
@@ -279,7 +279,6 @@ controlFlow/controlFlowElementAccess.ts
 controlFlow/controlFlowElementAccess2.ts
 controlFlow/controlFlowForInStatement.ts
 controlFlow/controlFlowForInStatement2.ts
-controlFlow/controlFlowIfStatement.ts
 controlFlow/controlFlowInOperator.ts
 controlFlow/controlFlowInstanceOfGuardPrimitives.ts
 controlFlow/controlFlowInstanceofExtendsFunction.ts

--- a/crates/stc_ts_type_checker/tests/conformance/controlFlow/controlFlowIfStatement.ts.stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/conformance/controlFlow/controlFlowIfStatement.ts.stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
     required_error: 0,
     matched_error: 0,
-    extra_error: 0,
+    extra_error: 1,
     panic: 0,
 }

--- a/crates/stc_ts_type_checker/tests/conformance/types/never/neverTypeErrors1.ts.stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/conformance/types/never/neverTypeErrors1.ts.stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
-    required_error: 4,
-    matched_error: 8,
+    required_error: 2,
+    matched_error: 10,
     extra_error: 0,
     panic: 0,
 }

--- a/crates/stc_ts_type_checker/tests/conformance/types/unknown/unknownControlFlow.ts.stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/conformance/types/unknown/unknownControlFlow.ts.stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
     required_error: 4,
     matched_error: 1,
-    extra_error: 3,
+    extra_error: 4,
     panic: 0,
 }

--- a/crates/stc_ts_type_checker/tests/tsc-stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/tsc-stats.rust-debug
@@ -1,6 +1,20 @@
 Stats {
+<<<<<<< HEAD
     required_error: 4233,
     matched_error: 5651,
     extra_error: 736,
     panic: 69,
+=======
+<<<<<<< HEAD
+    required_error: 4234,
+    matched_error: 5650,
+    extra_error: 732,
+    panic: 71,
+=======
+    required_error: 4243,
+    matched_error: 5641,
+    extra_error: 735,
+    panic: 72,
+>>>>>>> a7ae05c7 (fix(ts/analyzer): Report error when assigning null/undefined to never)
+>>>>>>> 99327fb6 (fix(ts/analyzer): Report error when assigning null/undefined to never)
 }

--- a/crates/stc_ts_type_checker/tests/tsc-stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/tsc-stats.rust-debug
@@ -1,5 +1,6 @@
 Stats {
 <<<<<<< HEAD
+<<<<<<< HEAD
     required_error: 4233,
     matched_error: 5651,
     extra_error: 736,
@@ -17,4 +18,10 @@ Stats {
     panic: 72,
 >>>>>>> a7ae05c7 (fix(ts/analyzer): Report error when assigning null/undefined to never)
 >>>>>>> 99327fb6 (fix(ts/analyzer): Report error when assigning null/undefined to never)
+=======
+    required_error: 4232,
+    matched_error: 5652,
+    extra_error: 733,
+    panic: 71,
+>>>>>>> c68eed87 (update stats)
 }

--- a/crates/stc_ts_type_checker/tests/tsc-stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/tsc-stats.rust-debug
@@ -1,27 +1,6 @@
 Stats {
-<<<<<<< HEAD
-<<<<<<< HEAD
-    required_error: 4233,
-    matched_error: 5651,
-    extra_error: 736,
+    required_error: 4231,
+    matched_error: 5653,
+    extra_error: 738,
     panic: 69,
-=======
-<<<<<<< HEAD
-    required_error: 4234,
-    matched_error: 5650,
-    extra_error: 732,
-    panic: 71,
-=======
-    required_error: 4243,
-    matched_error: 5641,
-    extra_error: 735,
-    panic: 72,
->>>>>>> a7ae05c7 (fix(ts/analyzer): Report error when assigning null/undefined to never)
->>>>>>> 99327fb6 (fix(ts/analyzer): Report error when assigning null/undefined to never)
-=======
-    required_error: 4232,
-    matched_error: 5652,
-    extra_error: 733,
-    panic: 71,
->>>>>>> c68eed87 (update stats)
 }


### PR DESCRIPTION
<!-- Note: CI script will automatically rebase your PR so please do not rebase unless required -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Always reports error when assigning T to never

Current:
```ts
var t: never;
t = undefined // ok (with strict null checks disabled)
t = null; // ok (with strict null checks disabled)
```

With this PR:
```ts
var t: never;
t = undefined // error
t = null; // error
```

**Extra Error:**

As a result of this change, there is an extra change error within stc/crates/stc_ts_type_checker/tests/conformance/controlFlow/controlFlowIfStatement.ts .

This is caused, because tsc does not currently correctly infer that the `else` branch is unreachable hence causing the type of data to be never.

<img width="515" alt="image" src="https://user-images.githubusercontent.com/18101008/211220002-56e52d89-2f16-44ef-90b0-f0bf0e41b48b.png">

As you can see, TS correctly infers `data` as never, hence never -> never assignment succeeds 

Given this, I believe that the extra error is acceptable

**BREAKING CHANGE:**

<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG. Add description or remove entirely if not breaking.

You may need to update `MIGRATION.md` for the breaking changes.
-->

None

**Related issue (if exists):**

None