### PR TITLE
feat(ts/analyzer): Update instance of constructur ret_ty is any

### DIFF
--- a/crates/stc_ts_file_analyzer/src/analyzer/expr/bin.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/expr/bin.rs
@@ -548,7 +548,9 @@ impl Analyzer<'_, '_> {
                                 .context("tried to narrow type with instanceof")?
                                 .freezed();
 
-                            narrowed_ty.assert_valid();
+                            let filtered_ty = if narrowed_ty.is_any() { orig_ty.clone() } else { narrowed_ty };
+
+                            filtered_ty.assert_valid();
 
                             // TODO(kdy1): Maybe we need to check for intersection or union
                             if orig_ty.is_type_param() {
@@ -556,7 +558,7 @@ impl Analyzer<'_, '_> {
                                     name,
                                     Type::Intersection(Intersection {
                                         span,
-                                        types: vec![orig_ty, narrowed_ty],
+                                        types: vec![orig_ty, filtered_ty],
                                         metadata: Default::default(),
                                         tracker: Default::default(),
                                     })
@@ -564,9 +566,9 @@ impl Analyzer<'_, '_> {
                                     .freezed(),
                                 );
                             } else {
-                                self.cur_facts.true_facts.vars.insert(name.clone(), narrowed_ty.clone());
+                                self.cur_facts.true_facts.vars.insert(name.clone(), filtered_ty.clone());
 
-                                self.cur_facts.false_facts.excludes.entry(name).or_default().push(narrowed_ty);
+                                self.cur_facts.false_facts.excludes.entry(name).or_default().push(filtered_ty);
                             }
                         }
                     }
