### PR TITLE
fix(ts/analyzer): make unknown assignable to null | undefied | {}

### DIFF
--- a/crates/stc_ts_file_analyzer/src/analyzer/expr/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/expr/mod.rs
@@ -3036,6 +3036,10 @@ impl Analyzer<'_, '_> {
                         tracker: Default::default(),
                     }));
                 }
+
+                if let Key::Computed(key) = prop {
+                    return Ok(*key.ty.clone());
+                }
             }
 
             Type::Rest(rest) => {

--- a/crates/stc_ts_type_checker/tests/conformance/functions/strictBindCallApply1.ts.stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/conformance/functions/strictBindCallApply1.ts.stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
     required_error: 26,
     matched_error: 0,
-    extra_error: 0,
-    panic: 1,
+    extra_error: 2,
+    panic: 0,
 }

--- a/crates/stc_ts_type_checker/tests/conformance/types/unknown/unknownControlFlow.ts.stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/conformance/types/unknown/unknownControlFlow.ts.stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
-    required_error: 5,
-    matched_error: 0,
-    extra_error: 0,
-    panic: 1,
+    required_error: 4,
+    matched_error: 1,
+    extra_error: 6,
+    panic: 0,
 }

--- a/crates/stc_ts_type_checker/tests/conformance/types/unknown/unknownControlFlow.ts.stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/conformance/types/unknown/unknownControlFlow.ts.stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
     required_error: 4,
     matched_error: 1,
-    extra_error: 6,
+    extra_error: 3,
     panic: 0,
 }

--- a/crates/stc_ts_type_checker/tests/conformance/types/unknown/unknownType1.ts.stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/conformance/types/unknown/unknownType1.ts.stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
     required_error: 9,
     matched_error: 18,
-    extra_error: 1,
+    extra_error: 0,
     panic: 0,
 }

--- a/crates/stc_ts_type_checker/tests/tsc-stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/tsc-stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
     required_error: 4233,
     matched_error: 5651,
-    extra_error: 740,
+    extra_error: 736,
     panic: 69,
 }

--- a/crates/stc_ts_type_checker/tests/tsc-stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/tsc-stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
-    required_error: 4234,
-    matched_error: 5650,
-    extra_error: 732,
-    panic: 71,
+    required_error: 4233,
+    matched_error: 5651,
+    extra_error: 740,
+    panic: 69,
 }


### PR DESCRIPTION
<!-- Note: CI script will automatically rebase your PR so please do not rebase unless required -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**
- Fix some panic that occurs when accessing the index type with a TS keyword like `string`
- make unknown assignable to `null | undefied | {}`

I will fix the extra_errors that were introduced by fixing the panic in another PR.

**BREAKING CHANGE:**

<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG. Add description or remove entirely if not breaking.

You may need to update `MIGRATION.md` for the breaking changes.
-->

**Related issue (if exists):**
