### PR TITLE
fix: Fix evaluation of template literals

### DIFF
--- a/crates/stc_ts_file_analyzer/src/analyzer/assign/tpl.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/assign/tpl.rs
@@ -73,8 +73,8 @@ impl Analyzer<'_, '_> {
             Type::Lit(LitType {
                 lit: RTsLit::Str(value), ..
             }) => {
-                if target.is_kwd(TsKeywordTypeKind::TsNumberKeyword) && self.is_valid_num_str(&value.value, false)
-                    || target.is_kwd(TsKeywordTypeKind::TsBigIntKeyword) && self.is_valid_big_int_str(&value.value, false)
+                if target.is_num() && self.is_valid_num_str(&value.value, false)
+                    || target.is_bigint() && self.is_valid_big_int_str(&value.value, false)
                 {
                     return Ok(true);
                 }

--- a/crates/stc_ts_file_analyzer/src/analyzer/assign/tpl.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/assign/tpl.rs
@@ -73,8 +73,8 @@ impl Analyzer<'_, '_> {
             Type::Lit(LitType {
                 lit: RTsLit::Str(value), ..
             }) => {
-                if target.is_num() && self.is_valid_num_str(&value.value, false)
-                    || target.is_bigint() && self.is_valid_big_int_str(&value.value, false)
+                if target.is_kwd(TsKeywordTypeKind::TsNumberKeyword) && self.is_valid_num_str(&value.value, false)
+                    || target.is_kwd(TsKeywordTypeKind::TsBigIntKeyword) && self.is_valid_big_int_str(&value.value, false)
                 {
                     return Ok(true);
                 }

--- a/crates/stc_ts_file_analyzer/src/analyzer/assign/tpl.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/assign/tpl.rs
@@ -73,8 +73,9 @@ impl Analyzer<'_, '_> {
             Type::Lit(LitType {
                 lit: RTsLit::Str(value), ..
             }) => {
-                if target.is_kwd(TsKeywordTypeKind::TsNumberKeyword) && self.is_valid_num_str(&value.value, false)
-                    || target.is_kwd(TsKeywordTypeKind::TsBigIntKeyword) && self.is_valid_big_int_str(&value.value, false)
+                // TODO: Validate literal value correctly
+                if target.is_num() && self.is_valid_num_str(&value.value, false)
+                    || target.is_bigint() && self.is_valid_big_int_str(&value.value, false)
                 {
                     return Ok(true);
                 }

--- a/crates/stc_ts_file_analyzer/src/analyzer/expr/bin.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/expr/bin.rs
@@ -223,6 +223,12 @@ impl Analyzer<'_, '_> {
             (Some(l), Some(r)) => (l, r),
             _ => return Err(ErrorKind::Errors { span, errors }.into()),
         };
+        if self.ctx.in_switch_case_test {
+            if lt.is_tpl() {
+                lt = lt.generalize_lit();
+            }
+        }
+
         lt.freeze();
         rt.freeze();
 

--- a/crates/stc_ts_file_analyzer/src/analyzer/expr/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/expr/mod.rs
@@ -4211,19 +4211,6 @@ impl Analyzer<'_, '_> {
 #[validator]
 impl Analyzer<'_, '_> {
     fn validate(&mut self, e: &RTpl, type_ann: Option<&Type>) -> VResult<Type> {
-        if e.exprs.is_empty() {
-            return Ok(Type::Lit(LitType {
-                span: e.span,
-                lit: RTsLit::Str(RStr {
-                    span: e.span,
-                    value: (&*e.quasis[0].cooked.clone().unwrap_or_else(|| e.quasis[0].raw.clone())).into(),
-                    raw: None,
-                }),
-                metadata: Default::default(),
-                tracker: Default::default(),
-            }));
-        }
-
         let types = e
             .exprs
             .iter()

--- a/crates/stc_ts_file_analyzer/src/analyzer/expr/type_cast.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/expr/type_cast.rs
@@ -260,7 +260,7 @@ impl Analyzer<'_, '_> {
             return Ok(true);
         }
 
-        if (from.is_str() || from.is_tpl()) && to.is_tpl() {
+        if from.is_kwd(TsKeywordTypeKind::TsStringKeyword) && to.is_tpl() {
             return Ok(true);
         }
 

--- a/crates/stc_ts_file_analyzer/src/analyzer/expr/type_cast.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/expr/type_cast.rs
@@ -206,6 +206,7 @@ impl Analyzer<'_, '_> {
             .convert_err(|err| ErrorKind::NonOverlappingTypeCast { span })
     }
 
+    #[cfg_attr(debug_assertions, tracing::instrument(skip_all))]
     pub(crate) fn has_overlap(&mut self, span: Span, l: &Type, r: &Type, opts: CastableOpts) -> VResult<bool> {
         let l = l.normalize();
         let r = r.normalize();
@@ -221,7 +222,7 @@ impl Analyzer<'_, '_> {
     ///
     /// - `l`: from
     /// - `r`: to
-
+    #[cfg_attr(debug_assertions, tracing::instrument(skip_all))]
     pub(crate) fn castable(&mut self, span: Span, from: &Type, to: &Type, opts: CastableOpts) -> VResult<bool> {
         let from = self
             .normalize(

--- a/crates/stc_ts_file_analyzer/src/analyzer/expr/type_cast.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/expr/type_cast.rs
@@ -405,11 +405,13 @@ impl Analyzer<'_, '_> {
             return Ok(false);
         }
 
-        if let (Type::Tpl(from), Type::Tpl(to)) = (from.normalize(), to.normalize()) {
-            if self.tpl_lit_type_definitely_unrelated(span, from, to)? {
-                return Ok(false);
-            } else {
-                return Ok(true);
+        if let Type::Tpl(to) = to.normalize() {
+            if let Type::Tpl(from) = from.normalize() {
+                if self.tpl_lit_type_definitely_unrelated(span, from, to)? {
+                    return Ok(false);
+                } else {
+                    return Ok(true);
+                }
             }
         }
 

--- a/crates/stc_ts_file_analyzer/src/analyzer/expr/type_cast.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/expr/type_cast.rs
@@ -407,11 +407,7 @@ impl Analyzer<'_, '_> {
 
         if let Type::Tpl(to) = to.normalize() {
             if let Type::Tpl(from) = from.normalize() {
-                if self.tpl_lit_type_definitely_unrelated(span, from, to)? {
-                    return Ok(false);
-                } else {
-                    return Ok(true);
-                }
+                return Ok(!self.tpl_lit_type_definitely_unrelated(span, from, to)?);
             }
         }
 

--- a/crates/stc_ts_file_analyzer/tests/pass-only/narrow/templateLiteralTypes3/1.ts
+++ b/crates/stc_ts_file_analyzer/tests/pass-only/narrow/templateLiteralTypes3/1.ts
@@ -1,0 +1,11 @@
+
+type Action =
+    | { type: `${string}_REQUEST` }
+    | { type: `${string}_SUCCESS`, response: string };
+
+export function reducer(action: Action) {
+    if (action.type === 'FOO_SUCCESS') {
+        action.type;
+        action.response;
+    }
+}

--- a/crates/stc_ts_file_analyzer/tests/pass/controlFlow/guard/tpl-in-1.swc-stderr
+++ b/crates/stc_ts_file_analyzer/tests/pass/controlFlow/guard/tpl-in-1.swc-stderr
@@ -6,7 +6,7 @@
    `----
 
 Error: 
-  > "test"
+  > `test`
 
   x Type
    ,-[$DIR/tests/pass/controlFlow/guard/tpl-in-1.ts:2:1]

--- a/crates/stc_ts_file_analyzer/tests/pass/controlFlow/guard/tpl-typoeof-1.swc-stderr
+++ b/crates/stc_ts_file_analyzer/tests/pass/controlFlow/guard/tpl-typoeof-1.swc-stderr
@@ -24,7 +24,7 @@ Error:
    `----
 
 Error: 
-  > "string"
+  > `string`
 
   x Type
    ,-[$DIR/tests/pass/controlFlow/guard/tpl-typoeof-1.ts:2:1]

--- a/crates/stc_ts_file_analyzer/tests/pass/exprs/object/key/10.swc-stderr
+++ b/crates/stc_ts_file_analyzer/tests/pass/exprs/object/key/10.swc-stderr
@@ -6,7 +6,7 @@
    `----
 
 Error: 
-  > "hello bye"
+  > `hello bye`
 
   x Type
    ,-[$DIR/tests/pass/exprs/object/key/10.ts:5:1]

--- a/crates/stc_ts_file_analyzer/tests/visualize/types/literal/templateLiteralTypes2.swc-stderr
+++ b/crates/stc_ts_file_analyzer/tests/visualize/types/literal/templateLiteralTypes2.swc-stderr
@@ -1077,7 +1077,7 @@ Error:
      `----
 
 Error: 
-  > "22px"
+  > `22px`
 
   x Type
      ,-[$DIR/tests/visualize/types/literal/templateLiteralTypes2.ts:109:1]

--- a/crates/stc_ts_type_checker/tests/conformance/types/literal/templateLiteralTypes3.stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/conformance/types/literal/templateLiteralTypes3.stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
-    required_error: 3,
-    matched_error: 5,
-    extra_error: 1,
+    required_error: 1,
+    matched_error: 7,
+    extra_error: 0,
     panic: 0,
 }

--- a/crates/stc_ts_type_checker/tests/tsc-stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/tsc-stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
-    required_error: 4267,
-    matched_error: 5807,
-    extra_error: 988,
+    required_error: 4265,
+    matched_error: 5809,
+    extra_error: 987,
     panic: 29,
 }

--- a/crates/stc_ts_types/src/lib.rs
+++ b/crates/stc_ts_types/src/lib.rs
@@ -2301,6 +2301,19 @@ impl Type {
         )
     }
 
+    pub fn is_bigint(&self) -> bool {
+        matches!(
+            self.normalize_instance(),
+            Type::Keyword(KeywordType {
+                kind: TsKeywordTypeKind::TsBigIntKeyword,
+                ..
+            }) | Type::Lit(LitType {
+                lit: RTsLit::BigInt(..),
+                ..
+            })
+        )
+    }
+
     pub fn is_num_lit(&self) -> bool {
         matches!(
             self.normalize(),


### PR DESCRIPTION
**Description:**

Previously we were evaluating type-less template literals as a string literal, but it's wrong.