### PR TITLE
fix(ts/analyzer): Handle TS2804

### DIFF
--- a/crates/stc_ts_errors/src/lib.rs
+++ b/crates/stc_ts_errors/src/lib.rs
@@ -1478,6 +1478,11 @@ pub enum ErrorKind {
     InvalidExtendDueToConstructorPrivate {
         span: Span,
     },
+
+    /// TS2804
+    DuplicatePrivateStaticInstance {
+        span: Span,
+    },
 }
 
 #[cfg(target_pointer_width = "64")]
@@ -2033,6 +2038,8 @@ impl ErrorKind {
             ErrorKind::InvalidExtendDueToConstructorPrivate { .. } => 2675,
 
             ErrorKind::SuperCanOnlyAccessMethod { .. } => 2340,
+
+            ErrorKind::DuplicatePrivateStaticInstance { .. } => 2804,
 
             _ => 0,
         }

--- a/crates/stc_ts_file_analyzer/src/analyzer/class/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/class/mod.rs
@@ -868,17 +868,22 @@ impl Analyzer<'_, '_> {
                     continue;
                 }
 
-                if l.0.eq_ignore_span(r.0) && l.1 == r.1 {
-                    if is_private_props.contains(&i) && is_private_props.contains(&j) {
-                        continue;
-                    }
+                if l.0.eq_ignore_span(r.0) {
+                    if l.1 == r.1 {
+                        if is_private_props.contains(&i) && is_private_props.contains(&j) {
+                            continue;
+                        }
 
-                    // We use different error for duplicate functions
-                    if !is_private_props.contains(&i) && !is_private_props.contains(&j) {
-                        continue;
-                    }
+                        // We use different error for duplicate functions
+                        if !is_private_props.contains(&i) && !is_private_props.contains(&j) {
+                            continue;
+                        }
 
-                    self.storage.report(ErrorKind::DuplicateNameWithoutName { span: l.0.span() }.into());
+                        self.storage.report(ErrorKind::DuplicateNameWithoutName { span: l.0.span() }.into());
+                    } else if j < i {
+                        self.storage
+                            .report(ErrorKind::DuplicatePrivateStaticInstance { span: l.0.span() }.into());
+                    }
                 }
             }
         }

--- a/crates/stc_ts_type_checker/tests/conformance.pass.txt
+++ b/crates/stc_ts_type_checker/tests/conformance.pass.txt
@@ -267,6 +267,7 @@ classes/members/privateNames/privateNamesAssertion.ts
 classes/members/privateNames/privateNamesInGenericClasses.ts
 classes/members/privateNames/privateNamesInterfaceExtendingClass.ts
 classes/members/privateNames/privateNamesUnique-1.ts
+classes/members/privateNames/privateNamesUnique-3.ts
 classes/members/privateNames/privateNamesUnique-4.ts
 classes/members/privateNames/privateNamesUnique-5.ts
 classes/members/privateNames/privateStaticNameShadowing.ts

--- a/crates/stc_ts_type_checker/tests/conformance/classes/members/privateNames/privateNameDuplicateField.stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/conformance/classes/members/privateNames/privateNameDuplicateField.stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
-    required_error: 64,
-    matched_error: 19,
+    required_error: 32,
+    matched_error: 51,
     extra_error: 5,
     panic: 0,
 }

--- a/crates/stc_ts_type_checker/tests/conformance/classes/members/privateNames/privateNamesUnique-3.stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/conformance/classes/members/privateNames/privateNamesUnique-3.stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
-    required_error: 1,
-    matched_error: 1,
+    required_error: 0,
+    matched_error: 2,
     extra_error: 0,
     panic: 0,
 }

--- a/crates/stc_ts_type_checker/tests/tsc-stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/tsc-stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
-    required_error: 4222,
-    matched_error: 5852,
+    required_error: 4189,
+    matched_error: 5885,
     extra_error: 841,
     panic: 18,
 }


### PR DESCRIPTION
**Description:**

Handles duplicate static and instance names.

```typescript
class A {
   #b = 1
   static #b = 1 //TS2804
}
```

