### PR TITLE
fix(ts/analyzer): Allow member expr as the init of const enums

### DIFF
--- a/crates/stc_ts_file_analyzer/src/analyzer/enums.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/enums.rs
@@ -618,8 +618,6 @@ struct LitValidator<'a> {
 
 impl Visit<RExpr> for LitValidator<'_> {
     fn visit(&mut self, e: &RExpr) {
-        e.visit_children_with(self);
-
         match e {
             RExpr::Lit(..) => {}
             RExpr::Ident(ref i) => {
@@ -637,7 +635,10 @@ impl Visit<RExpr> for LitValidator<'_> {
                     self.error = true;
                 }
             }
-            RExpr::Unary(..) | RExpr::Bin(..) | RExpr::Paren(..) => {}
+            RExpr::Member(..) => {}
+            RExpr::Unary(..) | RExpr::Bin(..) | RExpr::Paren(..) => {
+                e.visit_children_with(self);
+            }
 
             _ => {
                 self.error = true;

--- a/crates/stc_ts_type_checker/tests/conformance/types/literal/templateLiteralTypes4.stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/conformance/types/literal/templateLiteralTypes4.stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
     required_error: 1,
     matched_error: 1,
-    extra_error: 5,
+    extra_error: 3,
     panic: 0,
 }

--- a/crates/stc_ts_type_checker/tests/tsc-stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/tsc-stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
     required_error: 4320,
     matched_error: 5785,
-    extra_error: 1057,
+    extra_error: 1055,
     panic: 85,
 }


### PR DESCRIPTION
**Description:**
