### PR TITLE
refactor: Prepare analysis of namespaces

### DIFF
--- a/crates/stc_ts_file_analyzer/src/analyzer/expr/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/expr/mod.rs
@@ -3776,22 +3776,8 @@ impl Analyzer<'_, '_> {
                             Type::Conditional(_) => {}
                             Type::Tuple(_) => {}
                             Type::Array(_) => {}
-                            Type::Union(ty) => {
-                                // TODO(kdy1): Expand types
-                                if !self.is_builtin {
-                                    if cfg!(debug_assertions) {
-                                        dbg!(&ty);
-                                    }
-                                }
-                            }
-                            Type::Intersection(ty) => {
-                                // TODO(kdy1): Expand types
-                                if !self.is_builtin {
-                                    if cfg!(debug_assertions) {
-                                        dbg!(&ty);
-                                    }
-                                }
-                            }
+                            Type::Union(_) => {}
+                            Type::Intersection(_) => {}
                             Type::Operator(_) => {}
                             Type::Mapped(_) => {}
                             Type::Arc(_) => {}

--- a/crates/stc_ts_file_analyzer/src/analyzer/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/mod.rs
@@ -489,7 +489,7 @@ impl<'scope, 'b> Analyzer<'scope, 'b> {
                 in_opt_chain: false,
                 in_declare: is_dts,
                 in_fn_without_body: false,
-                in_global: false,
+                in_global: is_dts,
                 in_export_default_expr: false,
                 in_async: false,
                 in_generator: false,

--- a/crates/stc_ts_module_loader/src/lib.rs
+++ b/crates/stc_ts_module_loader/src/lib.rs
@@ -210,8 +210,8 @@ where
         let loaded = match loaded {
             Ok(v) => v,
             Err(err) => {
-                error!("failed to load module: {:?}", err);
                 if resolve_all {
+                    error!("failed to load module: {:?}", err);
                     self.errors.lock().push(err);
 
                     self.loaded.insert(id, Err(()));

--- a/crates/stc_ts_type_checker/src/lib.rs
+++ b/crates/stc_ts_type_checker/src/lib.rs
@@ -281,6 +281,8 @@ impl Checker {
     }
 
     fn analyze_non_circular_module(&self, module_id: ModuleId, path: Arc<FileName>) -> Type {
+        info!("analyze_non_circular_module({:?}, {})", module_id, path);
+
         let _panic = panic_ctx!(format!("analyze_non_circular_module({})", path));
 
         let start = Instant::now();

--- a/crates/stc_ts_type_checker/src/typings.rs
+++ b/crates/stc_ts_type_checker/src/typings.rs
@@ -8,6 +8,7 @@ use std::{
 use rayon::prelude::*;
 use stc_ts_module_loader::resolvers::node::NodeResolver;
 use swc_common::FileName;
+use tracing::info;
 
 use crate::Checker;
 
@@ -60,6 +61,8 @@ impl Checker {
     /// - https://www.typescriptlang.org/tsconfig#typeRoots
     /// - https://www.typescriptlang.org/tsconfig#types
     pub fn load_typings(&self, base: &Path, _type_roots: Option<&[PathBuf]>, types: Option<&[String]>) {
+        info!("Loading typings from `{}`", base.display());
+
         let mut dirs = vec![];
 
         let mut cur = Some(base);

--- a/crates/stc_ts_type_checker/tests/dts_types.rs
+++ b/crates/stc_ts_type_checker/tests/dts_types.rs
@@ -12,7 +12,6 @@ use swc_ecma_loader::resolve::Resolve;
 use swc_ecma_parser::TsConfig;
 
 #[test]
-#[ignore = "Not implemented yet"]
 fn test_node() {
     run_tests_for_types_pkg("node");
 }

--- a/crates/stc_ts_type_checker/tests/dts_types.rs
+++ b/crates/stc_ts_type_checker/tests/dts_types.rs
@@ -33,7 +33,7 @@ fn run_tests_for_types_pkg(name: &str) {
         let mut checker = Checker::new(
             cm,
             handler.clone(),
-            Env::simple(Default::default(), EsVersion::latest(), ModuleConfig::None, &Lib::load("es2020")),
+            Env::simple(Default::default(), EsVersion::latest(), ModuleConfig::None, &Lib::load("esnext")),
             TsConfig { ..Default::default() },
             None,
             Arc::new(NodeResolver),

--- a/crates/stc_ts_type_checker/tests/dts_types.rs
+++ b/crates/stc_ts_type_checker/tests/dts_types.rs
@@ -33,7 +33,7 @@ fn run_tests_for_types_pkg(name: &str) {
         let mut checker = Checker::new(
             cm,
             handler.clone(),
-            Env::simple(Default::default(), EsVersion::latest(), ModuleConfig::None, &Lib::load("es5")),
+            Env::simple(Default::default(), EsVersion::latest(), ModuleConfig::None, &Lib::load("es2020")),
             TsConfig { ..Default::default() },
             None,
             Arc::new(NodeResolver),

--- a/crates/stc_ts_type_checker/tests/dts_types.rs
+++ b/crates/stc_ts_type_checker/tests/dts_types.rs
@@ -12,6 +12,7 @@ use swc_ecma_loader::resolve::Resolve;
 use swc_ecma_parser::TsConfig;
 
 #[test]
+#[ignore = "Not implemented yet"]
 fn test_node() {
     run_tests_for_types_pkg("node");
 }


### PR DESCRIPTION
# Investigation

I'm using `cargo test --test dts_types --features stc_ts_module_loader/no-threading --features stc_ts_file_analyzer/no-threading --features tracing/max_level_off` for testing

# Conclusion

 - Module loading is parallelizable with the current approach.
 - Parallel processing cannot be applied to `/// <reference path="foo.d.ts" />` files.
 - `namespace`s cannot be analyzed in parallel.