@@ -1269,6 +1271,7 @@ impl Analyzer<'_, '_> {
                 .map(|orig_ty| self.narrow_with_instanceof(span, ty.clone(), orig_ty))
                 .collect::<Result<Vec<_>, _>>()?;
 
+            dbg!(&new_types, &orig.types, &ty);
             for elem in new_types.iter() {
                 if orig.types.iter().any(|o_ty| elem.type_eq(o_ty)) {
                     return Ok(elem.to_owned());
@@ -1330,6 +1333,9 @@ impl Analyzer<'_, '_> {
                     for m in &ty.members {
                         if let TypeElement::Constructor(c) = m {
                             if let Some(ret_ty) = &c.ret_ty {
+                                if ret_ty.is_any() {
+                                    return Ok(*ret_ty.clone());
+                                }
                                 return self
                                     .narrow_with_instanceof(span, Cow::Borrowed(ret_ty), &orig_ty)
                                     .context("tried to narrow constructor return type");

--- a/crates/stc_ts_file_analyzer/src/analyzer/expr/bin.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/expr/bin.rs
@@ -1271,7 +1271,6 @@ impl Analyzer<'_, '_> {
                 .map(|orig_ty| self.narrow_with_instanceof(span, ty.clone(), orig_ty))
                 .collect::<Result<Vec<_>, _>>()?;
 
-            dbg!(&new_types, &orig.types, &ty);
             for elem in new_types.iter() {
                 if orig.types.iter().any(|o_ty| elem.type_eq(o_ty)) {
                     return Ok(elem.to_owned());

--- a/crates/stc_ts_file_analyzer/src/analyzer/expr/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/expr/mod.rs
@@ -517,6 +517,17 @@ pub(crate) struct AccessPropertyOpts {
     pub disallow_indexing_array_with_string: bool,
 
     /// If `true`, `access_property` will not produce types like `Array['b']`
+    ///
+    /// ```ts
+    /// interface F {
+    ///   foo: string;
+    ///   bar: number;
+    /// }
+    ///
+    ///  var obj11: F | string;
+    ///
+    ///  obj11.foo; // Error TS2339
+    /// ```
     pub disallow_creating_indexed_type_from_ty_els: bool,
 
     pub disallow_indexing_class_with_computed: bool,
@@ -538,19 +549,6 @@ pub(crate) struct AccessPropertyOpts {
 
     /// `true` means that the provided [Key] is crated from a computed key.
     pub is_key_computed: bool,
-
-    // ```ts
-    // interface F {
-    //   foo: string;
-    //   bar: number;
-    // }
-
-    //  var obj11: F | string;
-    //
-    //  obj11.foo; // Error TS2339
-    //
-    // ```
-    pub disallow_property_is_any: bool,
 }
 
 #[validator]
@@ -2189,17 +2187,7 @@ impl Analyzer<'_, '_> {
                 let interface = self.env.get_global_type(span, &word)?;
 
                 let err = match self.access_property(span, &interface, prop, type_mode, id_ctx, opts) {
-                    Ok(v) => {
-                        if v.is_indexed_access_type() && opts.disallow_property_is_any {
-                            return Err(ErrorKind::NoSuchProperty {
-                                span,
-                                obj: Some(box obj.clone()),
-                                prop: Some(box prop.clone()),
-                            }
-                            .into());
-                        }
-                        return Ok(v);
-                    }
+                    Ok(v) => return Ok(v),
                     Err(err) => err,
                 };
                 if *kind == TsKeywordTypeKind::TsObjectKeyword && !self.ctx.disallow_unknown_object_property {
@@ -2449,7 +2437,7 @@ impl Analyzer<'_, '_> {
                         id_ctx,
                         AccessPropertyOpts {
                             use_undefined_for_tuple_index_error,
-                            disallow_property_is_any: true,
+                            disallow_creating_indexed_type_from_ty_els: true,
                             ..opts
                         },
                     ) {

--- a/crates/stc_ts_file_analyzer/tests/pass/exprs/typeGuards/typeGuardsWithInstanceOfByConstructorSignature/14.swc-stderr
+++ b/crates/stc_ts_file_analyzer/tests/pass/exprs/typeGuards/typeGuardsWithInstanceOfByConstructorSignature/14.swc-stderr
@@ -1,0 +1,36 @@
+
+  x Type
+    ,-[$DIR/tests/pass/exprs/typeGuards/typeGuardsWithInstanceOfByConstructorSignature/14.ts:11:1]
+ 11 | if (obj11 instanceof F) {
+    :     ^^^^^
+    `----
+
+Error: 
+  > (F | string)
+
+  x Type
+    ,-[$DIR/tests/pass/exprs/typeGuards/typeGuardsWithInstanceOfByConstructorSignature/14.ts:11:1]
+ 11 | if (obj11 instanceof F) {
+    :                      ^
+    `----
+
+Error: 
+  > FConstructor
+
+  x Type
+    ,-[$DIR/tests/pass/exprs/typeGuards/typeGuardsWithInstanceOfByConstructorSignature/14.ts:11:1]
+ 11 | if (obj11 instanceof F) {
+    :     ^^^^^^^^^^^^^^^^^^
+    `----
+
+Error: 
+  > boolean
+
+  x Type
+    ,-[$DIR/tests/pass/exprs/typeGuards/typeGuardsWithInstanceOfByConstructorSignature/14.ts:13:3]
+ 13 | obj11; // F | string Because F constructor is any
+    : ^^^^^
+    `----
+
+Error: 
+  > (F | string)

--- a/crates/stc_ts_file_analyzer/tests/pass/exprs/typeGuards/typeGuardsWithInstanceOfByConstructorSignature/14.ts
+++ b/crates/stc_ts_file_analyzer/tests/pass/exprs/typeGuards/typeGuardsWithInstanceOfByConstructorSignature/14.ts
@@ -1,0 +1,14 @@
+interface FConstructor {
+  new (): any;
+}
+interface F {
+  foo: string;
+  bar: number;
+}
+declare var F: FConstructor;
+
+var obj11: F | string;
+if (obj11 instanceof F) {
+  // can't type narrowing, construct signature returns any.
+  obj11; // F | string Because F constructor is any
+}

--- a/crates/stc_ts_type_checker/tests/conformance.pass.txt
+++ b/crates/stc_ts_type_checker/tests/conformance.pass.txt
@@ -1438,6 +1438,7 @@ expressions/typeGuards/typeGuardsInWhileStatement.ts
 expressions/typeGuards/typeGuardsObjectMethods.ts
 expressions/typeGuards/typeGuardsOnClassProperty.ts
 expressions/typeGuards/typeGuardsWithAny.ts
+expressions/typeGuards/typeGuardsWithInstanceOfByConstructorSignature.ts
 expressions/typeGuards/typePredicateASI.ts
 expressions/typeSatisfaction/typeSatisfaction_contextualTyping1.ts
 expressions/typeSatisfaction/typeSatisfaction_contextualTyping2.ts

--- a/crates/stc_ts_type_checker/tests/conformance/controlFlow/dependentDestructuredVariables.stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/conformance/controlFlow/dependentDestructuredVariables.stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
     required_error: 2,
     matched_error: 0,
-    extra_error: 23,
+    extra_error: 35,
     panic: 0,
 }

--- a/crates/stc_ts_type_checker/tests/conformance/expressions/typeGuards/typeGuardsWithInstanceOfByConstructorSignature.stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/conformance/expressions/typeGuards/typeGuardsWithInstanceOfByConstructorSignature.stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
-    required_error: 2,
-    matched_error: 18,
+    required_error: 0,
+    matched_error: 20,
     extra_error: 0,
     panic: 0,
 }

--- a/crates/stc_ts_type_checker/tests/tsc-stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/tsc-stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
-    required_error: 4220,
-    matched_error: 5854,
-    extra_error: 853,
+    required_error: 4187,
+    matched_error: 5887,
+    extra_error: 841,
     panic: 18,
 }

--- a/crates/stc_ts_type_checker/tests/tsc-stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/tsc-stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
-    required_error: 4222,
-    matched_error: 5852,
-    extra_error: 841,
+    required_error: 4220,
+    matched_error: 5854,
+    extra_error: 853,
     panic: 18,
 }


### PR DESCRIPTION
**Description:**

```ts
interface FConstructor {
  new (): any;
}
interface F {
  foo: string;
  bar: number;
}
declare var F: FConstructor;

var obj11: F | string;
if (obj11 instanceof F) {
  // can't type narrowing, construct signature returns any.
  obj11; // F | string Because F constructor is any
  obj11.foo; // Error NoSuchVar
}
```

But, increase extra_error in DestructureVariables

So we need to solve the #552 issue first.