### PR TITLE
fix: Remove symbol form check

### DIFF
--- a/crates/stc_ts_errors/src/lib.rs
+++ b/crates/stc_ts_errors/src/lib.rs
@@ -1367,11 +1367,6 @@ pub enum ErrorKind {
         op: AssignOp,
     },
 
-    /// TS2471
-    NonSymbolComputedPropInFormOfSymbol {
-        span: Span,
-    },
-
     ExpectedNArgsButGotM {
         span: Span,
         min: usize,
@@ -1691,7 +1686,6 @@ impl ErrorKind {
             | ErrorKind::NoSuchPropertyInModule { .. } => 2339,
 
             ErrorKind::AssignOpCannotBeApplied { .. } => 2365,
-            ErrorKind::NonSymbolComputedPropInFormOfSymbol { .. } => 2471,
             ErrorKind::TypeUsedAsVar { .. } => 2693,
             ErrorKind::TypeNotFound { .. } => 2304,
 

--- a/crates/stc_ts_file_analyzer/src/analyzer/props.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/props.rs
@@ -153,27 +153,6 @@ impl Analyzer<'_, '_> {
                 }
             }
 
-            if check_for_validity && check_for_symbol_form && is_symbol_access {
-                match ty.normalize_instance() {
-                    Type::Keyword(KeywordType {
-                        kind: TsKeywordTypeKind::TsSymbolKeyword,
-                        ..
-                    })
-                    | Type::Symbol(..) => {}
-                    Type::Operator(Operator {
-                        op: TsTypeOperatorOp::Unique,
-                        ty,
-                        ..
-                    }) if ty.normalize_instance().is_kwd(TsKeywordTypeKind::TsSymbolKeyword) => {}
-                    _ => {
-                        //
-                        analyzer
-                            .storage
-                            .report(ErrorKind::NonSymbolComputedPropInFormOfSymbol { span }.into());
-                    }
-                }
-            }
-
             if !errors.is_empty() {
                 analyzer.storage.report_all(errors);
             }

--- a/crates/stc_ts_file_analyzer/src/analyzer/props.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/props.rs
@@ -89,14 +89,12 @@ impl Analyzer<'_, '_> {
 
         self.with_ctx(ctx).with(|analyzer: &mut Analyzer| {
             let mut check_for_validity = true;
-            let mut check_for_symbol_form = true;
 
             let mut errors = Errors::default();
 
             let mut ty = match node.expr.validate_with_default(analyzer) {
                 Ok(ty) => ty,
                 Err(err) => {
-                    check_for_symbol_form = false;
                     if let ErrorKind::TS2585 { span } = *err {
                         Err(ErrorKind::TS2585 { span })?
                     }
@@ -142,7 +140,6 @@ impl Analyzer<'_, '_> {
                                 _ => {
                                     if let ComputedPropMode::Interface = mode {
                                         errors.push(ErrorKind::TS1169 { span: node.span }.into());
-                                        check_for_symbol_form = false;
                                     }
                                 }
                             }

--- a/crates/stc_ts_type_checker/tests/conformance.pass.txt
+++ b/crates/stc_ts_type_checker/tests/conformance.pass.txt
@@ -1,4 +1,9 @@
+Symbols/ES5SymbolProperty1.ts
+Symbols/ES5SymbolProperty2.ts
+Symbols/ES5SymbolProperty3.ts
+Symbols/ES5SymbolProperty4.ts
 Symbols/ES5SymbolProperty6.ts
+Symbols/ES5SymbolProperty7.ts
 Symbols/ES5SymbolType1.ts
 ambient/ambientDeclarations.ts
 ambient/ambientDeclarationsPatterns_tooManyAsterisks.ts
@@ -415,6 +420,8 @@ es6/Symbols/symbolProperty41.ts
 es6/Symbols/symbolProperty43.ts
 es6/Symbols/symbolProperty45.ts
 es6/Symbols/symbolProperty46.ts
+es6/Symbols/symbolProperty48.ts
+es6/Symbols/symbolProperty49.ts
 es6/Symbols/symbolProperty5.ts
 es6/Symbols/symbolProperty50.ts
 es6/Symbols/symbolProperty51.ts
@@ -424,6 +431,7 @@ es6/Symbols/symbolProperty54.ts
 es6/Symbols/symbolProperty55.ts
 es6/Symbols/symbolProperty56.ts
 es6/Symbols/symbolProperty57.ts
+es6/Symbols/symbolProperty58.ts
 es6/Symbols/symbolProperty6.ts
 es6/Symbols/symbolProperty60.ts
 es6/Symbols/symbolProperty8.ts

--- a/crates/stc_ts_type_checker/tests/conformance/Symbols/ES5SymbolProperty1.stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/conformance/Symbols/ES5SymbolProperty1.stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
     required_error: 0,
     matched_error: 0,
-    extra_error: 1,
+    extra_error: 0,
     panic: 0,
 }

--- a/crates/stc_ts_type_checker/tests/conformance/Symbols/ES5SymbolProperty2.stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/conformance/Symbols/ES5SymbolProperty2.stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
     required_error: 0,
     matched_error: 1,
-    extra_error: 1,
+    extra_error: 0,
     panic: 0,
 }

--- a/crates/stc_ts_type_checker/tests/conformance/Symbols/ES5SymbolProperty3.stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/conformance/Symbols/ES5SymbolProperty3.stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
     required_error: 0,
     matched_error: 0,
-    extra_error: 1,
+    extra_error: 0,
     panic: 0,
 }

--- a/crates/stc_ts_type_checker/tests/conformance/Symbols/ES5SymbolProperty4.stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/conformance/Symbols/ES5SymbolProperty4.stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
     required_error: 0,
     matched_error: 0,
-    extra_error: 1,
+    extra_error: 0,
     panic: 0,
 }

--- a/crates/stc_ts_type_checker/tests/conformance/Symbols/ES5SymbolProperty7.stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/conformance/Symbols/ES5SymbolProperty7.stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
     required_error: 0,
     matched_error: 0,
-    extra_error: 1,
+    extra_error: 0,
     panic: 0,
 }

--- a/crates/stc_ts_type_checker/tests/conformance/es6/Symbols/symbolProperty48.stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/conformance/es6/Symbols/symbolProperty48.stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
     required_error: 0,
     matched_error: 0,
-    extra_error: 1,
+    extra_error: 0,
     panic: 0,
 }

--- a/crates/stc_ts_type_checker/tests/conformance/es6/Symbols/symbolProperty49.stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/conformance/es6/Symbols/symbolProperty49.stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
     required_error: 0,
     matched_error: 0,
-    extra_error: 1,
+    extra_error: 0,
     panic: 0,
 }

--- a/crates/stc_ts_type_checker/tests/conformance/es6/Symbols/symbolProperty58.stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/conformance/es6/Symbols/symbolProperty58.stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
     required_error: 0,
     matched_error: 0,
-    extra_error: 1,
+    extra_error: 0,
     panic: 0,
 }

--- a/crates/stc_ts_type_checker/tests/tsc-stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/tsc-stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
     required_error: 4252,
     matched_error: 5814,
-    extra_error: 1030,
+    extra_error: 1022,
     panic: 29,
 }


### PR DESCRIPTION
**Description:**

`TS2471` is not relevant anymore.

https://github.com/microsoft/TypeScript/blob/4ba756fdc847115bc1ff5032ed06e9bed60f16b2/src/compiler/diagnosticMessages.json