### PR TITLE
refactor(ts/env): Remove swc globals from `Env`

### DIFF
--- a/crates/stc_ts_dts/benches/fixture.rs
+++ b/crates/stc_ts_dts/benches/fixture.rs
@@ -24,7 +24,7 @@ use stc_ts_file_analyzer::{
 use stc_ts_storage::Single;
 use stc_ts_types::module_id;
 use stc_ts_utils::StcComments;
-use swc_common::{input::SourceFileInput, FileName, SyntaxContext, GLOBALS};
+use swc_common::{input::SourceFileInput, FileName, SyntaxContext};
 use swc_ecma_ast::EsVersion;
 use swc_ecma_parser::{lexer::Lexer, Parser, Syntax, TsConfig};
 use swc_ecma_transforms::resolver;

--- a/crates/stc_ts_dts/benches/fixture.rs
+++ b/crates/stc_ts_dts/benches/fixture.rs
@@ -24,7 +24,7 @@ use stc_ts_file_analyzer::{
 use stc_ts_storage::Single;
 use stc_ts_types::module_id;
 use stc_ts_utils::StcComments;
-use swc_common::{input::SourceFileInput, FileName, GLOBALS};
+use swc_common::{input::SourceFileInput, FileName, SyntaxContext, GLOBALS};
 use swc_ecma_ast::EsVersion;
 use swc_ecma_parser::{lexer::Lexer, Parser, Syntax, TsConfig};
 use swc_ecma_transforms::resolver;
@@ -190,26 +190,23 @@ fn run_bench(b: &mut Bencher, path: PathBuf) {
         let mut node_id_gen = NodeIdGenerator::default();
         let mut parser = Parser::new_from(lexer);
         let module = parser.parse_module().unwrap();
-        let module = GLOBALS.set(stable_env.swc_globals(), || {
-            module.fold_with(&mut resolver(stable_env.marks().unresolved_mark(), top_level_mark, true))
-        });
+        let module = module.fold_with(&mut resolver(stable_env.marks().unresolved_mark(), top_level_mark, true));
         let module = RModule::from_orig(&mut node_id_gen, module);
 
         b.iter(|| {
             let mut storage = Single {
                 parent: None,
                 id: module_id,
+                top_level_ctxt: SyntaxContext::empty().apply_mark(top_level_mark),
                 path: path.clone(),
-                info: Default::default(),
                 is_dts: false,
+                info: Default::default(),
             };
 
             let mut module = module.clone();
             {
                 let mut analyzer = Analyzer::root(env.clone(), cm.clone(), Default::default(), box &mut storage, &NoopLoader, None);
-                GLOBALS.set(stable_env.swc_globals(), || {
-                    module.validate_with(&mut analyzer).unwrap();
-                });
+                module.validate_with(&mut analyzer).unwrap();
             }
 
             {

--- a/crates/stc_ts_dts/tests/fixture.rs
+++ b/crates/stc_ts_dts/tests/fixture.rs
@@ -30,7 +30,7 @@ use stc_ts_file_analyzer::{
 use stc_ts_storage::Single;
 use stc_ts_types::module_id;
 use stc_ts_utils::StcComments;
-use swc_common::{input::SourceFileInput, FileName, SyntaxContext, GLOBALS};
+use swc_common::{input::SourceFileInput, FileName, SyntaxContext};
 use swc_ecma_ast::{EsVersion, Ident, Module, TsIntersectionType, TsKeywordTypeKind, TsLit, TsLitType, TsType, TsUnionType};
 use swc_ecma_codegen::{text_writer::JsWriter, Emitter};
 use swc_ecma_parser::{lexer::Lexer, Parser, StringInput, Syntax, TsConfig};
@@ -108,16 +108,12 @@ fn do_test(file_name: &Path) -> Result<(), StdErr> {
         );
         let mut parser = Parser::new_from(lexer);
         let module = parser.parse_module().unwrap();
-        let module = GLOBALS.set(stable_env.swc_globals(), || {
-            module.fold_with(&mut resolver(stable_env.marks().unresolved_mark(), top_level_mark, true))
-        });
+        let module = module.fold_with(&mut resolver(stable_env.marks().unresolved_mark(), top_level_mark, true));
         let mut module = RModule::from_orig(&mut node_id_gen, module);
         let mut mutations;
         {
             let mut analyzer = Analyzer::root(env, cm.clone(), Default::default(), box &mut storage, &NoopLoader, None);
-            GLOBALS.set(stable_env.swc_globals(), || {
-                module.validate_with(&mut analyzer).unwrap();
-            });
+            module.validate_with(&mut analyzer).unwrap();
 
             mutations = analyzer.mutations.unwrap()
         }

--- a/crates/stc_ts_dts/tests/fixture.rs
+++ b/crates/stc_ts_dts/tests/fixture.rs
@@ -87,9 +87,10 @@ fn do_test(file_name: &Path) -> Result<(), StdErr> {
         let mut storage = Single {
             parent: None,
             id: module_id,
+            top_level_ctxt: SyntaxContext::empty().apply_mark(top_level_mark),
             path,
-            info: Default::default(),
             is_dts: false,
+            info: Default::default(),
         };
 
         let mut node_id_gen = NodeIdGenerator::default();

--- a/crates/stc_ts_env/src/lib.rs
+++ b/crates/stc_ts_env/src/lib.rs
@@ -1,6 +1,5 @@
 use std::sync::Arc;
 
-use derivative::Derivative;
 use parking_lot::Mutex;
 use rustc_hash::FxHashMap;
 use serde::{Deserialize, Serialize};
@@ -10,7 +9,7 @@ use stc_ts_types::{Id, Type};
 use stc_utils::cache::Freeze;
 use string_enum::StringEnum;
 use swc_atoms::JsWord;
-use swc_common::{Globals, Span, Spanned, DUMMY_SP, GLOBALS};
+use swc_common::{Span, Spanned, DUMMY_SP};
 use swc_ecma_ast::EsVersion;
 
 pub use self::marks::{MarkExt, Marks};
@@ -133,18 +132,15 @@ impl Env {
 }
 
 /// Stuffs which are not changed regardless
-#[derive(Clone, Derivative)]
-#[derivative(Debug)]
+#[derive(Clone, Debug)]
 pub struct StableEnv {
-    #[derivative(Debug = "ignore")]
-    globals: Arc<Globals>,
     marks: Marks,
 }
 
 impl StableEnv {
-    pub fn new(globals: Arc<Globals>) -> Self {
-        let marks = Marks::new(&globals);
-        Self { globals, marks }
+    pub fn new() -> Self {
+        let marks = Marks::new();
+        Self { marks }
     }
 
     /// Note: The return marks should not be modified as it will not has any
@@ -152,22 +148,11 @@ impl StableEnv {
     pub const fn marks(&self) -> Marks {
         self.marks
     }
-
-    pub fn swc_globals(&self) -> &Arc<Globals> {
-        &self.globals
-    }
-
-    pub fn with<F, Ret>(&self, op: F) -> Ret
-    where
-        F: FnOnce() -> Ret,
-    {
-        GLOBALS.set(&self.globals, op)
-    }
 }
 
 impl Default for StableEnv {
     fn default() -> Self {
-        Self::new(Default::default())
+        Self::new()
     }
 }
 

--- a/crates/stc_ts_env/src/lib.rs
+++ b/crates/stc_ts_env/src/lib.rs
@@ -10,7 +10,7 @@ use stc_ts_types::{Id, Type};
 use stc_utils::cache::Freeze;
 use string_enum::StringEnum;
 use swc_atoms::JsWord;
-use swc_common::{Globals, Span, Spanned, DUMMY_SP};
+use swc_common::{Globals, Span, Spanned, DUMMY_SP, GLOBALS};
 use swc_ecma_ast::EsVersion;
 
 pub use self::marks::{MarkExt, Marks};
@@ -155,6 +155,13 @@ impl StableEnv {
 
     pub fn swc_globals(&self) -> &Arc<Globals> {
         &self.globals
+    }
+
+    pub fn with<F, Ret>(&self, op: F) -> Ret
+    where
+        F: FnOnce() -> Ret,
+    {
+        GLOBALS.set(&self.globals, op)
     }
 }
 

--- a/crates/stc_ts_env/src/lib.rs
+++ b/crates/stc_ts_env/src/lib.rs
@@ -139,7 +139,7 @@ pub struct StableEnv {
 
 impl StableEnv {
     pub fn new() -> Self {
-        let marks = Marks::new();
+        let marks = Marks::default();
         Self { marks }
     }
 

--- a/crates/stc_ts_env/src/marks.rs
+++ b/crates/stc_ts_env/src/marks.rs
@@ -1,6 +1,7 @@
-use swc_common::{Globals, Mark, SyntaxContext};
+use swc_common::{Mark, SyntaxContext};
 use tracing::info;
 
+/// The caller should ensure that [swc_common::GLOBALS] and `Marks` is matched.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct Marks {
     pub(crate) unresolved_mark: Mark,
@@ -15,8 +16,10 @@ impl Marks {
     pub fn unresolved_ctxt(self) -> SyntaxContext {
         self.unresolved_ctxt
     }
+}
 
-    pub fn new() -> Self {
+impl Default for Marks {
+    fn default() -> Self {
         fn m(name: &str) -> Mark {
             let m = Mark::fresh(Mark::root());
             info!("Mark ({}): {:?}", name, SyntaxContext::empty().apply_mark(m));

--- a/crates/stc_ts_env/src/marks.rs
+++ b/crates/stc_ts_env/src/marks.rs
@@ -16,21 +16,19 @@ impl Marks {
         self.unresolved_ctxt
     }
 
-    pub fn new(globals: &Globals) -> Self {
+    pub fn new() -> Self {
         fn m(name: &str) -> Mark {
             let m = Mark::fresh(Mark::root());
             info!("Mark ({}): {:?}", name, SyntaxContext::empty().apply_mark(m));
             m
         }
 
-        swc_common::GLOBALS.set(globals, || {
-            let unresolved_mark = m("unresolved");
+        let unresolved_mark = m("unresolved");
 
-            Self {
-                unresolved_mark,
-                unresolved_ctxt: SyntaxContext::empty().apply_mark(unresolved_mark),
-            }
-        })
+        Self {
+            unresolved_mark,
+            unresolved_ctxt: SyntaxContext::empty().apply_mark(unresolved_mark),
+        }
     }
 }
 

--- a/crates/stc_ts_file_analyzer/examples/file.rs
+++ b/crates/stc_ts_file_analyzer/examples/file.rs
@@ -42,9 +42,7 @@ fn profile_file(path: &Path) {
 
             parser.parse_module().unwrap()
         };
-        module = GLOBALS.set(env.shared().swc_globals(), || {
-            module.fold_with(&mut resolver(env.shared().marks().unresolved_mark(), Mark::new(), true))
-        });
+        module = module.fold_with(&mut resolver(env.shared().marks().unresolved_mark(), Mark::new(), true));
         let module = RModule::from_orig(&mut node_id_gen, module);
 
         // Don't print logs from builtin modules.

--- a/crates/stc_ts_file_analyzer/examples/file.rs
+++ b/crates/stc_ts_file_analyzer/examples/file.rs
@@ -17,7 +17,7 @@ use stc_ts_file_analyzer::{
 };
 use stc_ts_storage::Single;
 use stc_ts_types::ModuleId;
-use swc_common::{input::SourceFileInput, FileName, Mark, GLOBALS};
+use swc_common::{input::SourceFileInput, FileName, Mark, SyntaxContext, GLOBALS};
 use swc_ecma_ast::EsVersion;
 use swc_ecma_parser::{lexer::Lexer, Parser, Syntax, TsConfig};
 use swc_ecma_transforms::resolver;
@@ -53,6 +53,7 @@ fn profile_file(path: &Path) {
         let mut storage = Single {
             parent: None,
             id: ModuleId::builtin(),
+            top_level_ctxt: SyntaxContext::empty().apply_mark(top_level_mark),
             path: Arc::new(FileName::Real(PathBuf::from(path))),
             is_dts: false,
             info: Default::default(),

--- a/crates/stc_ts_file_analyzer/examples/file.rs
+++ b/crates/stc_ts_file_analyzer/examples/file.rs
@@ -17,7 +17,7 @@ use stc_ts_file_analyzer::{
 };
 use stc_ts_storage::Single;
 use stc_ts_types::ModuleId;
-use swc_common::{input::SourceFileInput, FileName, Mark, SyntaxContext, GLOBALS};
+use swc_common::{input::SourceFileInput, FileName, Mark, SyntaxContext};
 use swc_ecma_ast::EsVersion;
 use swc_ecma_parser::{lexer::Lexer, Parser, Syntax, TsConfig};
 use swc_ecma_transforms::resolver;

--- a/crates/stc_ts_file_analyzer/examples/file.rs
+++ b/crates/stc_ts_file_analyzer/examples/file.rs
@@ -42,7 +42,8 @@ fn profile_file(path: &Path) {
 
             parser.parse_module().unwrap()
         };
-        module = module.fold_with(&mut resolver(env.shared().marks().unresolved_mark(), Mark::new(), true));
+        let top_level_mark = Mark::new();
+        module = module.fold_with(&mut resolver(env.shared().marks().unresolved_mark(), top_level_mark, true));
         let module = RModule::from_orig(&mut node_id_gen, module);
 
         // Don't print logs from builtin modules.
@@ -67,11 +68,9 @@ fn profile_file(path: &Path) {
             return Ok(());
         }
 
-        GLOBALS.set(env.shared().swc_globals(), || {
-            for e in errors {
-                e.emit(&handler);
-            }
-        });
+        for e in errors {
+            e.emit(&handler);
+        }
 
         Ok(())
     })

--- a/crates/stc_ts_file_analyzer/examples/file.rs
+++ b/crates/stc_ts_file_analyzer/examples/file.rs
@@ -59,7 +59,7 @@ fn profile_file(path: &Path) {
         };
 
         {
-            let mut analyzer = Analyzer::root(env.clone(), cm, Default::default(), box &mut storage, &NoopLoader, None);
+            let mut analyzer = Analyzer::root(env, cm, Default::default(), box &mut storage, &NoopLoader, None);
             module.visit_with(&mut analyzer);
         }
         let errors = ::stc_ts_errors::ErrorKind::flatten(storage.info.errors.into_iter().collect());

--- a/crates/stc_ts_file_analyzer/src/analyzer/tests.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/tests.rs
@@ -41,9 +41,13 @@ where
     F: FnOnce(&mut Tester) -> Ret,
 {
     ::testing::run_test2(false, |cm, handler| {
+        let top_level_mark = Mark::new();
+        let top_level_ctxt = SyntaxContext::empty().apply_mark(top_level_mark);
+
         let mut storage = Single {
             parent: None,
             id: ModuleId::builtin(),
+            top_level_ctxt,
             path: Arc::new(FileName::Real(PathBuf::new())),
             is_dts: false,
             info: Default::default(),
@@ -56,7 +60,7 @@ where
                 cm: cm.clone(),
                 analyzer,
                 node_id_gen: Default::default(),
-                top_level_mark: Mark::new(),
+                top_level_mark,
             };
             let ret = op(&mut tester);
 

--- a/crates/stc_ts_file_analyzer/src/analyzer/tests.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/tests.rs
@@ -128,18 +128,17 @@ where
 
             parser.parse_module().unwrap()
         };
-        module = swc_common::GLOBALS.set(env.shared().swc_globals(), || {
-            module.fold_with(&mut resolver(env.shared().marks().unresolved_mark(), top_level_mark, true))
-        });
+        module = module.fold_with(&mut resolver(env.shared().marks().unresolved_mark(), top_level_mark, true));
         let span = module.span;
         let module = RModule::from_orig(&mut node_id_gen, module);
 
         let mut storage = Single {
             parent: None,
             id: module_id,
+            top_level_ctxt: SyntaxContext::empty().apply_mark(top_level_mark),
             path,
-            info: Default::default(),
             is_dts: false,
+            info: Default::default(),
         };
 
         {

--- a/crates/stc_ts_file_analyzer/src/env.rs
+++ b/crates/stc_ts_file_analyzer/src/env.rs
@@ -296,13 +296,13 @@ pub trait EnvFactory {
 
         let cell = CACHE.entry(libs.clone()).or_default().clone();
 
-        let builtin = swc_common::GLOBALS.set(STABLE_ENV.swc_globals(), || {
+        let builtin = {
             let builtin = cell.get_or_init(|| {
                 let builtin = BuiltIn::from_ts_libs(&STABLE_ENV, &libs);
                 Arc::new(builtin)
             });
             (*builtin).clone()
-        });
+        };
 
         Self::new(STABLE_ENV.clone(), rule, target, module, builtin)
     }

--- a/crates/stc_ts_file_analyzer/src/tests.rs
+++ b/crates/stc_ts_file_analyzer/src/tests.rs
@@ -6,4 +6,4 @@ use swc_common::Globals;
 
 pub(crate) static GLOBALS: Lazy<Arc<Globals>> = Lazy::new(Default::default);
 
-pub(crate) static MARKS: Lazy<Marks> = Lazy::new(|| Marks::new(&GLOBALS));
+pub(crate) static MARKS: Lazy<Marks> = Lazy::new(Marks::default);

--- a/crates/stc_ts_file_analyzer/tests/base.rs
+++ b/crates/stc_ts_file_analyzer/tests/base.rs
@@ -197,11 +197,9 @@ fn errors(input: PathBuf) {
             panic!("Should emit at least one error")
         }
 
-        GLOBALS.set(env.shared().swc_globals(), || {
-            for e in errors {
-                e.emit(&handler);
-            }
-        });
+        for e in errors {
+            e.emit(&handler);
+        }
 
         if false {
             return Ok(());
@@ -238,17 +236,16 @@ fn pass_only(input: PathBuf) {
 
             parser.parse_module().unwrap()
         };
-        module = GLOBALS.set(env.shared().swc_globals(), || {
-            module.fold_with(&mut resolver(env.shared().marks().unresolved_mark(), top_level_mark, true))
-        });
+        module = module.fold_with(&mut resolver(env.shared().marks().unresolved_mark(), top_level_mark, true));
         let module = RModule::from_orig(&mut node_id_gen, module);
 
         let mut storage = Single {
             parent: None,
             id: module_id,
+            top_level_ctxt: SyntaxContext::empty().apply_mark(top_level_mark),
             path,
-            info: Default::default(),
             is_dts: false,
+            info: Default::default(),
         };
 
         {
@@ -262,11 +259,9 @@ fn pass_only(input: PathBuf) {
         let errors = ::stc_ts_errors::ErrorKind::flatten(storage.info.errors.into_iter().collect());
         let ok = errors.is_empty();
 
-        GLOBALS.set(env.shared().swc_globals(), || {
-            for e in errors {
-                e.emit(&handler);
-            }
-        });
+        for e in errors {
+            e.emit(&handler);
+        }
 
         if !ok {
             return Err(());
@@ -413,9 +408,7 @@ fn run_test(file_name: PathBuf, for_error: bool) -> Option<NormalizedOutput> {
             );
             let mut parser = Parser::new_from(lexer);
             let module = parser.parse_module().unwrap();
-            let module = GLOBALS.set(stable_env.swc_globals(), || {
-                module.fold_with(&mut resolver(stable_env.marks().unresolved_mark(), top_level_mark, true))
-            });
+            let module = module.fold_with(&mut resolver(stable_env.marks().unresolved_mark(), top_level_mark, true));
             let module = RModule::from_orig(&mut node_id_gen, module);
             {
                 GLOBALS.set(stable_env.swc_globals(), || {

--- a/crates/stc_ts_file_analyzer/tests/base.rs
+++ b/crates/stc_ts_file_analyzer/tests/base.rs
@@ -24,7 +24,7 @@ use stc_ts_storage::{ErrorStore, Single};
 use stc_ts_testing::tsc::TscError;
 use stc_ts_types::module_id;
 use stc_ts_utils::StcComments;
-use swc_common::{errors::DiagnosticId, input::SourceFileInput, FileName, SyntaxContext, GLOBALS};
+use swc_common::{errors::DiagnosticId, input::SourceFileInput, FileName, SyntaxContext};
 use swc_ecma_ast::EsVersion;
 use swc_ecma_parser::{lexer::Lexer, Parser, Syntax, TsConfig};
 use swc_ecma_transforms::resolver;

--- a/crates/stc_ts_file_analyzer/tests/base.rs
+++ b/crates/stc_ts_file_analyzer/tests/base.rs
@@ -107,11 +107,9 @@ fn validate(input: &Path) -> Vec<StcError> {
 
             let errors = ::stc_ts_errors::ErrorKind::flatten(storage.info.errors.into_iter().collect());
 
-            GLOBALS.set(env.shared().swc_globals(), || {
-                for e in errors {
-                    e.emit(&handler);
-                }
-            });
+            for e in errors {
+                e.emit(&handler);
+            }
 
             if false {
                 return Ok(());
@@ -173,17 +171,16 @@ fn errors(input: PathBuf) {
 
             parser.parse_module().unwrap()
         };
-        module = GLOBALS.set(env.shared().swc_globals(), || {
-            module.fold_with(&mut resolver(env.shared().marks().unresolved_mark(), top_level_mark, true))
-        });
+        module = module.fold_with(&mut resolver(env.shared().marks().unresolved_mark(), top_level_mark, true));
         let module = RModule::from_orig(&mut node_id_gen, module);
 
         let mut storage = Single {
             parent: None,
             id: module_id,
+            top_level_ctxt: SyntaxContext::empty().apply_mark(top_level_mark),
             path,
-            info: Default::default(),
             is_dts: false,
+            info: Default::default(),
         };
 
         {

--- a/crates/stc_ts_file_analyzer/tests/base.rs
+++ b/crates/stc_ts_file_analyzer/tests/base.rs
@@ -101,7 +101,7 @@ fn validate(input: &Path) -> Vec<StcError> {
                 // Don't print logs from builtin modules.
                 let _tracing = tracing::subscriber::set_default(logger(Level::DEBUG));
 
-                let mut analyzer = Analyzer::root(env.clone(), cm, Default::default(), box &mut storage, &NoopLoader, None);
+                let mut analyzer = Analyzer::root(env, cm, Default::default(), box &mut storage, &NoopLoader, None);
                 module.visit_with(&mut analyzer);
             }
 
@@ -187,7 +187,7 @@ fn errors(input: PathBuf) {
             // Don't print logs from builtin modules.
             let _tracing = tracing::subscriber::set_default(logger(Level::DEBUG));
 
-            let mut analyzer = Analyzer::root(env.clone(), cm, Default::default(), box &mut storage, &NoopLoader, None);
+            let mut analyzer = Analyzer::root(env, cm, Default::default(), box &mut storage, &NoopLoader, None);
             module.visit_with(&mut analyzer);
         }
 
@@ -252,7 +252,7 @@ fn pass_only(input: PathBuf) {
             // Don't print logs from builtin modules.
             let _tracing = tracing::subscriber::set_default(logger(Level::DEBUG));
 
-            let mut analyzer = Analyzer::root(env.clone(), cm, Default::default(), box &mut storage, &NoopLoader, None);
+            let mut analyzer = Analyzer::root(env, cm, Default::default(), box &mut storage, &NoopLoader, None);
             module.visit_with(&mut analyzer);
         }
 
@@ -421,7 +421,7 @@ fn run_test(file_name: PathBuf, for_error: bool) -> Option<NormalizedOutput> {
                         None
                     } else {
                         Some(Debugger {
-                            cm: cm.clone(),
+                            cm,
                             handler: handler.clone(),
                         })
                     },

--- a/crates/stc_ts_file_analyzer/tests/base.rs
+++ b/crates/stc_ts_file_analyzer/tests/base.rs
@@ -411,29 +411,27 @@ fn run_test(file_name: PathBuf, for_error: bool) -> Option<NormalizedOutput> {
             let module = module.fold_with(&mut resolver(stable_env.marks().unresolved_mark(), top_level_mark, true));
             let module = RModule::from_orig(&mut node_id_gen, module);
             {
-                GLOBALS.set(stable_env.swc_globals(), || {
-                    let mut analyzer = Analyzer::root(
-                        env,
-                        cm.clone(),
-                        Default::default(),
-                        box &mut storage,
-                        &NoopLoader,
-                        if for_error {
-                            None
-                        } else {
-                            Some(Debugger {
-                                cm: cm.clone(),
-                                handler: handler.clone(),
-                            })
-                        },
-                    );
+                let mut analyzer = Analyzer::root(
+                    env,
+                    cm.clone(),
+                    Default::default(),
+                    box &mut storage,
+                    &NoopLoader,
+                    if for_error {
+                        None
+                    } else {
+                        Some(Debugger {
+                            cm: cm.clone(),
+                            handler: handler.clone(),
+                        })
+                    },
+                );
 
-                    let log_sub = logger(Level::DEBUG);
+                let log_sub = logger(Level::DEBUG);
 
-                    let _guard = tracing::subscriber::set_default(log_sub);
+                let _guard = tracing::subscriber::set_default(log_sub);
 
-                    module.validate_with(&mut analyzer).unwrap();
-                });
+                module.validate_with(&mut analyzer).unwrap();
             }
 
             if for_error {

--- a/crates/stc_ts_file_analyzer/tests/builtin.rs
+++ b/crates/stc_ts_file_analyzer/tests/builtin.rs
@@ -8,55 +8,51 @@ use swc_common::{Globals, DUMMY_SP, GLOBALS};
 #[test]
 pub fn builtin() {
     testing::run_test2(false, |_, _| {
-        let globals = Arc::new(Globals::default());
+        let shared = StableEnv::new();
+        let mut libs = vec![];
+        for s in &[
+            "es2020.full",
+            "es2019.full",
+            "es2018.full",
+            "es2017.full",
+            "es2016.full",
+            "es2015.full",
+            "es5.full",
+        ] {
+            libs.extend(Lib::load(s));
+        }
+        libs.sort();
+        libs.dedup();
+        let data = BuiltIn::from_ts_libs(&shared, &libs);
 
-        GLOBALS.set(&globals, || {
-            let shared = StableEnv::new(globals.clone());
-            let mut libs = vec![];
-            for s in &[
-                "es2020.full",
-                "es2019.full",
-                "es2018.full",
-                "es2017.full",
-                "es2016.full",
-                "es2015.full",
-                "es5.full",
-            ] {
-                libs.extend(Lib::load(s));
-            }
-            libs.sort();
-            libs.dedup();
-            let data = BuiltIn::from_ts_libs(&shared, &libs);
+        let env = Env::new(
+            shared,
+            Default::default(),
+            swc_ecma_ast::EsVersion::Es2020,
+            ModuleConfig::None,
+            Arc::new(data),
+        );
 
-            let env = Env::new(
-                shared,
-                Default::default(),
-                swc_ecma_ast::EsVersion::Es2020,
-                ModuleConfig::None,
-                Arc::new(data),
-            );
+        {
+            let f = env
+                .get_global_type(DUMMY_SP, &"Function".into())
+                .expect("failed to get global type Function");
 
-            {
-                let f = env
-                    .get_global_type(DUMMY_SP, &"Function".into())
-                    .expect("failed to get global type Function");
+            let function = f.expect_interface();
+            assert_eq!(function.extends, vec![]);
 
-                let function = f.expect_interface();
-                assert_eq!(function.extends, vec![]);
-
-                for member in &function.body {
-                    if let Some(key) = member.key() {
-                        println!("Key: {:?}", key);
-                    }
+            for member in &function.body {
+                if let Some(key) = member.key() {
+                    println!("Key: {:?}", key);
                 }
-
-                let keyed_item_count = function.body.iter().filter_map(|el| el.key()).count();
-
-                assert_eq!(keyed_item_count, 10);
             }
 
-            Ok(())
-        })
+            let keyed_item_count = function.body.iter().filter_map(|el| el.key()).count();
+
+            assert_eq!(keyed_item_count, 10);
+        }
+
+        Ok(())
     })
     .unwrap();
 }
@@ -64,40 +60,36 @@ pub fn builtin() {
 #[test]
 pub fn intl() {
     testing::run_test2(false, |_, _| {
-        let globals = Arc::new(Globals::default());
+        let shared = StableEnv::new();
+        let mut libs = vec![];
+        {
+            let s = &"es5";
+            libs.extend(Lib::load(s));
+        }
+        libs.sort();
+        libs.dedup();
+        let data = BuiltIn::from_ts_libs(&shared, &libs);
 
-        GLOBALS.set(&globals, || {
-            let shared = StableEnv::new(globals.clone());
-            let mut libs = vec![];
-            {
-                let s = &"es5";
-                libs.extend(Lib::load(s));
-            }
-            libs.sort();
-            libs.dedup();
-            let data = BuiltIn::from_ts_libs(&shared, &libs);
+        let env = Env::new(
+            shared,
+            Default::default(),
+            swc_ecma_ast::EsVersion::Es2020,
+            ModuleConfig::None,
+            Arc::new(data),
+        );
 
-            let env = Env::new(
-                shared,
-                Default::default(),
-                swc_ecma_ast::EsVersion::Es2020,
-                ModuleConfig::None,
-                Arc::new(data),
-            );
+        {
+            let intl = env
+                .get_global_type(DUMMY_SP, &"Intl".into())
+                .expect("failed to get global type Intl");
 
-            {
-                let intl = env
-                    .get_global_type(DUMMY_SP, &"Intl".into())
-                    .expect("failed to get global type Intl");
+            let i = intl.expect_module();
+            let type_names = i.exports.types.iter().map(|v| v.0).collect::<Vec<_>>();
+            eprintln!("Type names: {:?}", type_names);
+            assert!(i.exports.types.contains_key(&"NumberFormatOptions".into()));
+        }
 
-                let i = intl.expect_module();
-                let type_names = i.exports.types.iter().map(|v| v.0).collect::<Vec<_>>();
-                eprintln!("Type names: {:?}", type_names);
-                assert!(i.exports.types.contains_key(&"NumberFormatOptions".into()));
-            }
-
-            Ok(())
-        })
+        Ok(())
     })
     .unwrap();
 }

--- a/crates/stc_ts_file_analyzer/tests/builtin.rs
+++ b/crates/stc_ts_file_analyzer/tests/builtin.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use stc_ts_builtin_types::Lib;
 use stc_ts_env::{BuiltIn, Env, ModuleConfig, StableEnv};
 use stc_ts_file_analyzer::env::BuiltInGen;
-use swc_common::{Globals, DUMMY_SP, GLOBALS};
+use swc_common::DUMMY_SP;
 
 #[test]
 pub fn builtin() {

--- a/crates/stc_ts_file_analyzer/tests/perf.rs
+++ b/crates/stc_ts_file_analyzer/tests/perf.rs
@@ -16,7 +16,7 @@ use stc_ts_file_analyzer::{
 };
 use stc_ts_storage::Single;
 use stc_ts_types::ModuleId;
-use swc_common::{input::SourceFileInput, FileName, Mark, GLOBALS};
+use swc_common::{input::SourceFileInput, FileName, Mark, SyntaxContext, GLOBALS};
 use swc_ecma_ast::EsVersion;
 use swc_ecma_parser::{lexer::Lexer, Parser, Syntax, TsConfig};
 use swc_ecma_transforms::resolver;
@@ -40,9 +40,7 @@ fn profile_file(name: &str, path: &Path) {
 
             parser.parse_module().unwrap()
         };
-        module = GLOBALS.set(env.shared().swc_globals(), || {
-            module.fold_with(&mut resolver(env.shared().marks().unresolved_mark(), Mark::new(), true))
-        });
+        module = module.fold_with(&mut resolver(env.shared().marks().unresolved_mark(), Mark::new(), true));
         let module = RModule::from_orig(&mut node_id_gen, module);
 
         // Don't print logs from builtin modules.
@@ -51,9 +49,10 @@ fn profile_file(name: &str, path: &Path) {
         let mut storage = Single {
             parent: None,
             id: ModuleId::builtin(),
+            top_level_ctxt: SyntaxContext::empty().apply_mark(top_level_mark),
             path: Arc::new(FileName::Real(path.to_path_buf())),
-            info: Default::default(),
             is_dts: false,
+            info: Default::default(),
         };
 
         {

--- a/crates/stc_ts_file_analyzer/tests/perf.rs
+++ b/crates/stc_ts_file_analyzer/tests/perf.rs
@@ -16,7 +16,7 @@ use stc_ts_file_analyzer::{
 };
 use stc_ts_storage::Single;
 use stc_ts_types::ModuleId;
-use swc_common::{input::SourceFileInput, FileName, Mark, SyntaxContext, GLOBALS};
+use swc_common::{input::SourceFileInput, FileName, Mark, SyntaxContext};
 use swc_ecma_ast::EsVersion;
 use swc_ecma_parser::{lexer::Lexer, Parser, Syntax, TsConfig};
 use swc_ecma_transforms::resolver;
@@ -40,7 +40,8 @@ fn profile_file(name: &str, path: &Path) {
 
             parser.parse_module().unwrap()
         };
-        module = module.fold_with(&mut resolver(env.shared().marks().unresolved_mark(), Mark::new(), true));
+        let top_level_mark = Mark::new();
+        module = module.fold_with(&mut resolver(env.shared().marks().unresolved_mark(), top_level_mark, true));
         let module = RModule::from_orig(&mut node_id_gen, module);
 
         // Don't print logs from builtin modules.

--- a/crates/stc_ts_file_analyzer_macros/src/lib.rs
+++ b/crates/stc_ts_file_analyzer_macros/src/lib.rs
@@ -202,9 +202,7 @@ pub fn validator(_: proc_macro::TokenStream, item: proc_macro::TokenStream) -> p
                     fn validate(&mut self, node_pat: &NodeType, ctxt: Self::Context) -> Self::Output {
                         let (context_pats) = ctxt;
 
-                        let ret = { (|| body)() };
-
-                        ret
+                        body
                     }
                 }
             }

--- a/crates/stc_ts_storage/src/lib.rs
+++ b/crates/stc_ts_storage/src/lib.rs
@@ -8,7 +8,7 @@ use stc_ts_errors::{Error, ErrorKind, Errors};
 use stc_ts_types::{Id, ModuleId, ModuleTypeData, Type};
 use stc_utils::cache::Freeze;
 use swc_atoms::JsWord;
-use swc_common::{iter::IdentifyLast, FileName, Span, TypeEq, DUMMY_SP};
+use swc_common::{iter::IdentifyLast, FileName, Span, SyntaxContext, TypeEq, DUMMY_SP};
 
 #[derive(Debug, Default)]
 pub struct Info {
@@ -51,6 +51,8 @@ pub trait Mode: TypeStore + ErrorStore {
     /// Returns the id of the module where statement #`stmt_index` came from.
     fn module_id(&self, stmt_index: usize) -> ModuleId;
 
+    fn top_level_ctxt(&self, stmt_index: usize) -> SyntaxContext;
+
     fn is_dts(&self) -> bool;
 
     fn path(&self, id: ModuleId) -> Arc<FileName>;
@@ -68,6 +70,7 @@ pub trait Mode: TypeStore + ErrorStore {
 pub struct Single<'a> {
     pub parent: Option<&'a Single<'a>>,
     pub id: ModuleId,
+    pub top_level_ctxt: SyntaxContext,
     pub path: Arc<FileName>,
     pub is_dts: bool,
     pub info: Info,
@@ -192,6 +195,10 @@ impl<'a> Mode for Single<'a> {
         self.id
     }
 
+    fn top_level_ctxt(&self, _: usize) -> SyntaxContext {
+        self.top_level_ctxt
+    }
+
     fn is_dts(&self) -> bool {
         self.is_dts
     }
@@ -204,9 +211,10 @@ impl<'a> Mode for Single<'a> {
     fn subscope(&self) -> Storage {
         box Single {
             parent: Some(self),
-            is_dts: self.is_dts,
             id: self.id,
+            top_level_ctxt: self.top_level_ctxt,
             path: self.path.clone(),
+            is_dts: self.is_dts,
             info: Default::default(),
         }
     }
@@ -215,6 +223,7 @@ impl<'a> Mode for Single<'a> {
 #[derive(Debug, Clone)]
 pub struct File {
     pub id: ModuleId,
+    pub top_level_ctxt: SyntaxContext,
     pub path: Arc<FileName>,
     pub stmt_count: usize,
 }
@@ -325,22 +334,32 @@ impl TypeStore for Group<'_> {
     }
 }
 
-impl Mode for Group<'_> {
-    fn module_id(&self, stmt_index: usize) -> ModuleId {
+impl Group<'_> {
+    fn file(&self, stmt_index: usize) -> &File {
         let mut cur = 0;
         for (last, file) in self.files.iter().identify_last() {
             if cur <= stmt_index && stmt_index < cur + file.stmt_count {
-                return file.id;
+                return file;
             }
 
             if last {
-                return file.id;
+                return file;
             }
 
             cur += file.stmt_count;
         }
 
         unreachable!("failed to get module id")
+    }
+}
+
+impl Mode for Group<'_> {
+    fn module_id(&self, stmt_index: usize) -> ModuleId {
+        self.file(stmt_index).id
+    }
+
+    fn top_level_ctxt(&self, stmt_index: usize) -> SyntaxContext {
+        self.file(stmt_index).top_level_ctxt
     }
 
     fn is_dts(&self) -> bool {
@@ -437,6 +456,10 @@ impl TypeStore for Builtin {
 impl Mode for Builtin {
     fn module_id(&self, _stmt_index: usize) -> ModuleId {
         ModuleId::builtin()
+    }
+
+    fn top_level_ctxt(&self, _: usize) -> SyntaxContext {
+        SyntaxContext::empty()
     }
 
     fn is_dts(&self) -> bool {

--- a/crates/stc_ts_storage/src/lib.rs
+++ b/crates/stc_ts_storage/src/lib.rs
@@ -491,12 +491,14 @@ mod tests {
             let path1 = Arc::new(FileName::Real(PathBuf::from("1")));
             let file1 = File {
                 id: gen.generate(&path1).0,
+                top_level_ctxt: SyntaxContext::empty().apply_mark(gen.generate(&path1).1),
                 path: path1.clone(),
                 stmt_count: 4,
             };
             let path2 = Arc::new(FileName::Real(PathBuf::from("2")));
             let file2 = File {
                 id: gen.generate(&path2).0,
+                top_level_ctxt: SyntaxContext::empty().apply_mark(gen.generate(&path2).1),
                 path: path2.clone(),
                 stmt_count: 5,
             };

--- a/crates/stc_ts_type_checker/src/lib.rs
+++ b/crates/stc_ts_type_checker/src/lib.rs
@@ -97,23 +97,21 @@ impl Checker {
 
     /// After calling this method, you can get errors using `.take_errors()`
     pub fn check(&self, entry: Arc<FileName>) -> ModuleId {
-        self.run(|| {
-            let start = Instant::now();
+        let start = Instant::now();
 
-            let id = self.module_graph.load_all(&entry);
+        let id = self.module_graph.load_all(&entry);
 
-            let end = Instant::now();
-            log::debug!("Loading of `{}` and dependencies took {:?}", entry, end - start);
+        let end = Instant::now();
+        log::debug!("Loading of `{}` and dependencies took {:?}", entry, end - start);
 
-            let start = Instant::now();
+        let start = Instant::now();
 
-            self.analyze_module(None, entry.clone());
+        self.analyze_module(None, entry.clone());
 
-            let end = Instant::now();
-            log::debug!("Analysis of `{}` and dependencies took {:?}", entry, end - start);
+        let end = Instant::now();
+        log::debug!("Analysis of `{}` and dependencies took {:?}", entry, end - start);
 
-            id.unwrap_or_else(|(id, _)| id)
-        })
+        id.unwrap_or_else(|(id, _)| id)
     }
 
     pub fn take_errors(&mut self) -> Vec<Error> {

--- a/crates/stc_ts_type_checker/src/lib.rs
+++ b/crates/stc_ts_type_checker/src/lib.rs
@@ -77,17 +77,6 @@ impl Checker {
             declared_modules: Default::default(),
         }
     }
-
-    pub fn run<F, R>(&self, op: F) -> R
-    where
-        F: FnOnce() -> R,
-    {
-        ::swc_common::GLOBALS.set(self.globals(), op)
-    }
-
-    pub fn globals(&self) -> &swc_common::Globals {
-        self.env.shared().swc_globals()
-    }
 }
 
 impl Checker {
@@ -172,7 +161,13 @@ impl Checker {
                                     .map(|id| {
                                         let path = self.module_graph.path(id);
                                         let stmt_count = self.module_graph.stmt_count_of(id);
-                                        File { id, path, stmt_count }
+                                        let top_level_mark = self.module_graph.top_level_mark(id);
+                                        File {
+                                            id,
+                                            path,
+                                            stmt_count,
+                                            top_level_ctxt: SyntaxContext::empty().apply_mark(top_level_mark),
+                                        }
                                     })
                                     .collect(),
                             ),

--- a/crates/stc_ts_type_checker/src/lib.rs
+++ b/crates/stc_ts_type_checker/src/lib.rs
@@ -19,7 +19,7 @@ use stc_ts_types::{ModuleId, Type};
 use stc_ts_utils::StcComments;
 use stc_utils::{cache::Freeze, early_error, panic_ctx};
 use swc_atoms::JsWord;
-use swc_common::{errors::Handler, FileName, SourceMap, Spanned, DUMMY_SP};
+use swc_common::{errors::Handler, FileName, SourceMap, Spanned, SyntaxContext, DUMMY_SP};
 use swc_ecma_ast::Module;
 use swc_ecma_loader::resolve::Resolve;
 use swc_ecma_parser::TsConfig;
@@ -318,9 +318,10 @@ impl Checker {
             let mut storage = Single {
                 parent: None,
                 id: module_id,
+                top_level_ctxt: SyntaxContext::empty().apply_mark(top_level_mark),
                 path: path.clone(),
-                info: Default::default(),
                 is_dts,
+                info: Default::default(),
             };
             let mut mutations;
             {

--- a/crates/stc_ts_type_checker/src/lib.rs
+++ b/crates/stc_ts_type_checker/src/lib.rs
@@ -120,255 +120,251 @@ impl Checker {
 
     /// Analyzes one module.
     fn analyze_module(&self, starter: Option<Arc<FileName>>, path: Arc<FileName>) -> Type {
-        self.run(|| {
-            let id = self.module_graph.id(&path);
+        let id = self.module_graph.id(&path);
 
-            {
-                let lock = self.module_types.read();
-                // If a circular chunks are fully analyzed, used them.
-                if let Some(full) = lock.get(&id).and_then(|cell| cell.get().cloned()) {
-                    return full;
-                }
+        {
+            let lock = self.module_types.read();
+            // If a circular chunks are fully analyzed, used them.
+            if let Some(full) = lock.get(&id).and_then(|cell| cell.get().cloned()) {
+                return full;
             }
+        }
 
-            let is_first_run = self.started.insert(id);
+        let is_first_run = self.started.insert(id);
 
-            let circular_set = self.module_graph.get_circular(id);
+        let circular_set = self.module_graph.get_circular(id);
 
-            if is_first_run {
-                if let Some(set) = &circular_set {
+        if is_first_run {
+            if let Some(set) = &circular_set {
+                {
+                    // Mark all modules in the circular group as in-progress.
+                    let shards = self.started.shards();
+
+                    for &dep_id in set {
+                        let idx = self.started.determine_map(&dep_id);
+
+                        let mut lock = shards[idx].write();
+                        lock.insert(dep_id, SharedValue::new(()));
+                    }
+                }
+
+                {
+                    let mut node_id_gen = NodeIdGenerator::default();
+                    let mut storage = Group {
+                        parent: None,
+                        files: Arc::new(
+                            set.iter()
+                                .copied()
+                                .map(|id| {
+                                    let path = self.module_graph.path(id);
+                                    let stmt_count = self.module_graph.stmt_count_of(id);
+                                    let top_level_mark = self.module_graph.top_level_mark(id);
+                                    File {
+                                        id,
+                                        path,
+                                        stmt_count,
+                                        top_level_ctxt: SyntaxContext::empty().apply_mark(top_level_mark),
+                                    }
+                                })
+                                .collect(),
+                        ),
+                        errors: Default::default(),
+                        info: Default::default(),
+                    };
+                    let ids = set.to_vec();
+                    let modules = ids
+                        .iter()
+                        .map(|&id| (id, self.module_graph.clone_module(id)))
+                        .filter_map(|m| m.1.map(|v| (m.0, v)))
+                        .map(|(module_id, module)| {
+                            RModule::from_orig(
+                                &mut node_id_gen,
+                                module.fold_with(&mut resolver(
+                                    self.env.shared().marks().unresolved_mark(),
+                                    self.module_graph.top_level_mark(module_id),
+                                    true,
+                                )),
+                            )
+                        })
+                        .collect::<Vec<_>>();
+                    let mut mutations;
                     {
-                        // Mark all modules in the circular group as in-progress.
-                        let shards = self.started.shards();
+                        let mut a = Analyzer::root(
+                            self.env.clone(),
+                            self.cm.clone(),
+                            self.module_graph.comments().clone(),
+                            box &mut storage,
+                            self,
+                            self.debugger.clone(),
+                        );
+                        let _ = modules.validate_with(&mut a);
+                        mutations = a.mutations.unwrap();
+                    }
 
-                        for &dep_id in set {
-                            let idx = self.started.determine_map(&dep_id);
+                    for (id, mut dts_module) in ids.iter().zip(modules) {
+                        let type_data = storage.info.entry(*id).or_default();
 
-                            let mut lock = shards[idx].write();
-                            lock.insert(dep_id, SharedValue::new(()));
+                        {
+                            apply_mutations(&mut mutations, &mut dts_module);
+                            cleanup_module_for_dts(&mut dts_module.body, type_data);
+                        }
+
+                        // TODO(kdy1): Prevent duplicate work.
+                        if let Some(..) = self.dts_modules.insert(*id, dts_module) {
+                            warn!("Duplicated work: `{}`: (.d.ts already computed)", path);
                         }
                     }
 
                     {
-                        let mut node_id_gen = NodeIdGenerator::default();
-                        let mut storage = Group {
-                            parent: None,
-                            files: Arc::new(
-                                set.iter()
-                                    .copied()
-                                    .map(|id| {
-                                        let path = self.module_graph.path(id);
-                                        let stmt_count = self.module_graph.stmt_count_of(id);
-                                        let top_level_mark = self.module_graph.top_level_mark(id);
-                                        File {
-                                            id,
-                                            path,
-                                            stmt_count,
-                                            top_level_ctxt: SyntaxContext::empty().apply_mark(top_level_mark),
-                                        }
-                                    })
-                                    .collect(),
-                            ),
-                            errors: Default::default(),
-                            info: Default::default(),
-                        };
-                        let ids = set.to_vec();
-                        let modules = ids
-                            .iter()
-                            .map(|&id| (id, self.module_graph.clone_module(id)))
-                            .filter_map(|m| m.1.map(|v| (m.0, v)))
-                            .map(|(module_id, module)| {
-                                RModule::from_orig(
-                                    &mut node_id_gen,
-                                    module.fold_with(&mut resolver(
-                                        self.env.shared().marks().unresolved_mark(),
-                                        self.module_graph.top_level_mark(module_id),
-                                        true,
-                                    )),
-                                )
-                            })
-                            .collect::<Vec<_>>();
-                        let mut mutations;
-                        {
-                            let mut a = Analyzer::root(
-                                self.env.clone(),
-                                self.cm.clone(),
-                                self.module_graph.comments().clone(),
-                                box &mut storage,
-                                self,
-                                self.debugger.clone(),
-                            );
-                            let _ = modules.validate_with(&mut a);
-                            mutations = a.mutations.unwrap();
-                        }
-
-                        for (id, mut dts_module) in ids.iter().zip(modules) {
-                            let type_data = storage.info.entry(*id).or_default();
-
-                            {
-                                apply_mutations(&mut mutations, &mut dts_module);
-                                cleanup_module_for_dts(&mut dts_module.body, type_data);
-                            }
-
-                            // TODO(kdy1): Prevent duplicate work.
-                            if let Some(..) = self.dts_modules.insert(*id, dts_module) {
-                                warn!("Duplicated work: `{}`: (.d.ts already computed)", path);
-                            }
-                        }
-
-                        {
-                            let mut lock = self.errors.lock();
-                            lock.extend(storage.take_errors());
-                        }
-                        {
-                            let mut lock = self.module_types.write();
-                            for (module_id, data) in storage.info {
-                                let type_info = Type::Module(stc_ts_types::Module {
+                        let mut lock = self.errors.lock();
+                        lock.extend(storage.take_errors());
+                    }
+                    {
+                        let mut lock = self.module_types.write();
+                        for (module_id, data) in storage.info {
+                            let type_info = Type::Module(stc_ts_types::Module {
+                                span: DUMMY_SP,
+                                name: RTsModuleName::Str(RStr {
                                     span: DUMMY_SP,
-                                    name: RTsModuleName::Str(RStr {
-                                        span: DUMMY_SP,
-                                        value: format!("{:?}", module_id).into(),
-                                        raw: None,
-                                    }),
-                                    exports: box data,
-                                    metadata: Default::default(),
-                                    tracker: Default::default(),
-                                })
-                                .freezed();
+                                    value: format!("{:?}", module_id).into(),
+                                    raw: None,
+                                }),
+                                exports: box data,
+                                metadata: Default::default(),
+                                tracker: Default::default(),
+                            })
+                            .freezed();
 
-                                let res = lock.entry(module_id).or_default().set(type_info);
-                                match res {
-                                    Ok(()) => {}
-                                    Err(..) => {
-                                        warn!("Duplicated work: `{}`: (type info is already cached)", path);
-                                    }
+                            let res = lock.entry(module_id).or_default().set(type_info);
+                            match res {
+                                Ok(()) => {}
+                                Err(..) => {
+                                    warn!("Duplicated work: `{}`: (type info is already cached)", path);
                                 }
                             }
                         }
                     }
-
-                    let lock = self.module_types.read();
-                    return lock.get(&id).and_then(|cell| cell.get().cloned()).unwrap();
-                }
-            }
-            info!("Request: {}\nRequested by {:?}\nCircular set: {:?}", path, starter, circular_set);
-
-            {
-                // With write lock, we ensure that OnceCell is inserted.
-                let mut lock = self.module_types.write();
-                lock.entry(id).or_default();
-            }
-
-            {
-                let start = Instant::now();
-                let mut did_work = false;
-                let v = self.module_types.read().get(&id).cloned().unwrap();
-                // We now wait for dependency without holding lock
-                let res = v
-                    .get_or_init(|| {
-                        did_work = true;
-
-                        self.analyze_non_circular_module(id, path.clone())
-                    })
-                    .clone();
-
-                let dur = Instant::now() - start;
-                if !did_work {
-                    log::warn!("Waited for {}: {:?}", path, dur);
                 }
 
-                res
+                let lock = self.module_types.read();
+                return lock.get(&id).and_then(|cell| cell.get().cloned()).unwrap();
             }
-        })
+        }
+        info!("Request: {}\nRequested by {:?}\nCircular set: {:?}", path, starter, circular_set);
+
+        {
+            // With write lock, we ensure that OnceCell is inserted.
+            let mut lock = self.module_types.write();
+            lock.entry(id).or_default();
+        }
+
+        {
+            let start = Instant::now();
+            let mut did_work = false;
+            let v = self.module_types.read().get(&id).cloned().unwrap();
+            // We now wait for dependency without holding lock
+            let res = v
+                .get_or_init(|| {
+                    did_work = true;
+
+                    self.analyze_non_circular_module(id, path.clone())
+                })
+                .clone();
+
+            let dur = Instant::now() - start;
+            if !did_work {
+                log::warn!("Waited for {}: {:?}", path, dur);
+            }
+
+            res
+        }
     }
 
     fn analyze_non_circular_module(&self, module_id: ModuleId, path: Arc<FileName>) -> Type {
-        self.run(|| {
-            let _panic = panic_ctx!(format!("analyze_non_circular_module({})", path));
+        let _panic = panic_ctx!(format!("analyze_non_circular_module({})", path));
 
+        let start = Instant::now();
+
+        let is_dts = match &*path {
+            FileName::Real(path) => path.to_string_lossy().ends_with(".d.ts"),
+            _ => false,
+        };
+
+        let mut node_id_gen = NodeIdGenerator::default();
+        let mut module = self
+            .module_graph
+            .clone_module(module_id)
+            .unwrap_or_else(|| unreachable!("Module graph does not contains {:?}: {}", module_id, path));
+        let top_level_mark = self.module_graph.top_level_mark(module_id);
+        module = module.fold_with(&mut resolver(self.env.shared().marks().unresolved_mark(), top_level_mark, true));
+
+        let _panic = panic_ctx!(format!("Span of module = ({:?})", module.span));
+
+        let mut module = RModule::from_orig(&mut node_id_gen, module);
+
+        let mut storage = Single {
+            parent: None,
+            id: module_id,
+            top_level_ctxt: SyntaxContext::empty().apply_mark(top_level_mark),
+            path: path.clone(),
+            is_dts,
+            info: Default::default(),
+        };
+        let mut mutations;
+        {
             let start = Instant::now();
+            let mut a = Analyzer::root(
+                self.env.clone(),
+                self.cm.clone(),
+                self.module_graph.comments().clone(),
+                box &mut storage,
+                self,
+                self.debugger.clone(),
+            );
 
-            let is_dts = match &*path {
-                FileName::Real(path) => path.to_string_lossy().ends_with(".d.ts"),
-                _ => false,
-            };
+            module.visit_with(&mut a);
 
-            let mut node_id_gen = NodeIdGenerator::default();
-            let mut module = self
-                .module_graph
-                .clone_module(module_id)
-                .unwrap_or_else(|| unreachable!("Module graph does not contains {:?}: {}", module_id, path));
-            let top_level_mark = self.module_graph.top_level_mark(module_id);
-            module = module.fold_with(&mut resolver(self.env.shared().marks().unresolved_mark(), top_level_mark, true));
+            let end = Instant::now();
+            let dur = end - start;
+            log::debug!("[Timing] Analysis of {} took {:?}", path, dur);
 
-            let _panic = panic_ctx!(format!("Span of module = ({:?})", module.span));
+            mutations = a.mutations.unwrap();
+        }
 
-            let mut module = RModule::from_orig(&mut node_id_gen, module);
+        {
+            // Get .d.ts file
+            apply_mutations(&mut mutations, &mut module);
+            cleanup_module_for_dts(&mut module.body, &storage.info.exports);
+        }
 
-            let mut storage = Single {
-                parent: None,
-                id: module_id,
-                top_level_ctxt: SyntaxContext::empty().apply_mark(top_level_mark),
-                path: path.clone(),
-                is_dts,
-                info: Default::default(),
-            };
-            let mut mutations;
-            {
-                let start = Instant::now();
-                let mut a = Analyzer::root(
-                    self.env.clone(),
-                    self.cm.clone(),
-                    self.module_graph.comments().clone(),
-                    box &mut storage,
-                    self,
-                    self.debugger.clone(),
-                );
-
-                module.visit_with(&mut a);
-
-                let end = Instant::now();
-                let dur = end - start;
-                log::debug!("[Timing] Analysis of {} took {:?}", path, dur);
-
-                mutations = a.mutations.unwrap();
+        if early_error() {
+            for err in storage.info.errors {
+                self.handler.struct_span_err(err.span(), &format!("{:?}", err)).emit();
             }
+        } else {
+            let mut errors = self.errors.lock();
+            errors.extend(storage.info.errors);
+        }
 
-            {
-                // Get .d.ts file
-                apply_mutations(&mut mutations, &mut module);
-                cleanup_module_for_dts(&mut module.body, &storage.info.exports);
-            }
-
-            if early_error() {
-                for err in storage.info.errors {
-                    self.handler.struct_span_err(err.span(), &format!("{:?}", err)).emit();
-                }
-            } else {
-                let mut errors = self.errors.lock();
-                errors.extend(storage.info.errors);
-            }
-
-            let type_info = Type::Module(stc_ts_types::Module {
-                span: module.span,
-                name: RTsModuleName::Str(RStr {
-                    span: DUMMY_SP,
-                    value: format!("{:?}", module_id).into(),
-                    raw: None,
-                }),
-                exports: box storage.info.exports,
-                metadata: Default::default(),
-                tracker: Default::default(),
-            })
-            .freezed();
-
-            self.dts_modules.insert(module_id, module);
-
-            let dur = Instant::now() - start;
-            log::trace!("[Timing] Full analysis of {} took {:?}", path, dur);
-
-            type_info
+        let type_info = Type::Module(stc_ts_types::Module {
+            span: module.span,
+            name: RTsModuleName::Str(RStr {
+                span: DUMMY_SP,
+                value: format!("{:?}", module_id).into(),
+                raw: None,
+            }),
+            exports: box storage.info.exports,
+            metadata: Default::default(),
+            tracker: Default::default(),
         })
+        .freezed();
+
+        self.dts_modules.insert(module_id, module);
+
+        let dur = Instant::now() - start;
+        log::trace!("[Timing] Full analysis of {} took {:?}", path, dur);
+
+        type_info
     }
 }
 

--- a/crates/stc_ts_type_checker/src/lib.rs
+++ b/crates/stc_ts_type_checker/src/lib.rs
@@ -298,11 +298,8 @@ impl Checker {
                 .module_graph
                 .clone_module(module_id)
                 .unwrap_or_else(|| unreachable!("Module graph does not contains {:?}: {}", module_id, path));
-            module = module.fold_with(&mut resolver(
-                self.env.shared().marks().unresolved_mark(),
-                self.module_graph.top_level_mark(module_id),
-                true,
-            ));
+            let top_level_mark = self.module_graph.top_level_mark(module_id);
+            module = module.fold_with(&mut resolver(self.env.shared().marks().unresolved_mark(), top_level_mark, true));
 
             let _panic = panic_ctx!(format!("Span of module = ({:?})", module.span));
 

--- a/crates/stc_ts_type_checker/tests/conformance/internalModules/importDeclarations/invalidImportAliasIdentifiers.ts.stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/conformance/internalModules/importDeclarations/invalidImportAliasIdentifiers.ts.stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
     required_error: 2,
     matched_error: 1,
-    extra_error: 1,
+    extra_error: 0,
     panic: 0,
 }

--- a/crates/stc_ts_type_checker/tests/dts.rs
+++ b/crates/stc_ts_type_checker/tests/dts.rs
@@ -155,11 +155,9 @@ fn do_test(file_name: &Path) -> Result<(), StdErr> {
             return Ok(());
         }
 
-        checker.run(|| {
-            for e in errors {
-                e.emit(&handler);
-            }
-        });
+        for e in errors {
+            e.emit(&handler);
+        }
 
         let expected_dts = parse_dts(&expected);
         let generated_dts = parse_dts(&generated);

--- a/crates/stc_ts_type_checker/tests/error.rs
+++ b/crates/stc_ts_type_checker/tests/error.rs
@@ -68,11 +68,9 @@ fn do_test(file_name: &Path) -> Result<(), StdErr> {
         checker.check(Arc::new(FileName::Real(file_name.into())));
         let errors = ::stc_ts_errors::ErrorKind::flatten(checker.take_errors());
 
-        checker.run(|| {
-            for e in errors {
-                e.emit(&handler);
-            }
-        });
+        for e in errors {
+            e.emit(&handler);
+        }
 
         if handler.has_errors() {
             return Err(());

--- a/crates/stc_ts_type_checker/tests/pass.rs
+++ b/crates/stc_ts_type_checker/tests/pass.rs
@@ -68,11 +68,9 @@ fn do_test(file_name: &Path) -> Result<(), StdErr> {
 
         let errors = ::stc_ts_errors::ErrorKind::flatten(checker.take_errors());
 
-        checker.run(|| {
-            for e in errors {
-                e.emit(&handler);
-            }
-        });
+        for e in errors {
+            e.emit(&handler);
+        }
 
         if handler.has_errors() {
             return Err(());

--- a/crates/stc_ts_type_checker/tests/tsc-stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/tsc-stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
     required_error: 4164,
     matched_error: 5733,
-    extra_error: 959,
+    extra_error: 958,
     panic: 26,
 }

--- a/crates/stc_ts_type_checker/tests/tsc.rs
+++ b/crates/stc_ts_type_checker/tests/tsc.rs
@@ -609,11 +609,9 @@ fn do_test(file_name: &Path) -> Result<(), StdErr> {
 
                 let errors = ::stc_ts_errors::ErrorKind::flatten(checker.take_errors());
 
-                checker.run(|| {
-                    for e in errors {
-                        e.emit(&handler);
-                    }
-                });
+                for e in errors {
+                    e.emit(&handler);
+                }
 
                 let end = Instant::now();
 

--- a/crates/stc_ts_type_checker/tests/types.rs
+++ b/crates/stc_ts_type_checker/tests/types.rs
@@ -228,11 +228,9 @@ fn do_test(path: &Path) -> Result<(), StdErr> {
 
             let errors = ::stc_ts_errors::ErrorKind::flatten(checker.take_errors());
 
-            checker.run(|| {
-                for e in errors {
-                    e.emit(&handler_for_errors);
-                }
-            });
+            for e in errors {
+                e.emit(&handler_for_errors);
+            }
 
             eprintln!("{}", NormalizedOutput::from(error_text));
 


### PR DESCRIPTION
**Description:**

This PR removes `swc_globals` from `Env`. `Env` now does not manage `Marks`, so the user is responsible for providing the correct `Marks`. i.e. Created from the current `swc_common::GLOBALS`.

This change is made because the previous design was too error-prone. I found lots of mistakes due to `Env` in tests and fixed all of them.

Additionally, this PR exposes the top-level context to the `Analyzer`. The analyzer requires top-level context because of JSX.