### PR TITLE
feat: Handle `globalThis` partially

### DIFF
--- a/crates/stc_ts_file_analyzer/src/analyzer/expr/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/expr/mod.rs
@@ -4029,6 +4029,10 @@ impl Analyzer<'_, '_> {
 
                 ty = self.apply_type_facts(&name, ty);
 
+                if ty.span().is_dummy() {
+                    ty.respan(span);
+                }
+
                 debug_assert_ne!(ty.span(), DUMMY_SP);
 
                 self.exclude_types_using_fact(span, &name, &mut ty);

--- a/crates/stc_ts_file_analyzer/src/analyzer/expr/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/expr/mod.rs
@@ -3689,6 +3689,18 @@ impl Analyzer<'_, '_> {
                 }
             }
 
+            if &*i.sym == "globalThis" {
+                return Ok(Type::Query(QueryType {
+                    span,
+                    expr: box QueryExpr::TsEntityName(RTsEntityName::Ident(RIdent::new(
+                        "globalThis".into(),
+                        span.with_ctxt(SyntaxContext::empty()),
+                    ))),
+                    metadata: Default::default(),
+                    tracker: Default::default(),
+                }));
+            }
+
             if !self.ctx.disallow_suggesting_property_on_no_var && self.this_has_property_named(&i.clone().into()) {
                 Err(ErrorKind::NoSuchVarButThisHasSuchProperty {
                     span,

--- a/crates/stc_ts_file_analyzer/src/analyzer/expr/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/expr/mod.rs
@@ -3937,6 +3937,7 @@ impl Analyzer<'_, '_> {
         if let TypeOfMode::RValue = type_mode {
             if let Some(name) = &name {
                 if let Some(ty) = self.scope.get_type_from_name(name) {
+                    debug_assert_ne!(ty.span(), DUMMY_SP);
                     return Ok(ty);
                 }
             }
@@ -4024,9 +4025,15 @@ impl Analyzer<'_, '_> {
 
         if !self.is_builtin {
             if let Some(name) = name {
+                debug_assert_ne!(ty.span(), DUMMY_SP);
+
                 ty = self.apply_type_facts(&name, ty);
 
+                debug_assert_ne!(ty.span(), DUMMY_SP);
+
                 self.exclude_types_using_fact(span, &name, &mut ty);
+
+                debug_assert_ne!(ty.span(), DUMMY_SP);
             }
         }
 
@@ -4065,8 +4072,11 @@ impl Analyzer<'_, '_> {
         };
 
         if should_be_optional && include_optional_chaining_undefined {
-            Ok(Type::union(vec![Type::undefined(span, Default::default()), ty]))
+            Ok(Type::new_union(span, vec![Type::undefined(span, Default::default()), ty]))
         } else {
+            if !self.is_builtin {
+                debug_assert_ne!(ty.span(), DUMMY_SP);
+            }
             Ok(ty)
         }
     }

--- a/crates/stc_ts_file_analyzer/src/analyzer/expr/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/expr/mod.rs
@@ -4037,6 +4037,10 @@ impl Analyzer<'_, '_> {
 
                 self.exclude_types_using_fact(span, &name, &mut ty);
 
+                if ty.span().is_dummy() {
+                    ty.respan(span);
+                }
+
                 debug_assert_ne!(ty.span(), DUMMY_SP);
             }
         }

--- a/crates/stc_ts_type_checker/tests/conformance.pass.txt
+++ b/crates/stc_ts_type_checker/tests/conformance.pass.txt
@@ -369,6 +369,7 @@ es2017/useSharedArrayBuffer3.ts
 es2017/useSharedArrayBuffer4.ts
 es2017/useSharedArrayBuffer5.ts
 es2017/useSharedArrayBuffer6.ts
+es2018/es2018IntlAPIs.ts
 es2018/usePromiseFinally.ts
 es2018/useRegexpGroups.ts
 es2019/globalThisTypeIndexAccess.ts

--- a/crates/stc_ts_type_checker/tests/conformance.pass.txt
+++ b/crates/stc_ts_type_checker/tests/conformance.pass.txt
@@ -315,6 +315,7 @@ controlFlow/controlFlowAssignmentExpression.ts
 controlFlow/controlFlowAssignmentPatternOrder.ts
 controlFlow/controlFlowBinaryAndExpression.ts
 controlFlow/controlFlowBinaryOrExpression.ts
+controlFlow/controlFlowBindingElement.ts
 controlFlow/controlFlowCommaOperator.ts
 controlFlow/controlFlowConditionalExpression.ts
 controlFlow/controlFlowDeleteOperator.ts

--- a/crates/stc_ts_type_checker/tests/conformance/controlFlow/controlFlowBindingElement.stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/conformance/controlFlow/controlFlowBindingElement.stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
     required_error: 0,
     matched_error: 0,
-    extra_error: 3,
+    extra_error: 0,
     panic: 0,
 }

--- a/crates/stc_ts_type_checker/tests/conformance/es2018/es2018IntlAPIs.stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/conformance/es2018/es2018IntlAPIs.stats.rust-debug
@@ -2,5 +2,5 @@ Stats {
     required_error: 0,
     matched_error: 0,
     extra_error: 0,
-    panic: 1,
+    panic: 0,
 }

--- a/crates/stc_ts_type_checker/tests/conformance/es2019/globalThisAmbientModules.stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/conformance/es2019/globalThisAmbientModules.stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
     required_error: 0,
     matched_error: 2,
-    extra_error: 3,
+    extra_error: 2,
     panic: 0,
 }

--- a/crates/stc_ts_type_checker/tests/conformance/es2019/globalThisBlockscopedProperties.stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/conformance/es2019/globalThisBlockscopedProperties.stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
     required_error: 4,
     matched_error: 2,
-    extra_error: 10,
+    extra_error: 2,
     panic: 0,
 }

--- a/crates/stc_ts_type_checker/tests/conformance/es2019/globalThisGlobalExportAsGlobal.stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/conformance/es2019/globalThisGlobalExportAsGlobal.stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
     required_error: 2,
     matched_error: 0,
-    extra_error: 1,
+    extra_error: 0,
     panic: 0,
 }

