### PR TITLE
feat: Handle `Symbol.iterator` of `Array`

### DIFF
--- a/crates/stc_ts_file_analyzer/src/analyzer/expr/call_new.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/expr/call_new.rs
@@ -595,6 +595,14 @@ impl Analyzer<'_, '_> {
                 }
 
                 Type::Array(obj) => {
+                    if let Key::Computed(key) = prop {
+                        if let Type::Symbol(key_ty) = key.ty.normalize() {
+                            if key_ty.id == SymbolId::iterator() {
+                                return Ok(obj_type);
+                            }
+                        }
+                    }
+
                     let obj = Type::Ref(Ref {
                         span,
                         type_name: RTsEntityName::Ident(RIdent::new(

--- a/crates/stc_ts_file_analyzer/src/analyzer/expr/call_new.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/expr/call_new.rs
@@ -882,7 +882,7 @@ impl Analyzer<'_, '_> {
                     )
                 })
         })()
-        .with_context(|| format!("tried to call a property of an object ({})", dump_type_as_string(obj_type)));
+        .with_context(|| format!("tried to call a property of an object ({})", force_dump_type_as_string(obj_type)));
         self.scope.this = old_this;
         res
     }

--- a/crates/stc_ts_type_checker/tests/conformance/es6/destructuring/destructuringArrayBindingPatternAndAssignment2.stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/conformance/es6/destructuring/destructuringArrayBindingPatternAndAssignment2.stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
     required_error: 4,
     matched_error: 5,
-    extra_error: 1,
+    extra_error: 0,
     panic: 0,
 }

--- a/crates/stc_ts_type_checker/tests/conformance/types/rest/genericRestParameters3.stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/conformance/types/rest/genericRestParameters3.stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
-    required_error: 8,
-    matched_error: 5,
-    extra_error: 15,
+    required_error: 7,
+    matched_error: 6,
+    extra_error: 14,
     panic: 0,
 }

--- a/crates/stc_ts_type_checker/tests/conformance/types/tuple/arityAndOrderCompatibility01.stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/conformance/types/tuple/arityAndOrderCompatibility01.stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
     required_error: 2,
     matched_error: 15,
-    extra_error: 6,
+    extra_error: 5,
     panic: 0,
 }

--- a/crates/stc_ts_type_checker/tests/tsc-stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/tsc-stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
-    required_error: 4224,
-    matched_error: 5850,
-    extra_error: 845,
+    required_error: 4223,
+    matched_error: 5851,
+    extra_error: 842,
     panic: 18,
 }


### PR DESCRIPTION
**Description:**

Iteration over an array should work regardless of the symbol builtin, so I implemented it manually.