### PR TITLE
feat: Handle assignment of a tuple to a tuple

### DIFF
--- a/crates/stc_ts_errors/src/lib.rs
+++ b/crates/stc_ts_errors/src/lib.rs
@@ -2080,7 +2080,16 @@ impl ErrorKind {
 
         for e in vec {
             match *e.inner {
-                ErrorKind::Errors { errors, .. } | ErrorKind::TupleAssignError { errors, .. } => buf.extend(Self::flatten(errors)),
+                ErrorKind::Errors { errors, .. } | ErrorKind::TupleAssignError { errors, .. } => {
+                    buf.extend(Self::flatten(errors).into_iter().map(|mut err| {
+                        #[cfg(debug_assertions)]
+                        for context in &e.contexts {
+                            err.contexts.push(context.clone());
+                        }
+
+                        err
+                    }))
+                }
                 _ => buf.push(e),
             }
         }

--- a/crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs
@@ -2427,7 +2427,6 @@ impl Analyzer<'_, '_> {
                                     disallow_creating_indexed_type_from_ty_els: true,
                                     disallow_indexing_class_with_computed: true,
                                     use_undefined_for_tuple_index_error: true,
-                                    return_rest_tuple_element_as_is: true,
                                     ..Default::default()
                                 },
                             )?;
@@ -2448,7 +2447,6 @@ impl Analyzer<'_, '_> {
                                     disallow_creating_indexed_type_from_ty_els: true,
                                     disallow_indexing_class_with_computed: true,
                                     use_undefined_for_tuple_index_error: true,
-                                    return_rest_tuple_element_as_is: true,
                                     ..Default::default()
                                 },
                             )?;

--- a/crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs
@@ -2426,6 +2426,7 @@ impl Analyzer<'_, '_> {
                                     disallow_indexing_array_with_string: true,
                                     disallow_creating_indexed_type_from_ty_els: true,
                                     disallow_indexing_class_with_computed: true,
+                                    use_undefined_for_tuple_index_error: true,
                                     ..Default::default()
                                 },
                             )?;
@@ -2445,6 +2446,7 @@ impl Analyzer<'_, '_> {
                                     disallow_indexing_array_with_string: true,
                                     disallow_creating_indexed_type_from_ty_els: true,
                                     disallow_indexing_class_with_computed: true,
+                                    use_undefined_for_tuple_index_error: true,
                                     ..Default::default()
                                 },
                             )?;

--- a/crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs
@@ -2362,8 +2362,8 @@ impl Analyzer<'_, '_> {
                 _ => {}
             },
 
