### PR TITLE
fix(ts/analyzer): improve type guard of the form `typeof x === s`

### DIFF
--- a/crates/stc_ts_file_analyzer/src/analyzer/expr/bin.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/expr/bin.rs
@@ -963,7 +963,7 @@ impl Analyzer<'_, '_> {
                                 //  - typeof x === s
                                 //  removes the primitive types string, number, and boolean from
                                 //  the type of x in true facts.
-                                self.cur_facts.true_facts.excludes.entry(name.clone()).or_default().extend(vec![
+                                self.cur_facts.true_facts.excludes.entry(name).or_default().extend(vec![
                                     Type::Keyword(KeywordType {
                                         span,
                                         kind: TsKeywordTypeKind::TsStringKeyword,
@@ -987,7 +987,7 @@ impl Analyzer<'_, '_> {
                                 //  - typeof x !== s
                                 //  removes the primitive types string, number, and boolean from
                                 //  the type of x in false facts.
-                                self.cur_facts.false_facts.excludes.entry(name.clone()).or_default().extend(vec![
+                                self.cur_facts.false_facts.excludes.entry(name).or_default().extend(vec![
                                     Type::Keyword(KeywordType {
                                         span,
                                         kind: TsKeywordTypeKind::TsStringKeyword,

--- a/crates/stc_ts_file_analyzer/src/analyzer/expr/bin.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/expr/bin.rs
@@ -963,7 +963,7 @@ impl Analyzer<'_, '_> {
                                 //  - typeof x === s
                                 //  removes the primitive types string, number, and boolean from
                                 //  the type of x in true facts.
-                                self.cur_facts.false_facts.excludes.entry(name.clone()).or_default().extend(vec![
+                                self.cur_facts.true_facts.excludes.entry(name.clone()).or_default().extend(vec![
                                     Type::Keyword(KeywordType {
                                         span,
                                         kind: TsKeywordTypeKind::TsStringKeyword,

--- a/crates/stc_ts_file_analyzer/src/analyzer/expr/bin.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/expr/bin.rs
@@ -963,56 +963,50 @@ impl Analyzer<'_, '_> {
                                 //  - typeof x === s
                                 //  removes the primitive types string, number, and boolean from
                                 //  the type of x in true facts.
-                                self.cur_facts.true_facts.excludes.insert(
-                                    name.clone(),
-                                    vec![
-                                        Type::Keyword(KeywordType {
-                                            span,
-                                            kind: TsKeywordTypeKind::TsStringKeyword,
-                                            metadata: Default::default(),
-                                            tracker: Default::default(),
-                                        }),
-                                        Type::Keyword(KeywordType {
-                                            span,
-                                            kind: TsKeywordTypeKind::TsBooleanKeyword,
-                                            metadata: Default::default(),
-                                            tracker: Default::default(),
-                                        }),
-                                        Type::Keyword(KeywordType {
-                                            span,
-                                            kind: TsKeywordTypeKind::TsNumberKeyword,
-                                            metadata: Default::default(),
-                                            tracker: Default::default(),
-                                        }),
-                                    ],
-                                );
+                                self.cur_facts.false_facts.excludes.entry(name.clone()).or_default().extend(vec![
+                                    Type::Keyword(KeywordType {
+                                        span,
+                                        kind: TsKeywordTypeKind::TsStringKeyword,
+                                        metadata: Default::default(),
+                                        tracker: Default::default(),
+                                    }),
+                                    Type::Keyword(KeywordType {
+                                        span,
+                                        kind: TsKeywordTypeKind::TsBooleanKeyword,
+                                        metadata: Default::default(),
+                                        tracker: Default::default(),
+                                    }),
+                                    Type::Keyword(KeywordType {
+                                        span,
+                                        kind: TsKeywordTypeKind::TsNumberKeyword,
+                                        metadata: Default::default(),
+                                        tracker: Default::default(),
+                                    }),
+                                ]);
                             } else {
                                 //  - typeof x !== s
                                 //  removes the primitive types string, number, and boolean from
                                 //  the type of x in false facts.
-                                self.cur_facts.false_facts.excludes.insert(
-                                    name.clone(),
-                                    vec![
-                                        Type::Keyword(KeywordType {
-                                            span,
-                                            kind: TsKeywordTypeKind::TsStringKeyword,
-                                            metadata: Default::default(),
-                                            tracker: Default::default(),
-                                        }),
-                                        Type::Keyword(KeywordType {
-                                            span,
-                                            kind: TsKeywordTypeKind::TsBooleanKeyword,
-                                            metadata: Default::default(),
-                                            tracker: Default::default(),
-                                        }),
-                                        Type::Keyword(KeywordType {
-                                            span,
-                                            kind: TsKeywordTypeKind::TsNumberKeyword,
-                                            metadata: Default::default(),
-                                            tracker: Default::default(),
-                                        }),
-                                    ],
-                                );
+                                self.cur_facts.false_facts.excludes.entry(name.clone()).or_default().extend(vec![
+                                    Type::Keyword(KeywordType {
+                                        span,
+                                        kind: TsKeywordTypeKind::TsStringKeyword,
+                                        metadata: Default::default(),
+                                        tracker: Default::default(),
+                                    }),
+                                    Type::Keyword(KeywordType {
+                                        span,
+                                        kind: TsKeywordTypeKind::TsBooleanKeyword,
+                                        metadata: Default::default(),
+                                        tracker: Default::default(),
+                                    }),
+                                    Type::Keyword(KeywordType {
+                                        span,
+                                        kind: TsKeywordTypeKind::TsNumberKeyword,
+                                        metadata: Default::default(),
+                                        tracker: Default::default(),
+                                    }),
+                                ]);
                             }
                             None
                         }

--- a/crates/stc_ts_type_checker/tests/conformance/es2021/logicalAssignment/logicalAssignment8(target=es2015).stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/conformance/es2021/logicalAssignment/logicalAssignment8(target=es2015).stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
-    required_error: 1,
-    matched_error: 0,
+    required_error: 0,
+    matched_error: 1,
     extra_error: 0,
     panic: 0,
 }

--- a/crates/stc_ts_type_checker/tests/conformance/es2021/logicalAssignment/logicalAssignment8(target=es2020).stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/conformance/es2021/logicalAssignment/logicalAssignment8(target=es2020).stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
-    required_error: 1,
-    matched_error: 0,
+    required_error: 0,
+    matched_error: 1,
     extra_error: 0,
     panic: 0,
 }

--- a/crates/stc_ts_type_checker/tests/conformance/es2021/logicalAssignment/logicalAssignment8(target=es2021).stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/conformance/es2021/logicalAssignment/logicalAssignment8(target=es2021).stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
-    required_error: 1,
-    matched_error: 0,
+    required_error: 0,
+    matched_error: 1,
     extra_error: 0,
     panic: 0,
 }

--- a/crates/stc_ts_type_checker/tests/conformance/es2021/logicalAssignment/logicalAssignment8(target=es2022).stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/conformance/es2021/logicalAssignment/logicalAssignment8(target=es2022).stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
     required_error: 0,
     matched_error: 0,
-    extra_error: 0,
+    extra_error: 1,
     panic: 0,
 }

--- a/crates/stc_ts_type_checker/tests/conformance/esnext/logicalAssignment/logicalAssignment8(target=es2015).stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/conformance/esnext/logicalAssignment/logicalAssignment8(target=es2015).stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
-    required_error: 1,
-    matched_error: 0,
+    required_error: 0,
+    matched_error: 1,
     extra_error: 0,
     panic: 0,
 }

--- a/crates/stc_ts_type_checker/tests/conformance/esnext/logicalAssignment/logicalAssignment8(target=es2020).stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/conformance/esnext/logicalAssignment/logicalAssignment8(target=es2020).stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
-    required_error: 1,
-    matched_error: 0,
+    required_error: 0,
+    matched_error: 1,
     extra_error: 0,
     panic: 0,
 }

--- a/crates/stc_ts_type_checker/tests/conformance/esnext/logicalAssignment/logicalAssignment8(target=es2022).stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/conformance/esnext/logicalAssignment/logicalAssignment8(target=es2022).stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
     required_error: 0,
     matched_error: 0,
-    extra_error: 0,
+    extra_error: 1,
     panic: 0,
 }

--- a/crates/stc_ts_type_checker/tests/conformance/expressions/typeGuards/typeGuardOfFormTypeOfEqualEqualHasNoEffect.stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/conformance/expressions/typeGuards/typeGuardOfFormTypeOfEqualEqualHasNoEffect.stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
-    required_error: 5,
-    matched_error: 0,
+    required_error: 4,
+    matched_error: 1,
     extra_error: 0,
     panic: 0,
 }

--- a/crates/stc_ts_type_checker/tests/conformance/expressions/typeGuards/typeGuardOfFormTypeOfNotEqualHasNoEffect.stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/conformance/expressions/typeGuards/typeGuardOfFormTypeOfNotEqualHasNoEffect.stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
-    required_error: 5,
-    matched_error: 0,
+    required_error: 4,
+    matched_error: 1,
     extra_error: 0,
     panic: 0,
 }

--- a/crates/stc_ts_type_checker/tests/conformance/expressions/typeGuards/typeGuardOfFormTypeOfOther.stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/conformance/expressions/typeGuards/typeGuardOfFormTypeOfOther.stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
     required_error: 8,
     matched_error: 2,
-    extra_error: 12,
+    extra_error: 6,
     panic: 0,
 }

--- a/crates/stc_ts_type_checker/tests/conformance/expressions/typeGuards/typeGuardOfFormTypeOfOther.stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/conformance/expressions/typeGuards/typeGuardOfFormTypeOfOther.stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
-    required_error: 8,
-    matched_error: 2,
+    required_error: 0,
+    matched_error: 10,
     extra_error: 6,
     panic: 0,
 }

--- a/crates/stc_ts_type_checker/tests/tsc-stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/tsc-stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
-    required_error: 4291,
-    matched_error: 5814,
-    extra_error: 1067,
+    required_error: 4276,
+    matched_error: 5829,
+    extra_error: 1063,
     panic: 29,
 }


### PR DESCRIPTION
<!-- Note: CI script will automatically rebase your PR so please do not rebase unless required -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**
from [this test case](https://github.com/dudykr/stc/blob/main/crates/stc_ts_type_checker/tests/conformance/expressions/typeGuards/typeGuardOfFormTypeOfOther.ts)

```
A type guard of the form typeof x === s, where s is a string literal with any value but 'string', 'number' or 'boolean',
  - when true, removes the primitive types string, number, and boolean from the type of x, or
  - when false, has no effect on the type of x.

A type guard of the form typeof x !== s, where s is a string literal,
  - when true, narrows the type of x by typeof x === s when false, or
  - when false, narrows the type of x by typeof x === s when true.
```
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**BREAKING CHANGE:**

<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG. Add description or remove entirely if not breaking.

You may need to update `MIGRATION.md` for the breaking changes.
-->

**Related issue (if exists):**
