### PR TITLE
feat: Intersect type facts from `cons` and `alt` of an if stmt

### DIFF
--- a/crates/stc_ts_file_analyzer/src/analyzer/control_flow.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/control_flow.rs
@@ -374,7 +374,7 @@ impl Analyzer<'_, '_> {
 
         let mut cons_ends_with_unreachable = false;
 
-        let ends_with_ret = stmt.cons.ends_with_ret();
+        let cons_ends_with_ret = stmt.cons.ends_with_ret();
 
         self.cur_facts = prev_facts.clone();
         self.with_child(ScopeKind::Flow, true_facts, |child: &mut Analyzer| {
@@ -402,7 +402,7 @@ impl Analyzer<'_, '_> {
 
         self.cur_facts = prev_facts;
 
-        if ends_with_ret {
+        if cons_ends_with_ret {
             self.cur_facts.true_facts += false_facts;
             return Ok(());
         }

--- a/crates/stc_ts_file_analyzer/src/analyzer/control_flow.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/control_flow.rs
@@ -378,12 +378,12 @@ impl Analyzer<'_, '_> {
 
         self.cur_facts = prev_facts.clone();
         let facts_from_cons = self
-            .with_child(ScopeKind::Flow, true_facts.clone(), |child: &mut Analyzer| {
+            .with_child(ScopeKind::Flow, true_facts, |child: &mut Analyzer| {
                 stmt.cons.visit_with(child);
 
                 cons_ends_with_unreachable = child.ctx.in_unreachable;
 
-                Ok(())
+                Ok(child.cur_facts.true_facts.take())
             })
             .report(&mut self.storage);
 
@@ -396,9 +396,11 @@ impl Analyzer<'_, '_> {
 
                 alt_ends_with_unreachable = Some(child.ctx.in_unreachable);
 
-                Ok(())
+                Ok(child.cur_facts.true_facts.take())
             })
-            .report(&mut self.storage);
+            .report(&mut self.storage)
+        } else {
+            None
         };
 
         self.cur_facts = prev_facts;

--- a/crates/stc_ts_file_analyzer/src/analyzer/expr/bin.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/expr/bin.rs
@@ -388,20 +388,48 @@ impl Analyzer<'_, '_> {
                         };
 
                         let mut is_loose_comparison = false;
-                        if let op!("==") | op!("!=") = op {
-                            if r.is_null() | r.is_undefined() {
-                                is_loose_comparison = true;
-                                let eq = TypeFacts::EQUndefinedOrNull | TypeFacts::EQNull | TypeFacts::EQUndefined;
-                                let neq = TypeFacts::NEUndefinedOrNull | TypeFacts::NENull | TypeFacts::NEUndefined;
+                        match op {
+                            op!("==") | op!("!=") => {
+                                if r.is_null() | r.is_undefined() {
+                                    is_loose_comparison = true;
+                                    let eq = TypeFacts::EQUndefinedOrNull | TypeFacts::EQNull | TypeFacts::EQUndefined;
+                                    let neq = TypeFacts::NEUndefinedOrNull | TypeFacts::NENull | TypeFacts::NEUndefined;
 
-                                if op == op!("==") {
-                                    *self.cur_facts.true_facts.facts.entry(name.clone()).or_default() |= eq;
-                                    *self.cur_facts.false_facts.facts.entry(name.clone()).or_default() |= neq;
-                                } else {
-                                    *self.cur_facts.true_facts.facts.entry(name.clone()).or_default() |= neq;
-                                    *self.cur_facts.false_facts.facts.entry(name.clone()).or_default() |= eq;
+                                    if op == op!("==") {
+                                        *self.cur_facts.true_facts.facts.entry(name.clone()).or_default() |= eq;
+                                        *self.cur_facts.false_facts.facts.entry(name.clone()).or_default() |= neq;
+                                    } else {
+                                        *self.cur_facts.true_facts.facts.entry(name.clone()).or_default() |= neq;
+                                        *self.cur_facts.false_facts.facts.entry(name.clone()).or_default() |= eq;
+                                    }
                                 }
                             }
+                            op!("===") => {
+                                if r.is_null() {
+                                    let eq = TypeFacts::EQNull;
+                                    let neq = TypeFacts::NENull;
+
+                                    if op == op!("===") {
+                                        *self.cur_facts.true_facts.facts.entry(name.clone()).or_default() |= eq;
+                                        *self.cur_facts.false_facts.facts.entry(name.clone()).or_default() |= neq;
+                                    } else {
+                                        *self.cur_facts.true_facts.facts.entry(name.clone()).or_default() |= neq;
+                                        *self.cur_facts.false_facts.facts.entry(name.clone()).or_default() |= eq;
+                                    }
+                                } else if r.is_undefined() {
+                                    let eq = TypeFacts::EQUndefined;
+                                    let neq = TypeFacts::NEUndefined;
+
+                                    if op == op!("===") {
+                                        *self.cur_facts.true_facts.facts.entry(name.clone()).or_default() |= eq;
+                                        *self.cur_facts.false_facts.facts.entry(name.clone()).or_default() |= neq;
+                                    } else {
+                                        *self.cur_facts.true_facts.facts.entry(name.clone()).or_default() |= neq;
+                                        *self.cur_facts.false_facts.facts.entry(name.clone()).or_default() |= eq;
+                                    }
+                                }
+                            }
+                            _ => (),
                         }
 
                         let exclude_types = if is_loose_comparison {

--- a/crates/stc_ts_file_analyzer/src/analyzer/expr/bin.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/expr/bin.rs
@@ -395,11 +395,11 @@ impl Analyzer<'_, '_> {
                                 let neq = TypeFacts::NEUndefinedOrNull | TypeFacts::NENull | TypeFacts::NEUndefined;
 
                                 if op == op!("==") {
-                                    self.cur_facts.true_facts.facts.insert(name.clone(), eq);
-                                    self.cur_facts.false_facts.facts.insert(name.clone(), neq);
+                                    *self.cur_facts.true_facts.facts.entry(name.clone()).or_default() |= eq;
+                                    *self.cur_facts.false_facts.facts.entry(name.clone()).or_default() |= neq;
                                 } else {
-                                    self.cur_facts.true_facts.facts.insert(name.clone(), neq);
-                                    self.cur_facts.false_facts.facts.insert(name.clone(), eq);
+                                    *self.cur_facts.true_facts.facts.entry(name.clone()).or_default() |= neq;
+                                    *self.cur_facts.false_facts.facts.entry(name.clone()).or_default() |= eq;
                                 }
                             }
                         }

--- a/crates/stc_ts_file_analyzer/src/analyzer/expr/bin.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/expr/bin.rs
@@ -220,7 +220,7 @@ impl Analyzer<'_, '_> {
                 self.cur_facts.true_facts += true_facts_for_rhs;
 
                 for (k, v) in additional_false_facts.facts.drain() {
-                    *self.cur_facts.false_facts.facts.entry(k.clone()).or_insert(TypeFacts::None) &= v;
+                    *self.cur_facts.false_facts.facts.entry(k.clone()).or_default() &= v;
                 }
             }
 

--- a/crates/stc_ts_file_analyzer/src/analyzer/expr/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/expr/mod.rs
@@ -248,7 +248,10 @@ impl Analyzer<'_, '_> {
                     // Foo.a
                     if self.ctx.should_store_truthy_for_access {
                         if let Ok(name) = Name::try_from(expr) {
-                            self.cur_facts.true_facts.facts.insert(name.clone(), TypeFacts::Truthy);
+                            self.cur_facts.true_facts.facts.insert(
+                                name.clone(),
+                                TypeFacts::Truthy | TypeFacts::NEUndefinedOrNull | TypeFacts::NEUndefined | TypeFacts::NENull,
+                            );
                             self.cur_facts.false_facts.facts.insert(name, TypeFacts::Falsy);
                         }
                     }
@@ -4029,7 +4032,7 @@ impl Analyzer<'_, '_> {
                                 Key::Normal { sym, .. } => sym,
                                 _ => unreachable!(),
                             },
-                            Some(TypeFacts::Truthy),
+                            Some(TypeFacts::Truthy | TypeFacts::NEUndefinedOrNull | TypeFacts::NEUndefined | TypeFacts::NENull),
                         )
                         .report(&mut self.storage)
                         .map(|ty| ty.freezed());
@@ -4369,7 +4372,10 @@ impl Analyzer<'_, '_> {
         let ty = self.type_of_var(i, mode, type_args)?;
         if self.ctx.should_store_truthy_for_access && mode == TypeOfMode::RValue {
             // `i` is truthy
-            self.cur_facts.true_facts.facts.insert(i.into(), TypeFacts::Truthy);
+            self.cur_facts.true_facts.facts.insert(
+                i.into(),
+                TypeFacts::Truthy | TypeFacts::NEUndefinedOrNull | TypeFacts::NEUndefined | TypeFacts::NENull,
+            );
             self.cur_facts.false_facts.facts.insert(i.into(), TypeFacts::Falsy);
         }
 

--- a/crates/stc_ts_file_analyzer/src/analyzer/expr/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/expr/mod.rs
@@ -4372,11 +4372,9 @@ impl Analyzer<'_, '_> {
         let ty = self.type_of_var(i, mode, type_args)?;
         if self.ctx.should_store_truthy_for_access && mode == TypeOfMode::RValue {
             // `i` is truthy
-            self.cur_facts.true_facts.facts.insert(
-                i.into(),
-                TypeFacts::Truthy | TypeFacts::NEUndefinedOrNull | TypeFacts::NEUndefined | TypeFacts::NENull,
-            );
-            self.cur_facts.false_facts.facts.insert(i.into(), TypeFacts::Falsy);
+            *self.cur_facts.true_facts.facts.entry(i.into()).or_default() |=
+                TypeFacts::Truthy | TypeFacts::NEUndefinedOrNull | TypeFacts::NEUndefined | TypeFacts::NENull;
+            *self.cur_facts.false_facts.facts.entry(i.into()).or_default() |= TypeFacts::Falsy;
         }
 
         if ty.is_interface() || ty.is_class() || ty.is_class_def() || ty.is_alias() {

--- a/crates/stc_ts_file_analyzer/src/type_facts.rs
+++ b/crates/stc_ts_file_analyzer/src/type_facts.rs
@@ -3,6 +3,12 @@
 use bitflags::bitflags;
 use swc_common::add_bitflags;
 
+impl Default for TypeFacts {
+    fn default() -> Self {
+        Self::None
+    }
+}
+
 bitflags! {
     pub struct TypeFacts: u32 {
         const None = 0;

--- a/crates/stc_ts_type_checker/tests/conformance.pass.txt
+++ b/crates/stc_ts_type_checker/tests/conformance.pass.txt
@@ -334,6 +334,7 @@ controlFlow/controlFlowParameter.ts
 controlFlow/controlFlowStringIndex.ts
 controlFlow/controlFlowSuperPropertyAccess.ts
 controlFlow/controlFlowTruthiness.ts
+controlFlow/controlFlowTypeofObject.ts
 controlFlow/controlFlowWhileStatement.ts
 controlFlow/controlFlowWithTemplateLiterals.ts
 controlFlow/switchWithConstrainedTypeVariable.ts

--- a/crates/stc_ts_type_checker/tests/conformance/controlFlow/controlFlowTypeofObject.stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/conformance/controlFlow/controlFlowTypeofObject.stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
     required_error: 0,
     matched_error: 1,
-    extra_error: 1,
+    extra_error: 0,
     panic: 0,
 }

--- a/crates/stc_ts_type_checker/tests/tsc-stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/tsc-stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
     required_error: 4234,
     matched_error: 5840,
-    extra_error: 883,
+    extra_error: 882,
     panic: 20,
 }


### PR DESCRIPTION
**Description:**

 - Interesect type facts from each branch.
 - Use `.entry().or_default() |=` instead of `.insert()` for type facts.