### PR TITLE
fix: Don't generalize from `access_property`

### DIFF
--- a/crates/stc_ts_file_analyzer/src/analyzer/expr/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/expr/mod.rs
@@ -30,7 +30,6 @@ use swc_atoms::js_word;
 use swc_common::{SourceMapper, Span, Spanned, SyntaxContext, TypeEq, DUMMY_SP};
 use swc_ecma_ast::{op, EsVersion, TruePlusMinus, TsKeywordTypeKind, TsTypeOperatorOp, VarDeclKind};
 use tracing::{debug, info, warn, Level};
-use ty::TypeExt;
 
 use self::bin::extract_name_for_assignment;
 pub(crate) use self::{array::GetIteratorOpts, call_new::CallOpts};
@@ -1660,10 +1659,7 @@ impl Analyzer<'_, '_> {
         if !self.is_builtin {
             obj.freeze();
         }
-        let mut obj = self
-            .with_ctx(ctx)
-            .expand(span, obj.into_owned(), Default::default())?
-            .generalize_lit();
+        let mut obj = self.with_ctx(ctx).expand(span, obj.into_owned(), Default::default())?;
         if !self.is_builtin {
             obj.freeze();
         }

--- a/crates/stc_ts_file_analyzer/src/analyzer/scope/vars.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/scope/vars.rs
@@ -25,6 +25,7 @@ use crate::{
         util::{opt_union, ResultExt},
         Analyzer, Ctx,
     },
+    ty::TypeExt,
     validator::ValidateWith,
     VResult,
 };
@@ -313,7 +314,7 @@ impl Analyzer<'_, '_> {
                                     });
 
                                     match result {
-                                        Ok(ty) => Ok(ty.into_owned()),
+                                        Ok(ty) => Ok(ty.into_owned().generalize_lit()),
                                         Err(err) => match &*err {
                                             ErrorKind::TupleIndexError { .. } => match elem {
                                                 RPat::Assign(p) => {
@@ -365,6 +366,7 @@ impl Analyzer<'_, '_> {
                                         .ok()
                                 })
                                 .map(Cow::into_owned)
+                                .map(|ty| ty.generalize_lit())
                                 .freezed();
 
                             // TODO(kdy1): actual_ty
@@ -437,6 +439,7 @@ impl Analyzer<'_, '_> {
                                             IdCtx::Var,
                                             Default::default(),
                                         )
+                                        .map(|ty| ty.generalize_lit())
                                         .context("tried to access property to declare variables using an array pattern")
                                         .report(&mut self.storage),
                                     None => None,
@@ -457,6 +460,7 @@ impl Analyzer<'_, '_> {
                                             IdCtx::Var,
                                             Default::default(),
                                         )
+                                        .map(|ty| ty.generalize_lit())
                                         .context("tried to access property to declare variables using an array pattern")
                                         .report(&mut self.storage),
                                     None => None,
@@ -541,6 +545,7 @@ impl Analyzer<'_, '_> {
                                             ..Default::default()
                                         },
                                     )
+                                    .map(|ty| ty.generalize_lit())
                                     .context("tried to access property to declare variables")
                             });
 
@@ -563,6 +568,7 @@ impl Analyzer<'_, '_> {
                                         )
                                         .ok()
                                 })
+                                .map(|ty| ty.generalize_lit())
                                 .freezed();
 
                             let real_property_type = match prop_ty {
@@ -635,6 +641,7 @@ impl Analyzer<'_, '_> {
                                             ..Default::default()
                                         },
                                     )
+                                    .map(|ty| ty.generalize_lit())
                                     .context("tried to access property to declare variables")
                             });
 
@@ -657,6 +664,7 @@ impl Analyzer<'_, '_> {
                                         )
                                         .ok()
                                 })
+                                .map(|ty| ty.generalize_lit())
                                 .freezed();
 
                             let real_property_type = match prop_ty {


### PR DESCRIPTION
**Description:**

This PR fixes `[1, 2, 3][0]`.