### PR TITLE
perf: Migrate simple operations to `replace_type`

### DIFF
--- a/crates/stc_ts_file_analyzer/src/analyzer/expr/call_new.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/expr/call_new.rs
@@ -3620,7 +3620,7 @@ impl VisitMut<Type> for ReturnTypeSimplifier<'_, '_, '_> {
                 .fixed();
             }
 
-            Type::IndexedAccessType(ty) if is_str_lit_or_union(&ty.index_type) => {
+            Type::IndexedAccessType(iat) if is_str_lit_or_union(&iat.index_type) => {
                 prevent_generalize(ty);
             }
 

--- a/crates/stc_ts_file_analyzer/src/analyzer/generic/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/generic/mod.rs
@@ -2227,35 +2227,6 @@ impl Fold<Type> for SingleTypeParamReplacer<'_> {
     }
 }
 
-struct TypeParamInliner<'a> {
-    param: &'a Id,
-    value: &'a RStr,
-}
-
-impl VisitMut<Type> for TypeParamInliner<'_> {
-    fn visit_mut(&mut self, ty: &mut Type) {
-        // TODO(kdy1): PERF
-        ty.normalize_mut();
-
-        ty.visit_mut_children_with(self);
-
-        match ty.normalize() {
-            Type::Param(p) if p.name == *self.param => {
-                *ty = Type::Lit(LitType {
-                    span: p.span,
-                    lit: RTsLit::Str(self.value.clone()),
-                    metadata: LitTypeMetadata {
-                        common: p.metadata.common,
-                        ..Default::default()
-                    },
-                    tracker: Default::default(),
-                });
-            }
-            _ => {}
-        }
-    }
-}
-
 pub(crate) fn calc_true_plus_minus_in_param(param: Option<TruePlusMinus>, previous: bool) -> bool {
     match param {
         Some(v) => match v {

--- a/crates/stc_ts_type_ops/src/generalization/metadata.rs
+++ b/crates/stc_ts_type_ops/src/generalization/metadata.rs
@@ -4,10 +4,7 @@ use stc_ts_types::{LitType, Type};
 use tracing::instrument;
 
 #[instrument(skip(ty))]
-pub fn prevent_generalize<N>(ty: &mut N)
-where
-    N: VisitMutWith<PreventGeneralization>,
-{
+pub fn prevent_generalize(ty: &mut Type) {
     ty.visit_mut_with(&mut PreventGeneralization { _priv: () });
 }
 
@@ -34,7 +31,7 @@ impl Visit<Type> for GeneralizableLiteralFinder {
     }
 }
 
-pub struct PreventGeneralization {
+struct PreventGeneralization {
     _priv: (),
 }
 

--- a/crates/stc_ts_type_ops/src/generalization/metadata.rs
+++ b/crates/stc_ts_type_ops/src/generalization/metadata.rs
@@ -1,59 +1,26 @@
-use rnode::{Visit, VisitMut, VisitMutWith, VisitWith};
-use stc_ts_ast_rnode::RIdent;
-use stc_ts_types::{LitType, Type};
+use stc_ts_types::{replace::replace_type, LitType, Type};
+use stc_ts_utils::MapWithMut;
 use tracing::instrument;
 
 #[instrument(skip(ty))]
 pub fn prevent_generalize(ty: &mut Type) {
-    ty.visit_mut_with(&mut PreventGeneralization { _priv: () });
-}
+    replace_type(
+        ty,
+        |ty| {
+            if let Type::Lit(LitType { metadata, .. }) = ty.normalize() {
+                if metadata.common.prevent_generalization {
+                    return false;
+                }
 
-pub(crate) struct GeneralizableLiteralFinder {
-    pub found: bool,
-}
-
-impl Visit<Type> for GeneralizableLiteralFinder {
-    fn visit(&mut self, ty: &Type) {
-        if self.found {
-            return;
-        }
-
-        if let Type::Lit(LitType { metadata, .. }) = ty.normalize() {
-            if metadata.common.prevent_generalization {
-                return;
+                return true;
             }
 
-            self.found = true;
-            return;
-        }
-
-        ty.visit_children_with(self);
-    }
-}
-
-struct PreventGeneralization {
-    _priv: (),
-}
-
-impl VisitMut<Type> for PreventGeneralization {
-    fn visit_mut(&mut self, ty: &mut Type) {
-        {
-            let mut checker = GeneralizableLiteralFinder { found: false };
-            ty.visit_with(&mut checker);
-
-            if !checker.found {
-                return;
-            }
-        }
-
-        ty.normalize_mut();
-        ty.metadata_mut().prevent_generalization = true;
-
-        ty.visit_mut_children_with(self);
-    }
-}
-
-/// Prevent interop with hygiene.
-impl VisitMut<RIdent> for PreventGeneralization {
-    fn visit_mut(&mut self, _: &mut RIdent) {}
+            false
+        },
+        |ty| {
+            let mut ty = ty.take();
+            ty.metadata_mut().prevent_generalization = true;
+            Some(ty)
+        },
+    )
 }

--- a/crates/stc_ts_type_ops/src/tuple_to_array/metadata.rs
+++ b/crates/stc_ts_type_ops/src/tuple_to_array/metadata.rs
@@ -1,27 +1,17 @@
-use rnode::{VisitMut, VisitMutWith};
-use stc_ts_ast_rnode::RIdent;
-use stc_ts_types::Type;
+use stc_ts_types::{replace::replace_type, Type};
+use stc_ts_utils::MapWithMut;
 use tracing::instrument;
 
 /// TODO(kdy1): Optimize by visiting only tuple types.
 #[instrument(skip(ty))]
 pub fn prevent_tuple_to_array(ty: &mut Type) {
-    ty.visit_mut_with(&mut PreventTupleToArray);
-}
-
-struct PreventTupleToArray;
-
-impl VisitMut<Type> for PreventTupleToArray {
-    fn visit_mut(&mut self, ty: &mut Type) {
-        // TODO(kdy1): PERF
-        ty.normalize_mut();
-        ty.metadata_mut().prevent_tuple_to_array = true;
-
-        ty.visit_mut_children_with(self);
-    }
-}
-
-/// Prevent interop with hygiene.
-impl VisitMut<RIdent> for PreventTupleToArray {
-    fn visit_mut(&mut self, _: &mut RIdent) {}
+    replace_type(
+        ty,
+        |ty| ty.is_tuple(),
+        |ty| {
+            let mut ty = ty.take();
+            ty.metadata_mut().prevent_tuple_to_array = true;
+            Some(ty)
+        },
+    )
 }


### PR DESCRIPTION
**Description:**

Patched operations:
 - `rename_inferred`
 - `prevent_tuple_to_array`
 - `prevent_generalize`
 - `generic::SingleTypeParamReplacer`
 - `expr::ConstraintReducer`