-            Type::Tuple(Tuple { ref elems, .. }) => {
-                if elems.is_empty() {
+            Type::Tuple(Tuple { elems: ref lhs_elems, .. }) => {
+                if lhs_elems.is_empty() {
                     match rhs {
                         Type::Array(..) | Type::Tuple(..) => return Ok(()),
                         _ => {}
@@ -2376,16 +2376,16 @@ impl Analyzer<'_, '_> {
                             fail!()
                         }
 
-                        if !opts.ignore_tuple_length_difference && elems.len() < rhs_elems.len() {
-                            if elems.iter().any(|elem| elem.ty.is_rest()) {
+                        if !opts.ignore_tuple_length_difference && lhs_elems.len() < rhs_elems.len() {
+                            if lhs_elems.iter().any(|elem| elem.ty.is_rest()) {
                                 // Type::Rest eats many elements
                             } else {
                                 return Err(ErrorKind::AssignFailedBecauseTupleLengthDiffers { span }.into());
                             }
                         }
 
-                        if !opts.ignore_tuple_length_difference && elems.len() > rhs_elems.len() {
-                            let is_len_fine = elems.iter().skip(rhs_elems.len()).all(|l| {
+                        if !opts.ignore_tuple_length_difference && lhs_elems.len() > rhs_elems.len() {
+                            let is_len_fine = lhs_elems.iter().skip(rhs_elems.len()).all(|l| {
                                 matches!(
                                     l.ty.normalize_instance(),
                                     Type::Keyword(KeywordType {
@@ -2401,8 +2401,8 @@ impl Analyzer<'_, '_> {
                         }
 
                         let mut errors = vec![];
-                        for (l, r) in elems.iter().zip(rhs_elems) {
-                            for el in elems {
+                        for (l, r) in lhs_elems.iter().zip(rhs_elems) {
+                            for el in lhs_elems {
                                 if let Type::Keyword(KeywordType {
                                     kind: TsKeywordTypeKind::TsUndefinedKeyword,
                                     ..
@@ -2436,11 +2436,11 @@ impl Analyzer<'_, '_> {
                         elem_type: ref rhs_elem_type,
                         ..
                     }) => {
-                        if elems.len() != 1 {
+                        if lhs_elems.len() != 1 {
                             fail!();
                         }
 
-                        match elems[0].ty.normalize() {
+                        match lhs_elems[0].ty.normalize() {
                             Type::Rest(RestType { ty: l_ty, .. }) => {
                                 self.assign_inner(
                                     data,
@@ -2480,7 +2480,7 @@ impl Analyzer<'_, '_> {
                                 .get_iterator(span, Cow::Borrowed(rhs), Default::default())
                                 .context("tried to convert a type to an iterator to assign to a tuple")?;
                             //
-                            for (i, elem) in elems.iter().enumerate() {
+                            for (i, elem) in lhs_elems.iter().enumerate() {
                                 let r_ty = self
                                     .get_element_from_iterator(span, Cow::Borrowed(&r), i)
                                     .context("tried to get an element of type to assign to a tuple element")?;

--- a/crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs
@@ -2461,6 +2461,7 @@ impl Analyzer<'_, '_> {
                                         ..opts
                                     },
                                 )
+                                .with_context(|| format!("tried to assign {}th tuple assignment", index))
                                 .err(),
                             );
                         }

--- a/crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs
@@ -2403,11 +2403,40 @@ impl Analyzer<'_, '_> {
 
                         let len = lhs_elems.len().max(rhs_elems.len());
 
-                        let mut errors = vec![];
-                        for (l, r) in lhs_elems
+                        let lhs = lhs_elems
                             .iter()
-                            .flat_map(|e| e.ty.iter_rest())
-                            .zip(rhs_elems.iter().flat_map(|e| e.ty.iter_rest()))
+                            .map(|el| {
+                                self.normalize(
+                                    Some(span),
+                                    Cow::Borrowed(&el.ty),
+                                    NormalizeTypeOpts {
+                                        preserve_global_this: true,
+                                        preserve_intersection: true,
+                                        ..Default::default()
+                                    },
+                                )
+                            })
+                            .collect::<Result<Vec<_>, _>>()?;
+                        let rhs = rhs_elems
+                            .iter()
+                            .map(|el| {
+                                self.normalize(
+                                    Some(span),
+                                    Cow::Borrowed(&el.ty),
+                                    NormalizeTypeOpts {
+                                        preserve_global_this: true,
+                                        preserve_intersection: true,
+                                        ..Default::default()
+                                    },
+                                )
+                            })
+                            .collect::<Result<Vec<_>, _>>()?;
+
+                        let mut errors = vec![];
+                        for (l, r) in lhs
+                            .iter()
+                            .flat_map(|ty| ty.iter_rest())
+                            .zip(rhs.iter().flat_map(|ty| ty.iter_rest()))
                             .take(len)
                         {
                             for el in lhs_elems {

--- a/crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs
@@ -2401,13 +2401,20 @@ impl Analyzer<'_, '_> {
                             }
                         }
 
+                        let len = lhs_elems.len().max(rhs_elems.len());
+
                         let mut errors = vec![];
-                        for (l, r) in lhs_elems.iter().zip(rhs_elems) {
+                        for (l, r) in lhs_elems
+                            .iter()
+                            .flat_map(|e| e.ty.iter_rest())
+                            .zip(rhs_elems.iter().flat_map(|e| e.ty.iter_rest()))
+                            .take(len)
+                        {
                             for el in lhs_elems {
                                 if let Type::Keyword(KeywordType {
                                     kind: TsKeywordTypeKind::TsUndefinedKeyword,
                                     ..
-                                }) = *r.ty.normalize()
+                                }) = r.normalize()
                                 {
                                     continue;
                                 }
@@ -2415,8 +2422,8 @@ impl Analyzer<'_, '_> {
                                 errors.extend(
                                     self.assign_inner(
                                         data,
-                                        &l.ty,
-                                        &r.ty,
+                                        l,
+                                        r,
                                         AssignOpts {
                                             allow_unknown_rhs: Some(true),
                                             ..opts

--- a/crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs
@@ -2427,6 +2427,7 @@ impl Analyzer<'_, '_> {
                                     disallow_creating_indexed_type_from_ty_els: true,
                                     disallow_indexing_class_with_computed: true,
                                     use_undefined_for_tuple_index_error: true,
+                                    return_rest_tuple_element_as_is: true,
                                     ..Default::default()
                                 },
                             )?;
@@ -2447,6 +2448,7 @@ impl Analyzer<'_, '_> {
                                     disallow_creating_indexed_type_from_ty_els: true,
                                     disallow_indexing_class_with_computed: true,
                                     use_undefined_for_tuple_index_error: true,
+                                    return_rest_tuple_element_as_is: true,
                                     ..Default::default()
                                 },
                             )?;

--- a/crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs
@@ -534,6 +534,7 @@ impl Analyzer<'_, '_> {
             | Type::StringMapping(..)
             | Type::Mapped(..)
             | Type::Enum(..)
+            | Type::Tuple(..)
             | Type::Union(..)
             | Type::Operator(Operator {
                 op: TsTypeOperatorOp::KeyOf,

--- a/crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs
@@ -2385,15 +2385,16 @@ impl Analyzer<'_, '_> {
                         }
 
                         if !opts.ignore_tuple_length_difference && lhs_elems.len() > rhs_elems.len() {
-                            let is_len_fine = lhs_elems.iter().skip(rhs_elems.len()).all(|l| {
-                                matches!(
-                                    l.ty.normalize_instance(),
-                                    Type::Keyword(KeywordType {
-                                        kind: TsKeywordTypeKind::TsAnyKeyword,
-                                        ..
-                                    }) | Type::Optional(..)
-                                )
-                            });
+                            let is_len_fine = rhs_elems.iter().any(|elem| elem.ty.is_rest())
+                                || lhs_elems.iter().skip(rhs_elems.len()).all(|l| {
+                                    matches!(
+                                        l.ty.normalize_instance(),
+                                        Type::Keyword(KeywordType {
+                                            kind: TsKeywordTypeKind::TsAnyKeyword,
+                                            ..
+                                        }) | Type::Optional(..)
+                                    )
+                                });
 
                             if !is_len_fine {
                                 return Err(ErrorKind::AssignFailedBecauseTupleLengthDiffers { span }.into());

--- a/crates/stc_ts_file_analyzer/src/analyzer/expr/array.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/expr/array.rs
@@ -909,6 +909,21 @@ impl Analyzer<'_, '_> {
                     }
                     Ok(Some(sum))
                 }
+                Type::Union(u) => {
+                    let val = self.calculate_tuple_element_count(span, &u.types[0])?;
+                    let val = match val {
+                        Some(v) => v,
+                        None => return Ok(None),
+                    };
+                    for ty in u.types.iter() {
+                        if let Some(v) = self.calculate_tuple_element_count(ty.span(), ty)? {
+                            if v != val {
+                                return Ok(None);
+                            }
+                        }
+                    }
+                    Ok(Some(val))
+                }
                 _ => Ok(None),
             },
             _ => Ok(Some(1)),

--- a/crates/stc_ts_file_analyzer/src/analyzer/expr/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/expr/mod.rs
@@ -2526,29 +2526,31 @@ impl Analyzer<'_, '_> {
 
                         if (v as usize) + 1 >= elems.len() {
                             if let Some(elem) = elems.last() {
-                                if !opts.return_rest_tuple_element_as_is {
-                                    if let Type::Rest(rest_ty) = elem.ty.normalize() {
-                                        if let Ok(ty) = self.access_property(
-                                            span,
-                                            &rest_ty.ty,
-                                            &Key::Num(RNumber {
-                                                span: n.span,
-                                                value: (v + 1i64 - (elems.len() as i64)) as _,
-                                                raw: None,
-                                            }),
-                                            type_mode,
-                                            id_ctx,
-                                            AccessPropertyOpts {
-                                                use_undefined_for_tuple_index_error: false,
-                                                ..opts
-                                            },
-                                        ) {
-                                            return Ok(ty);
-                                        }
-
-                                        // debug_assert!(rest_ty.ty.is_clone_cheap());
+                                if let Type::Rest(rest_ty) = elem.ty.normalize() {
+                                    if opts.return_rest_tuple_element_as_is {
                                         return Ok(*rest_ty.ty.clone());
                                     }
+
+                                    if let Ok(ty) = self.access_property(
+                                        span,
+                                        &rest_ty.ty,
+                                        &Key::Num(RNumber {
+                                            span: n.span,
+                                            value: (v + 1i64 - (elems.len() as i64)) as _,
+                                            raw: None,
+                                        }),
+                                        type_mode,
+                                        id_ctx,
+                                        AccessPropertyOpts {
+                                            use_undefined_for_tuple_index_error: false,
+                                            ..opts
+                                        },
+                                    ) {
+                                        return Ok(ty);
+                                    }
+
+                                    // debug_assert!(rest_ty.ty.is_clone_cheap());
+                                    return Ok(*rest_ty.ty.clone());
                                 }
                             }
                         }

--- a/crates/stc_ts_file_analyzer/src/analyzer/expr/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/expr/mod.rs
@@ -2546,7 +2546,7 @@ impl Analyzer<'_, '_> {
                                         &rest_ty.ty,
                                         &Key::Num(RNumber {
                                             span: n.span,
-                                            value: sum as _,
+                                            value: (v as usize - sum) as _,
                                             raw: None,
                                         }),
                                         type_mode,

--- a/crates/stc_ts_file_analyzer/src/analyzer/expr/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/expr/mod.rs
@@ -2525,8 +2525,15 @@ impl Analyzer<'_, '_> {
                             .into());
                         }
 
-                        if (v as usize) + 1 >= elems.len() {
-                            if let Some(elem) = elems.last() {
+                        let mut val = v as usize;
+                        for elem in elems {
+                            if let Some(count) = self.calculate_tuple_element_count(span, &elem.ty)? {
+                                if val < count {
+                                    return Ok(*elem.ty.clone());
+                                }
+
+                                val -= count;
+                            } else {
                                 if let Type::Rest(rest_ty) = elem.ty.normalize() {
                                     if opts.return_rest_tuple_element_as_is {
                                         return Ok(*elem.ty.clone());
@@ -2554,6 +2561,8 @@ impl Analyzer<'_, '_> {
 
                                     // debug_assert!(rest_ty.ty.is_clone_cheap());
                                     return Ok(*rest_ty.ty.clone());
+                                } else {
+                                    unreachable!()
                                 }
                             }
                         }

--- a/crates/stc_ts_file_analyzer/src/analyzer/expr/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/expr/mod.rs
@@ -1048,7 +1048,7 @@ impl Analyzer<'_, '_> {
             let obj = dump_type_as_string(obj);
             // let prop_ty = dump_type_as_string( &prop.ty());
 
-            Some(tracing::span!(Level::ERROR, "access_property", obj = &*obj).entered())
+            Some(tracing::span!(Level::ERROR, "access_property", obj = &*obj, prop = tracing::field::debug(&prop)).entered())
         } else {
             None
         };
@@ -2532,7 +2532,7 @@ impl Analyzer<'_, '_> {
                                         return Ok(*elem.ty.clone());
                                     }
 
-                                    if let Ok(ty) = self.access_property(
+                                    let inner_result = self.access_property(
                                         span,
                                         &rest_ty.ty,
                                         &Key::Num(RNumber {
@@ -2546,7 +2546,9 @@ impl Analyzer<'_, '_> {
                                             use_undefined_for_tuple_index_error: false,
                                             ..opts
                                         },
-                                    ) {
+                                    );
+                                    // dbg!(&inner_result);
+                                    if let Ok(ty) = inner_result {
                                         return Ok(ty);
                                     }
 

--- a/crates/stc_ts_file_analyzer/src/analyzer/expr/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/expr/mod.rs
@@ -2535,7 +2535,10 @@ impl Analyzer<'_, '_> {
                                         }),
                                         type_mode,
                                         id_ctx,
-                                        opts,
+                                        AccessPropertyOpts {
+                                            use_undefined_for_tuple_index_error: false,
+                                            ..opts
+                                        },
                                     ) {
                                         return Ok(ty);
                                     }

--- a/crates/stc_ts_file_analyzer/src/analyzer/expr/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/expr/mod.rs
@@ -2526,8 +2526,10 @@ impl Analyzer<'_, '_> {
                         }
 
                         let mut val = v as usize;
+                        let mut sum = 0;
                         for elem in elems {
                             if let Some(count) = self.calculate_tuple_element_count(span, &elem.ty)? {
+                                sum += count;
                                 if val < count {
                                     return Ok(*elem.ty.clone());
                                 }
@@ -2544,7 +2546,7 @@ impl Analyzer<'_, '_> {
                                         &rest_ty.ty,
                                         &Key::Num(RNumber {
                                             span: n.span,
-                                            value: (v + 1i64 - (elems.len() as i64)) as _,
+                                            value: sum as _,
                                             raw: None,
                                         }),
                                         type_mode,

--- a/crates/stc_ts_file_analyzer/src/analyzer/expr/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/expr/mod.rs
@@ -531,6 +531,7 @@ pub(crate) struct AccessPropertyOpts {
 
     pub disallow_indexing_class_with_computed: bool,
 
+    /// If true, [Type::Rest] is returned as is.
     pub return_rest_tuple_element_as_is: bool,
 
     /// Note: If it's in l-value context, `access_property` will return

--- a/crates/stc_ts_file_analyzer/src/analyzer/expr/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/expr/mod.rs
@@ -2528,7 +2528,7 @@ impl Analyzer<'_, '_> {
                             if let Some(elem) = elems.last() {
                                 if let Type::Rest(rest_ty) = elem.ty.normalize() {
                                     if opts.return_rest_tuple_element_as_is {
-                                        return Ok(*rest_ty.ty.clone());
+                                        return Ok(*elem.ty.clone());
                                     }
 
                                     if let Ok(ty) = self.access_property(

--- a/crates/stc_ts_file_analyzer/src/analyzer/expr/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/expr/mod.rs
@@ -531,6 +531,8 @@ pub(crate) struct AccessPropertyOpts {
 
     pub disallow_indexing_class_with_computed: bool,
 
+    pub return_rest_tuple_element_as_is: bool,
+
     /// Note: If it's in l-value context, `access_property` will return
     /// undefined even if this field is `false`.
     pub use_undefined_for_tuple_index_error: bool,
@@ -2524,27 +2526,29 @@ impl Analyzer<'_, '_> {
 
                         if (v as usize) + 1 >= elems.len() {
                             if let Some(elem) = elems.last() {
-                                if let Type::Rest(rest_ty) = elem.ty.normalize() {
-                                    if let Ok(ty) = self.access_property(
-                                        span,
-                                        &rest_ty.ty,
-                                        &Key::Num(RNumber {
-                                            span: n.span,
-                                            value: (v + 1i64 - (elems.len() as i64)) as _,
-                                            raw: None,
-                                        }),
-                                        type_mode,
-                                        id_ctx,
-                                        AccessPropertyOpts {
-                                            use_undefined_for_tuple_index_error: false,
-                                            ..opts
-                                        },
-                                    ) {
-                                        return Ok(ty);
-                                    }
+                                if !opts.return_rest_tuple_element_as_is {
+                                    if let Type::Rest(rest_ty) = elem.ty.normalize() {
+                                        if let Ok(ty) = self.access_property(
+                                            span,
+                                            &rest_ty.ty,
+                                            &Key::Num(RNumber {
+                                                span: n.span,
+                                                value: (v + 1i64 - (elems.len() as i64)) as _,
+                                                raw: None,
+                                            }),
+                                            type_mode,
+                                            id_ctx,
+                                            AccessPropertyOpts {
+                                                use_undefined_for_tuple_index_error: false,
+                                                ..opts
+                                            },
+                                        ) {
+                                            return Ok(ty);
+                                        }
 
-                                    // debug_assert!(rest_ty.ty.is_clone_cheap());
-                                    return Ok(*rest_ty.ty.clone());
+                                        // debug_assert!(rest_ty.ty.is_clone_cheap());
+                                        return Ok(*rest_ty.ty.clone());
+                                    }
                                 }
                             }
                         }

--- a/crates/stc_ts_file_analyzer/src/analyzer/generic/inference.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/generic/inference.rs
@@ -15,7 +15,7 @@ use stc_ts_generics::expander::InferTypeResult;
 use stc_ts_type_ops::generalization::prevent_generalize;
 use stc_ts_types::{
     Array, ArrayMetadata, Class, ClassDef, ClassMember, Function, Id, Interface, KeywordType, KeywordTypeMetadata, LitType, Operator, Ref,
-    TplElem, TplType, Type, TypeElement, TypeLit, TypeParam, TypeParamMetadata, Union,
+    TplElem, TplType, Tuple, TupleElement, Type, TypeElement, TypeLit, TypeParam, TypeParamMetadata, Union,
 };
 use stc_utils::cache::Freeze;
 use swc_atoms::Atom;
@@ -94,6 +94,9 @@ pub(crate) struct InferTypeOpts {
     pub ignore_builtin_object_interface: bool,
 
     pub skip_initial_union_check: bool,
+
+    /// If true, we are inferring a type from [Type::Rest]
+    pub is_inferring_rest_type: bool,
 }
 
 bitflags! {
@@ -836,6 +839,33 @@ impl Analyzer<'_, '_> {
                             .is_ok()
                         {
                             arg.clone()
+                        } else if opts.is_inferring_rest_type
+                            && match e.get().inferred_type.normalize() {
+                                Type::Tuple(tuple) => tuple.elems.len() == 1,
+                                _ => false,
+                            }
+                            && match arg.normalize() {
+                                Type::Tuple(tuple) => tuple.elems.len() == 1,
+                                _ => false,
+                            }
+                        {
+                            // If both are tuples with length is 1, we merge
+                            // them.
+                            let prev = e.get().inferred_type.as_tuple().unwrap().elems[0].ty.clone();
+                            let new = arg.as_tuple().unwrap().elems[0].ty.clone();
+
+                            Type::Tuple(Tuple {
+                                span,
+                                elems: vec![TupleElement {
+                                    span,
+                                    label: None,
+                                    ty: box Type::new_union(span, vec![*prev, *new]),
+                                    tracker: Default::default(),
+                                }],
+                                metadata: Default::default(),
+                                tracker: Default::default(),
+                            })
+                            .freezed()
                         } else {
                             Type::new_union(span, vec![e.get().inferred_type.clone(), arg.clone()].freezed())
                         };

--- a/crates/stc_ts_file_analyzer/src/analyzer/generic/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/generic/mod.rs
@@ -2052,6 +2052,7 @@ impl Analyzer<'_, '_> {
                     disallow_creating_indexed_type_from_ty_els: true,
                     disallow_indexing_class_with_computed: true,
                     use_undefined_for_tuple_index_error: true,
+                    return_rest_tuple_element_as_is: true,
                     ..Default::default()
                 },
             )?;
@@ -2072,6 +2073,7 @@ impl Analyzer<'_, '_> {
                     disallow_creating_indexed_type_from_ty_els: true,
                     disallow_indexing_class_with_computed: true,
                     use_undefined_for_tuple_index_error: true,
+                    return_rest_tuple_element_as_is: true,
                     ..Default::default()
                 },
             )?;

--- a/crates/stc_ts_file_analyzer/src/analyzer/generic/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/generic/mod.rs
@@ -2084,7 +2084,16 @@ impl Analyzer<'_, '_> {
                 },
             )?;
 
-            self.infer_type(span, inferred, &l_elem_type, &r_elem_type, opts)?;
+            self.infer_type(
+                span,
+                inferred,
+                &l_elem_type,
+                &r_elem_type,
+                InferTypeOpts {
+                    append_type_as_union: true,
+                    ..opts
+                },
+            )?;
         }
 
         Ok(())

--- a/crates/stc_ts_file_analyzer/src/analyzer/generic/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/generic/mod.rs
@@ -2033,6 +2033,12 @@ impl Analyzer<'_, '_> {
         arg_ty: &Type,
         opts: InferTypeOpts,
     ) -> VResult<()> {
+        let _tracing = if cfg!(debug_assertions) {
+            Some(span!(Level::ERROR, "infer_type_using_tuple_and_tuple").entered())
+        } else {
+            None
+        };
+
         let len = param.elems.len().max(arg.elems.len());
 
         for index in 0..len {

--- a/crates/stc_ts_file_analyzer/src/analyzer/generic/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/generic/mod.rs
@@ -957,6 +957,28 @@ impl Analyzer<'_, '_> {
                 if let Type::Rest(arg_rest) = arg {
                     return self.infer_type(span, inferred, &param_rest.ty, &arg_rest.ty, opts);
                 }
+
+                return self.infer_type(
+                    span,
+                    inferred,
+                    &param_rest.ty,
+                    &Type::Tuple(Tuple {
+                        span,
+                        elems: vec![TupleElement {
+                            span,
+                            label: None,
+                            ty: box arg.clone(),
+                            tracker: Default::default(),
+                        }],
+                        metadata: Default::default(),
+                        tracker: Default::default(),
+                    })
+                    .freezed(),
+                    InferTypeOpts {
+                        append_type_as_union: true,
+                        ..opts
+                    },
+                );
             }
 
             Type::Ref(param) => match arg {

--- a/crates/stc_ts_file_analyzer/src/analyzer/generic/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/generic/mod.rs
@@ -953,6 +953,12 @@ impl Analyzer<'_, '_> {
                 dbg!();
             }
 
+            Type::Rest(param_rest) => {
+                if let Type::Rest(arg_rest) = arg {
+                    return self.infer_type(span, inferred, &param_rest.ty, &arg_rest.ty, opts);
+                }
+            }
+
             Type::Ref(param) => match arg {
                 Type::Ref(arg)
                     if param.type_name.eq_ignore_span(&arg.type_name)

--- a/crates/stc_ts_file_analyzer/src/analyzer/generic/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/generic/mod.rs
@@ -975,6 +975,7 @@ impl Analyzer<'_, '_> {
                     })
                     .freezed(),
                     InferTypeOpts {
+                        is_inferring_rest_type: true,
                         append_type_as_union: true,
                         ..opts
                     },

--- a/crates/stc_ts_file_analyzer/src/analyzer/types/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/types/mod.rs
@@ -110,7 +110,6 @@ impl Analyzer<'_, '_> {
             | Type::Interface(..)
             | Type::Class(..)
             | Type::ClassDef(..)
-            | Type::Tuple(..)
             | Type::Function(..)
             | Type::Constructor(..)
             | Type::EnumVariant(..)
@@ -734,6 +733,8 @@ impl Analyzer<'_, '_> {
                     Type::Operator(_) => {
                         // TODO(kdy1):
                     }
+
+                    Type::Tuple(tuple) => {}
 
                     Type::Tpl(tpl) => {
                         if tpl.quasis.len() == 2

--- a/crates/stc_ts_file_analyzer/src/analyzer/types/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/types/mod.rs
@@ -18,8 +18,8 @@ use stc_ts_types::{
     name::Name, Accessor, Array, Class, ClassDef, ClassMember, ClassMetadata, ComputedKey, Conditional, ConditionalMetadata,
     ConstructorSignature, EnumVariant, FnParam, Id, IdCtx, IndexSignature, IndexedAccessType, Instance, InstanceMetadata, Intersection,
     IntrinsicKind, Key, KeywordType, KeywordTypeMetadata, LitType, LitTypeMetadata, MethodSignature, Operator, PropertySignature,
-    QueryExpr, QueryType, Ref, StringMapping, ThisType, ThisTypeMetadata, TplElem, TplType, Type, TypeElement, TypeLit, TypeLitMetadata,
-    TypeParam, TypeParamInstantiation, Union,
+    QueryExpr, QueryType, Ref, RestType, StringMapping, ThisType, ThisTypeMetadata, TplElem, TplType, Type, TypeElement, TypeLit,
+    TypeLitMetadata, TypeParam, TypeParamInstantiation, Union,
 };
 use stc_ts_utils::run;
 use stc_utils::{
@@ -733,6 +733,17 @@ impl Analyzer<'_, '_> {
 
                     Type::Operator(_) => {
                         // TODO(kdy1):
+                    }
+
+                    Type::Rest(rest) => {
+                        let ty = box self.normalize(span, Cow::Borrowed(&rest.ty), opts)?.into_owned();
+
+                        return Ok(Cow::Owned(Type::Rest(RestType {
+                            span: rest.span,
+                            ty,
+                            metadata: Default::default(),
+                            tracker: Default::default(),
+                        })));
                     }
 
                     Type::Tpl(tpl) => {

--- a/crates/stc_ts_file_analyzer/src/analyzer/types/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/types/mod.rs
@@ -18,8 +18,8 @@ use stc_ts_types::{
     name::Name, Accessor, Array, Class, ClassDef, ClassMember, ClassMetadata, ComputedKey, Conditional, ConditionalMetadata,
     ConstructorSignature, EnumVariant, FnParam, Id, IdCtx, IndexSignature, IndexedAccessType, Instance, InstanceMetadata, Intersection,
     IntrinsicKind, Key, KeywordType, KeywordTypeMetadata, LitType, LitTypeMetadata, MethodSignature, Operator, PropertySignature,
-    QueryExpr, QueryType, Ref, RestType, StringMapping, ThisType, ThisTypeMetadata, TplElem, TplType, Type, TypeElement, TypeLit,
-    TypeLitMetadata, TypeParam, TypeParamInstantiation, Union,
+    QueryExpr, QueryType, Ref, StringMapping, ThisType, ThisTypeMetadata, TplElem, TplType, Type, TypeElement, TypeLit, TypeLitMetadata,
+    TypeParam, TypeParamInstantiation, Union,
 };
 use stc_ts_utils::run;
 use stc_utils::{
@@ -733,17 +733,6 @@ impl Analyzer<'_, '_> {
 
                     Type::Operator(_) => {
                         // TODO(kdy1):
-                    }
-
-                    Type::Rest(rest) => {
-                        let ty = box self.normalize(span, Cow::Borrowed(&rest.ty), opts)?.into_owned();
-
-                        return Ok(Cow::Owned(Type::Rest(RestType {
-                            span: rest.span,
-                            ty,
-                            metadata: Default::default(),
-                            tracker: Default::default(),
-                        })));
                     }
 
                     Type::Tpl(tpl) => {

--- a/crates/stc_ts_file_analyzer/tests/base.rs
+++ b/crates/stc_ts_file_analyzer/tests/base.rs
@@ -265,7 +265,7 @@ fn pass_only(input: PathBuf) {
         }
 
         if !ok {
-            return Err(());
+            panic!()
         }
 
         Ok(())

--- a/crates/stc_ts_file_analyzer/tests/pass-only/types/literal/numericStringLiteralTypes/1.ts
+++ b/crates/stc_ts_file_analyzer/tests/pass-only/types/literal/numericStringLiteralTypes/1.ts
@@ -1,0 +1,25 @@
+//@strict: true
+
+
+
+
+
+type Container<T> = {
+    value: T
+}
+
+type UnwrapContainers<T extends Container<unknown>[]> = { [K in keyof T]: T[K]['value'] };
+
+declare function createContainer<T extends unknown>(value: T): Container<T>;
+
+declare function f<T extends Container<unknown>[]>(containers: [...T], callback: (...values: UnwrapContainers<T>) => void): void;
+
+const container1 = createContainer('hi')
+const container2 = createContainer(2)
+
+f([container1, container2], (value1, value2) => {
+    value1;  // string
+    value2;  // number
+});
+
+export { }

--- a/crates/stc_ts_file_analyzer/tests/pass-only/types/tuple/variadicTuples1/1.ts
+++ b/crates/stc_ts_file_analyzer/tests/pass-only/types/tuple/variadicTuples1/1.ts
@@ -4,9 +4,7 @@ declare function f22<T extends unknown[] = []>(args: [...T, number]): T;
 declare function f22<T extends unknown[] = []>(args: [...T]): T;
 
 function f23<U extends string[]>(args: [...U, number]) {
-    let v1 = f22(args);  // U
     let v2 = f22(["foo", "bar"]);  // [string, string]
-    let v3 = f22(["foo", 42]);  // [string]
 }
 
 export { }

--- a/crates/stc_ts_file_analyzer/tests/pass-only/types/tuple/variadicTuples1/1.ts
+++ b/crates/stc_ts_file_analyzer/tests/pass-only/types/tuple/variadicTuples1/1.ts
@@ -1,0 +1,12 @@
+//@strict: true
+
+declare function f22<T extends unknown[] = []>(args: [...T, number]): T;
+declare function f22<T extends unknown[] = []>(args: [...T]): T;
+
+function f23<U extends string[]>(args: [...U, number]) {
+    let v1 = f22(args);  // U
+    let v2 = f22(["foo", "bar"]);  // [string, string]
+    let v3 = f22(["foo", 42]);  // [string]
+}
+
+export { }

--- a/crates/stc_ts_file_analyzer/tests/pass-only/types/tuple/variadicTuples1/1.ts
+++ b/crates/stc_ts_file_analyzer/tests/pass-only/types/tuple/variadicTuples1/1.ts
@@ -1,6 +1,5 @@
 //@strict: true
 
-declare function f22<T extends unknown[] = []>(args: [...T, number]): T;
 declare function f22<T extends unknown[] = []>(args: [...T]): T;
 
 function f23<U extends string[]>(args: [...U, number]) {

--- a/crates/stc_ts_file_analyzer/tests/pass-only/types/tuple/variadicTuples1/2.ts
+++ b/crates/stc_ts_file_analyzer/tests/pass-only/types/tuple/variadicTuples1/2.ts
@@ -1,0 +1,9 @@
+//@strict: true
+
+// Inference to [...T] has higher priority than inference to [...T, number?]
+
+declare function ft<T extends unknown[]>(t1: [...T], t2: [...T, number?]): T;
+
+ft([1, 2], [1, 2, 3]);
+
+export { }

--- a/crates/stc_ts_file_analyzer/tests/pass-only/types/tuple/variadicTuples1/3.ts
+++ b/crates/stc_ts_file_analyzer/tests/pass-only/types/tuple/variadicTuples1/3.ts
@@ -1,0 +1,9 @@
+//@strict: true
+
+// Inference to [...T] has higher priority than inference to [...T, number?]
+
+declare function ft<T extends unknown[]>(t1: [...T], t2: [...T, number?]): T;
+
+ft(['a', 'b'], ['c', 'd', 42])
+
+export { }

--- a/crates/stc_ts_type_checker/tests/conformance/types/tuple/variadicTuples1.stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/conformance/types/tuple/variadicTuples1.stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
-    required_error: 8,
-    matched_error: 12,
-    extra_error: 24,
+    required_error: 10,
+    matched_error: 10,
+    extra_error: 25,
     panic: 0,
 }

--- a/crates/stc_ts_type_checker/tests/tsc-stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/tsc-stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
-    required_error: 4183,
-    matched_error: 5891,
-    extra_error: 803,
+    required_error: 4185,
+    matched_error: 5889,
+    extra_error: 804,
     panic: 18,
 }

--- a/crates/stc_ts_types/src/lib.rs
+++ b/crates/stc_ts_types/src/lib.rs
@@ -2237,31 +2237,6 @@ impl Type {
             idx: 0,
         }
     }
-
-    // /// Note: This iterator is infinite if the type is [Type::Rest].
-    // pub fn iter_rest(&self) -> impl '_ + Iterator<Item = &Type> {
-    //     let mut done = false;
-    //     let mut index = 0;
-    //     iter::from_fn(move || {
-    //         if done {
-    //             return None;
-    //         }
-    //         match self.normalize_instance() {
-    //             Type::Rest(rest) => match rest.ty.normalize() {
-    //                 Type::Tuple(tuple) => {
-    //                     let ty = tuple.elems.get(index).map(|el| &*el.ty);
-    //                     index += 1;
-    //                     ty
-    //                 }
-    //                 _ => Some(&*rest.ty),
-    //             },
-    //             _ => {
-    //                 done = true;
-    //                 Some(self)
-    //             }
-    //         }
-    //     })
-    // }
 }
 
 #[derive(Debug)]

--- a/crates/stc_ts_types/src/lib.rs
+++ b/crates/stc_ts_types/src/lib.rs
@@ -2238,30 +2238,30 @@ impl Type {
         }
     }
 
-    /// Note: This iterator is infinite if the type is [Type::Rest].
-    pub fn iter_rest(&self) -> impl '_ + Iterator<Item = &Type> {
-        let mut done = false;
-        let mut index = 0;
-        iter::from_fn(move || {
-            if done {
-                return None;
-            }
-            match self.normalize_instance() {
-                Type::Rest(rest) => match rest.ty.normalize() {
-                    Type::Tuple(tuple) => {
-                        let ty = tuple.elems.get(index).map(|el| &*el.ty);
-                        index += 1;
-                        ty
-                    }
-                    _ => Some(&*rest.ty),
-                },
-                _ => {
-                    done = true;
-                    Some(self)
-                }
-            }
-        })
-    }
+    // /// Note: This iterator is infinite if the type is [Type::Rest].
+    // pub fn iter_rest(&self) -> impl '_ + Iterator<Item = &Type> {
+    //     let mut done = false;
+    //     let mut index = 0;
+    //     iter::from_fn(move || {
+    //         if done {
+    //             return None;
+    //         }
+    //         match self.normalize_instance() {
+    //             Type::Rest(rest) => match rest.ty.normalize() {
+    //                 Type::Tuple(tuple) => {
+    //                     let ty = tuple.elems.get(index).map(|el| &*el.ty);
+    //                     index += 1;
+    //                     ty
+    //                 }
+    //                 _ => Some(&*rest.ty),
+    //             },
+    //             _ => {
+    //                 done = true;
+    //                 Some(self)
+    //             }
+    //         }
+    //     })
+    // }
 }
 
 #[derive(Debug)]

--- a/crates/stc_ts_types/src/lib.rs
+++ b/crates/stc_ts_types/src/lib.rs
@@ -2241,12 +2241,20 @@ impl Type {
     /// Note: This iterator is infinite if the type is [Type::Rest].
     pub fn iter_rest(&self) -> impl '_ + Iterator<Item = &Type> {
         let mut done = false;
+        let mut index = 0;
         iter::from_fn(move || {
             if done {
                 return None;
             }
             match self.normalize_instance() {
-                Type::Rest(ty) => Some(&*ty.ty),
+                Type::Rest(rest) => match rest.ty.normalize() {
+                    Type::Tuple(tuple) => {
+                        let ty = tuple.elems.get(index).map(|el| &*el.ty);
+                        index += 1;
+                        ty
+                    }
+                    _ => Some(&*rest.ty),
+                },
                 _ => {
                     done = true;
                     Some(self)

--- a/crates/stc_ts_types/src/lib.rs
+++ b/crates/stc_ts_types/src/lib.rs
@@ -14,7 +14,7 @@ use std::{
     borrow::Cow,
     fmt,
     fmt::{Debug, Formatter},
-    iter::FusedIterator,
+    iter::{self, FusedIterator},
     mem::{replace, transmute},
     ops::AddAssign,
 };
@@ -2236,6 +2236,23 @@ impl Type {
             ty: self.normalize(),
             idx: 0,
         }
+    }
+
+    /// Note: This iterator is infinite if the type is [Type::Rest].
+    pub fn iter_rest(&self) -> impl '_ + Iterator<Item = &Type> {
+        let mut done = false;
+        iter::from_fn(move || {
+            if done {
+                return None;
+            }
+            match self.normalize_instance() {
+                Type::Rest(ty) => Some(&*ty.ty),
+                _ => {
+                    done = true;
+                    Some(self)
+                }
+            }
+        })
     }
 }
 

--- a/crates/stc_ts_types/src/lib.rs
+++ b/crates/stc_ts_types/src/lib.rs
@@ -14,7 +14,7 @@ use std::{
     borrow::Cow,
     fmt,
     fmt::{Debug, Formatter},
-    iter::{self, FusedIterator},
+    iter::FusedIterator,
     mem::{replace, transmute},
     ops::AddAssign,
 };


### PR DESCRIPTION
**Description:**

 - Infer a type parameter as a single-element tuple if the parameter is of a rest type.
 - Use `access_property` for the assignment of tuples.
 - Use `access_property` for the inference of tuples.
 - Improve `access_property` for tuples.