### PR TITLE
feat: Don't narrow type on equality comparison with `unknown`

### DIFF
--- a/crates/stc_ts_file_analyzer/src/analyzer/expr/bin.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/expr/bin.rs
@@ -372,7 +372,8 @@ impl Analyzer<'_, '_> {
 
                     (l, r) => Some((extract_name_for_assignment(l, op == op!("==="))?, r_ty)),
                 }) {
-                    if self.ctx.in_cond {
+                    // === with an unknown does not narrow type
+                    if self.ctx.in_cond && !r_ty.is_unknown() {
                         let (name, mut r) = self.calc_type_facts_for_equality(l, r_ty)?;
                         r = if has_switch_case_test_not_compatible {
                             Type::Keyword(KeywordType {

--- a/crates/stc_ts_file_analyzer/tests/pass-only/controlwFlow/controlFlowOptionalChain/1.ts
+++ b/crates/stc_ts_file_analyzer/tests/pass-only/controlwFlow/controlFlowOptionalChain/1.ts
@@ -1,0 +1,26 @@
+//@strict: true
+
+// Repro from #35842
+
+interface SomeObject {
+    someProperty: unknown;
+}
+
+let lastSomeProperty: unknown | undefined;
+
+function someFunction(someOptionalObject: SomeObject | undefined): void {
+    if (someOptionalObject?.someProperty !== lastSomeProperty) {
+        console.log(someOptionalObject);
+        console.log(someOptionalObject.someProperty);  // Error
+        lastSomeProperty = someOptionalObject?.someProperty;
+    }
+}
+
+const someObject: SomeObject = {
+    someProperty: 42
+};
+
+someFunction(someObject);
+someFunction(undefined);
+
+export { }

--- a/crates/stc_ts_file_analyzer/tests/pass-only/controlwFlow/controlFlowOptionalChain/1.ts
+++ b/crates/stc_ts_file_analyzer/tests/pass-only/controlwFlow/controlFlowOptionalChain/1.ts
@@ -11,7 +11,6 @@ let lastSomeProperty: unknown | undefined;
 function someFunction(someOptionalObject: SomeObject | undefined): void {
     if (someOptionalObject?.someProperty !== lastSomeProperty) {
         console.log(someOptionalObject);
-        console.log(someOptionalObject.someProperty);  // Error
         lastSomeProperty = someOptionalObject?.someProperty;
     }
 }

--- a/crates/stc_ts_type_checker/tests/conformance/controlFlow/controlFlowOptionalChain.stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/conformance/controlFlow/controlFlowOptionalChain.stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
-    required_error: 26,
-    matched_error: 35,
-    extra_error: 45,
+    required_error: 22,
+    matched_error: 39,
+    extra_error: 44,
     panic: 0,
 }

--- a/crates/stc_ts_type_checker/tests/tsc-stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/tsc-stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
-    required_error: 4234,
-    matched_error: 5840,
-    extra_error: 882,
+    required_error: 4230,
+    matched_error: 5844,
+    extra_error: 881,
     panic: 20,
 }


### PR DESCRIPTION
**Description:**

 - Exclude `unknown` from narrowing with a comparison.