### PR TITLE
fix: Fix evaluation of `this` and `staticthis`

### DIFF
--- a/crates/stc_ts_file_analyzer/src/analyzer/expr/call_new.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/expr/call_new.rs
@@ -19,7 +19,7 @@ use stc_ts_generics::type_param::finder::TypeParamUsageFinder;
 use stc_ts_type_ops::{generalization::prevent_generalize, is_str_lit_or_union, Fix};
 use stc_ts_types::{
     type_id::SymbolId, Alias, Array, Class, ClassDef, ClassMember, ClassProperty, CommonTypeMetadata, Function, Id, IdCtx,
-    IndexedAccessType, Instance, Interface, Intersection, Key, KeywordType, KeywordTypeMetadata, LitType, Ref, Symbol, ThisType, Union,
+    IndexedAccessType, Instance, Interface, Intersection, Key, KeywordType, KeywordTypeMetadata, LitType, Ref, StaticThis, Symbol, Union,
     UnionMetadata,
 };
 use stc_ts_utils::PatExt;
@@ -1507,10 +1507,10 @@ impl Analyzer<'_, '_> {
                     )
                 }
 
-                Type::This(..) => {
+                Type::StaticThis(..) => {
                     return Ok(Type::Instance(Instance {
                         span,
-                        ty: box Type::This(ThisType {
+                        ty: box Type::StaticThis(StaticThis {
                             span,
                             metadata: Default::default(),
                             tracker: Default::default(),

--- a/crates/stc_ts_file_analyzer/src/analyzer/function/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/function/mod.rs
@@ -47,6 +47,9 @@ impl Analyzer<'_, '_> {
             child.ctx.in_fn_with_return_type = f.return_type.is_some();
             child.ctx.in_async = f.is_async;
             child.ctx.in_generator = f.is_generator;
+            child.ctx.in_static_method = false;
+            child.ctx.in_static_property_initializer = false;
+            child.ctx.in_static_block = false;
 
             let mut errors = Errors::default();
 

--- a/crates/stc_ts_type_checker/tests/conformance.pass.txt
+++ b/crates/stc_ts_type_checker/tests/conformance.pass.txt
@@ -164,6 +164,7 @@ classes/classExpressions/genericClassExpressionInFunction.ts
 classes/classExpressions/modifierOnClassExpressionMemberInFunction.ts
 classes/classStaticBlock/classStaticBlock1.ts
 classes/classStaticBlock/classStaticBlock10.ts
+classes/classStaticBlock/classStaticBlock11.ts
 classes/classStaticBlock/classStaticBlock12.ts
 classes/classStaticBlock/classStaticBlock13.ts
 classes/classStaticBlock/classStaticBlock14.ts

--- a/crates/stc_ts_type_checker/tests/conformance/classes/classStaticBlock/classStaticBlock11(target=es2015).stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/conformance/classes/classStaticBlock/classStaticBlock11(target=es2015).stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
     required_error: 0,
     matched_error: 0,
-    extra_error: 1,
+    extra_error: 0,
     panic: 0,
 }

--- a/crates/stc_ts_type_checker/tests/conformance/classes/classStaticBlock/classStaticBlock11(target=es2022).stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/conformance/classes/classStaticBlock/classStaticBlock11(target=es2022).stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
     required_error: 0,
     matched_error: 0,
-    extra_error: 1,
+    extra_error: 0,
     panic: 0,
 }

--- a/crates/stc_ts_type_checker/tests/conformance/classes/classStaticBlock/classStaticBlock11(target=esnext).stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/conformance/classes/classStaticBlock/classStaticBlock11(target=esnext).stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
     required_error: 0,
     matched_error: 0,
-    extra_error: 1,
+    extra_error: 0,
     panic: 0,
 }

--- a/crates/stc_ts_type_checker/tests/conformance/classes/members/instanceAndStaticMembers/typeOfThisInStaticMembers.stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/conformance/classes/members/instanceAndStaticMembers/typeOfThisInStaticMembers.stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
     required_error: 0,
     matched_error: 0,
-    extra_error: 6,
+    extra_error: 4,
     panic: 0,
 }

--- a/crates/stc_ts_type_checker/tests/conformance/classes/members/privateNames/privateNameFieldDestructuredBinding(target=es2015).stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/conformance/classes/members/privateNames/privateNameFieldDestructuredBinding(target=es2015).stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
     required_error: 0,
     matched_error: 0,
-    extra_error: 3,
+    extra_error: 2,
     panic: 0,
 }

--- a/crates/stc_ts_type_checker/tests/conformance/classes/members/privateNames/privateNameFieldDestructuredBinding(target=es2022).stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/conformance/classes/members/privateNames/privateNameFieldDestructuredBinding(target=es2022).stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
     required_error: 0,
     matched_error: 0,
-    extra_error: 3,
+    extra_error: 2,
     panic: 0,
 }

--- a/crates/stc_ts_type_checker/tests/conformance/classes/members/privateNames/privateNameFieldDestructuredBinding(target=esnext).stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/conformance/classes/members/privateNames/privateNameFieldDestructuredBinding(target=esnext).stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
     required_error: 0,
     matched_error: 0,
-    extra_error: 3,
+    extra_error: 2,
     panic: 0,
 }

--- a/crates/stc_ts_type_checker/tests/conformance/classes/propertyMemberDeclarations/memberFunctionDeclarations/staticFactory1.stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/conformance/classes/propertyMemberDeclarations/memberFunctionDeclarations/staticFactory1.stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
     required_error: 0,
     matched_error: 0,
-    extra_error: 2,
+    extra_error: 1,
     panic: 0,
 }

--- a/crates/stc_ts_type_checker/tests/tsc-stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/tsc-stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
     required_error: 4235,
     matched_error: 5839,
-    extra_error: 926,
+    extra_error: 917,
     panic: 20,
 }


### PR DESCRIPTION
**Description:**

Create instance from `StaticThis` not `This`.
Check whether `this` is static beforehand and not during member access.

```typescript
class Base {
    static create() {
        return new this(); // StaticThis not This
    }
}
```