--- a/crates/stc_ts_type_checker/tests/conformance/es2019/globalThisReadonlyProperties.stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/conformance/es2019/globalThisReadonlyProperties.stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
     required_error: 2,
     matched_error: 0,
-    extra_error: 3,
+    extra_error: 0,
     panic: 0,
 }

--- a/crates/stc_ts_type_checker/tests/conformance/es2019/globalThisUnknown.stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/conformance/es2019/globalThisUnknown.stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
     required_error: 1,
     matched_error: 0,
-    extra_error: 2,
+    extra_error: 0,
     panic: 0,
 }

--- a/crates/stc_ts_type_checker/tests/conformance/es2019/globalThisUnknownNoImplicitAny.stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/conformance/es2019/globalThisUnknownNoImplicitAny.stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
     required_error: 6,
     matched_error: 0,
-    extra_error: 2,
+    extra_error: 0,
     panic: 0,
 }

--- a/crates/stc_ts_type_checker/tests/conformance/es2020/es2020IntlAPIs.stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/conformance/es2020/es2020IntlAPIs.stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
-    required_error: 4,
-    matched_error: 0,
+    required_error: 2,
+    matched_error: 2,
     extra_error: 0,
-    panic: 1,
+    panic: 0,
 }

--- a/crates/stc_ts_type_checker/tests/tsc-stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/tsc-stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
-    required_error: 4226,
-    matched_error: 5848,
-    extra_error: 865,
-    panic: 20,
+    required_error: 4224,
+    matched_error: 5850,
+    extra_error: 845,
+    panic: 18,
 }

--- a/crates/stc_ts_type_checker/tests/tsc.ignored.txt
+++ b/crates/stc_ts_type_checker/tests/tsc.ignored.txt
@@ -1,5 +1,6 @@
 classStaticBlock16.ts
 conditionalTypes1.ts
+controlFlowBindingElement.ts
 namedTupleMembers.ts
 privateNameAccessorssDerivedClasses.ts
 privateNameComputedPropertyName2.ts


### PR DESCRIPTION
**Description:**

This PR removes `NoSuchVar` for `globalThis` and fixes the dummy span issue of member expressions.
