### PR TITLE
fix: Fix static property access with a private key

### DIFF
--- a/crates/stc_ts_file_analyzer/src/analyzer/expr/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/expr/mod.rs
@@ -2604,6 +2604,12 @@ impl Analyzer<'_, '_> {
                             }
                             // TODO(kdy1): normalized string / ident
                             if self.key_matches(span, &p.key, prop, false) {
+                                if p.key.is_private() {
+                                    self.storage
+                                        .report(ErrorKind::CannotAccessPrivatePropertyFromOutside { span }.into());
+                                    return Ok(Type::any(span, Default::default()));
+                                }
+
                                 if let Some(ref ty) = p.value {
                                     return Ok(*ty.clone());
                                 }
@@ -2618,6 +2624,12 @@ impl Analyzer<'_, '_> {
                             }
 
                             if self.key_matches(span, &m.key, prop, false) {
+                                if m.key.is_private() {
+                                    self.storage
+                                        .report(ErrorKind::CannotAccessPrivatePropertyFromOutside { span }.into());
+                                    return Ok(Type::any(span, Default::default()));
+                                }
+
                                 return Ok(Type::Function(ty::Function {
                                     span,
                                     type_params: m.type_params.clone(),

--- a/crates/stc_ts_type_checker/tests/conformance.pass.txt
+++ b/crates/stc_ts_type_checker/tests/conformance.pass.txt
@@ -245,6 +245,7 @@ classes/members/privateNames/privateNameMethodInStaticFieldInit.ts
 classes/members/privateNames/privateNameNestedClassNameConflict.ts
 classes/members/privateNames/privateNameNotAccessibleOutsideDefiningClass.ts
 classes/members/privateNames/privateNameSetterExprReturnValue.ts
+classes/members/privateNames/privateNameStaticAccessorsAccess.ts
 classes/members/privateNames/privateNameStaticAndStaticInitializer.ts
 classes/members/privateNames/privateNameStaticFieldAccess.ts
 classes/members/privateNames/privateNameStaticFieldAssignment.ts

--- a/crates/stc_ts_type_checker/tests/conformance/classes/members/privateNames/privateNameStaticAccessorsAccess.stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/conformance/classes/members/privateNames/privateNameStaticAccessorsAccess.stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
-    required_error: 3,
-    matched_error: 0,
+    required_error: 0,
+    matched_error: 3,
     extra_error: 0,
     panic: 0,
 }

--- a/crates/stc_ts_type_checker/tests/tsc-stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/tsc-stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
-    required_error: 4265,
-    matched_error: 5809,
+    required_error: 4262,
+    matched_error: 5812,
     extra_error: 987,
     panic: 29,
 }


### PR DESCRIPTION
**Description:**
```javascript
class A {
    static #prop = 1
}

A.#prop; // Error```