### PR TITLE
perf: Refactor `Name` to prefer short names

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2461,7 +2461,6 @@ dependencies = [
  "rustc-hash",
  "scoped-tls",
  "serde",
- "smallvec",
  "static_assertions",
  "stc_arc_cow",
  "stc_ts_ast_rnode",

--- a/crates/stc_ts_file_analyzer/src/analyzer/control_flow.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/control_flow.rs
@@ -1314,7 +1314,7 @@ impl Analyzer<'_, '_> {
             return Ok(None);
         }
 
-        let (top, symbols) = name.as_ids();
+        let (top, symbols) = name.inner();
         let mut id: RIdent = top.clone().into();
         id.span.lo = span.lo;
         id.span.hi = span.hi;

--- a/crates/stc_ts_file_analyzer/src/analyzer/control_flow.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/control_flow.rs
@@ -1314,8 +1314,8 @@ impl Analyzer<'_, '_> {
             return Ok(None);
         }
 
-        let ids = name.as_ids();
-        let mut id: RIdent = ids[0].clone().into();
+        let (top, symbols) = name.as_ids();
+        let mut id: RIdent = top.clone().into();
         id.span.lo = span.lo;
         id.span.hi = span.hi;
 
@@ -1331,7 +1331,7 @@ impl Analyzer<'_, '_> {
         )?;
 
         if let Type::Union(u) = obj.normalize() {
-            if ids.len() == 2 {
+            if name.len() == 2 {
                 let mut new_obj_types = vec![];
 
                 for obj in &u.types {
@@ -1340,7 +1340,7 @@ impl Analyzer<'_, '_> {
                         obj,
                         &Key::Normal {
                             span: ty.span(),
-                            sym: ids[1].sym().clone(),
+                            sym: symbols[0].clone(),
                         },
                         TypeOfMode::RValue,
                         IdCtx::Var,
@@ -1358,7 +1358,7 @@ impl Analyzer<'_, '_> {
                 let mut ty = Type::union(new_obj_types);
                 ty.fix();
 
-                return Ok(Some((Name::from(ids[0].clone()), ty)));
+                return Ok(Some((Name::from(top.clone()), ty)));
             }
         }
 

--- a/crates/stc_ts_file_analyzer/src/analyzer/expr/bin.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/expr/bin.rs
@@ -1836,7 +1836,7 @@ impl Analyzer<'_, '_> {
 
         let prop = Key::Normal {
             span,
-            sym: ids[ids.len() - 1].sym().clone(),
+            sym: name.last().clone(),
         };
 
         let ty = self.type_of_name(span, &name.inner()[..name.len() - 1], TypeOfMode::RValue, None)?;

--- a/crates/stc_ts_file_analyzer/src/analyzer/expr/bin.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/expr/bin.rs
@@ -531,7 +531,7 @@ impl Analyzer<'_, '_> {
                         // typeGuardsTypeParameters.ts says
                         //
                         // Type guards involving type parameters produce intersection types
-                        let mut orig_ty = self.type_of_name(span, name.as_ids(), TypeOfMode::RValue, None)?;
+                        let mut orig_ty = self.type_of_name(span, name.inner(), TypeOfMode::RValue, None)?;
                         if !self.is_valid_lhs_of_instanceof(span, &orig_ty) {
                             self.storage.report(
                                 ErrorKind::InvalidLhsInInstanceOf {
@@ -1091,8 +1091,8 @@ impl Analyzer<'_, '_> {
         }) {
             // If typeof foo.bar is `string`, `foo` cannot be undefined nor null
             if t != TypeFacts::EQUndefined {
-                for idx in 1..name.as_ids().len() {
-                    let sub = Name::from(&name.as_ids()[..idx]);
+                for idx in 1..name.inner().len() {
+                    let sub = Name::from(&name.inner()[..idx]);
 
                     self.cur_facts.true_facts.facts.insert(sub.clone(), TypeFacts::NEUndefinedOrNull);
                 }
@@ -1813,7 +1813,7 @@ impl Analyzer<'_, '_> {
     fn calc_type_facts_for_equality(&mut self, name: Name, equals_to: &Type) -> VResult<(Name, Type, Vec<Type>)> {
         let span = equals_to.span();
 
-        let mut id: RIdent = name.as_ids()[0].clone().into();
+        let mut id: RIdent = name.inner()[0].clone().into();
         id.span.lo = span.lo;
         id.span.hi = span.hi;
 
@@ -1832,14 +1832,14 @@ impl Analyzer<'_, '_> {
 
         // We create a type fact for `foo` in `if (foo.type === 'bar');`
 
-        let ids = name.as_ids();
+        let ids = name.inner();
 
         let prop = Key::Normal {
             span,
             sym: ids[ids.len() - 1].sym().clone(),
         };
 
-        let ty = self.type_of_name(span, &name.as_ids()[..name.len() - 1], TypeOfMode::RValue, None)?;
+        let ty = self.type_of_name(span, &name.inner()[..name.len() - 1], TypeOfMode::RValue, None)?;
 
         let ty = self.normalize(Some(span), Cow::Owned(ty), Default::default())?.into_owned();
 
@@ -1879,7 +1879,7 @@ impl Analyzer<'_, '_> {
                     }
                 }
             }
-            let actual = Name::from(&name.as_ids()[..name.len() - 1]);
+            let actual = Name::from(&name.inner()[..name.len() - 1]);
 
             if has_undefined && candidates.is_empty() {
                 return Ok((

--- a/crates/stc_ts_file_analyzer/src/analyzer/expr/bin.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/expr/bin.rs
@@ -1813,7 +1813,7 @@ impl Analyzer<'_, '_> {
     fn calc_type_facts_for_equality(&mut self, name: Name, equals_to: &Type) -> VResult<(Name, Type, Vec<Type>)> {
         let span = equals_to.span();
 
-        let mut id: RIdent = name.top().clone().into();
+        let mut id: RIdent = name.top().into();
         id.span.lo = span.lo;
         id.span.hi = span.hi;
 

--- a/crates/stc_ts_file_analyzer/src/analyzer/expr/bin.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/expr/bin.rs
@@ -531,7 +531,7 @@ impl Analyzer<'_, '_> {
                         // typeGuardsTypeParameters.ts says
                         //
                         // Type guards involving type parameters produce intersection types
-                        let mut orig_ty = self.type_of_name(span, name.inner(), TypeOfMode::RValue, None)?;
+                        let mut orig_ty = self.type_of_name(span, &name, TypeOfMode::RValue, None)?;
                         if !self.is_valid_lhs_of_instanceof(span, &orig_ty) {
                             self.storage.report(
                                 ErrorKind::InvalidLhsInInstanceOf {
@@ -1091,7 +1091,7 @@ impl Analyzer<'_, '_> {
         }) {
             // If typeof foo.bar is `string`, `foo` cannot be undefined nor null
             if t != TypeFacts::EQUndefined {
-                for idx in 1..name.inner().len() {
+                for idx in 1..name.len() {
                     let sub = Name::from(&name.inner()[..idx]);
 
                     self.cur_facts.true_facts.facts.insert(sub.clone(), TypeFacts::NEUndefinedOrNull);

--- a/crates/stc_ts_file_analyzer/src/analyzer/expr/bin.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/expr/bin.rs
@@ -1092,7 +1092,7 @@ impl Analyzer<'_, '_> {
             // If typeof foo.bar is `string`, `foo` cannot be undefined nor null
             if t != TypeFacts::EQUndefined {
                 for idx in 1..name.len() {
-                    let sub = Name::from(&name.inner()[..idx]);
+                    let sub = name.slice_to(idx);
 
                     self.cur_facts.true_facts.facts.insert(sub.clone(), TypeFacts::NEUndefinedOrNull);
                 }

--- a/crates/stc_ts_file_analyzer/src/analyzer/expr/bin.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/expr/bin.rs
@@ -1813,7 +1813,7 @@ impl Analyzer<'_, '_> {
     fn calc_type_facts_for_equality(&mut self, name: Name, equals_to: &Type) -> VResult<(Name, Type, Vec<Type>)> {
         let span = equals_to.span();
 
-        let mut id: RIdent = name.inner()[0].clone().into();
+        let mut id: RIdent = name.top().clone().into();
         id.span.lo = span.lo;
         id.span.hi = span.hi;
 
@@ -1839,7 +1839,7 @@ impl Analyzer<'_, '_> {
             sym: name.last().clone(),
         };
 
-        let ty = self.type_of_name(span, &name.inner()[..name.len() - 1], TypeOfMode::RValue, None)?;
+        let ty = self.type_of_name(span, &name.slice_to(name.len() - 1), TypeOfMode::RValue, None)?;
 
         let ty = self.normalize(Some(span), Cow::Owned(ty), Default::default())?.into_owned();
 
@@ -1879,7 +1879,7 @@ impl Analyzer<'_, '_> {
                     }
                 }
             }
-            let actual = Name::from(&name.inner()[..name.len() - 1]);
+            let actual = name.slice_to(name.len() - 1);
 
             if has_undefined && candidates.is_empty() {
                 return Ok((

--- a/crates/stc_ts_file_analyzer/src/analyzer/expr/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/expr/mod.rs
@@ -3279,7 +3279,7 @@ impl Analyzer<'_, '_> {
                 .context("tried to get type of a name with len == 1"),
 
             _ => {
-                let last_id = name.last().unwrap();
+                let last_sym = name.last().clone();
 
                 let obj = self
                     .type_of_name(span, &name[..name.len() - 1], type_mode, type_args)
@@ -3291,7 +3291,7 @@ impl Analyzer<'_, '_> {
                         &obj,
                         &Key::Normal {
                             span: id.span,
-                            sym: last_id.sym().clone(),
+                            sym: last_sym,
                         },
                         type_mode,
                         IdCtx::Var,

--- a/crates/stc_ts_file_analyzer/src/analyzer/expr/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/expr/mod.rs
@@ -3262,13 +3262,14 @@ impl Analyzer<'_, '_> {
     pub(super) fn type_of_name(
         &mut self,
         span: Span,
-        name: &[Id],
+        name: &Name,
         type_mode: TypeOfMode,
         type_args: Option<&TypeParamInstantiation>,
     ) -> VResult<Type> {
         assert!(!name.is_empty(), "Cannot determine type of empty name");
 
-        let mut id: RIdent = name[0].clone().into();
+        let (top, symbols) = name.inner();
+        let mut id: RIdent = top.clone().into();
         id.span.lo = span.lo;
         id.span.hi = span.hi;
 

--- a/crates/stc_ts_file_analyzer/src/analyzer/expr/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/expr/mod.rs
@@ -3282,7 +3282,7 @@ impl Analyzer<'_, '_> {
                 let last_sym = name.last().clone();
 
                 let obj = self
-                    .type_of_name(span, &name[..name.len() - 1], type_mode, type_args)
+                    .type_of_name(span, name.slice_to(name.len() - 1), type_mode, type_args)
                     .context("tried to get type of &names[..-1]")?;
 
                 let ty = self

--- a/crates/stc_ts_file_analyzer/src/analyzer/expr/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/expr/mod.rs
@@ -3282,7 +3282,7 @@ impl Analyzer<'_, '_> {
                 let last_sym = name.last().clone();
 
                 let obj = self
-                    .type_of_name(span, name.slice_to(name.len() - 1), type_mode, type_args)
+                    .type_of_name(span, &name.slice_to(name.len() - 1), type_mode, type_args)
                     .context("tried to get type of &names[..-1]")?;
 
                 let ty = self

--- a/crates/stc_ts_types/Cargo.toml
+++ b/crates/stc_ts_types/Cargo.toml
@@ -23,7 +23,6 @@ rnode = {path = "../rnode"}
 rustc-hash = "1.1.0"
 scoped-tls = "1.0.0"
 serde = {version = "1.0.147", features = ["derive", "rc"]}
-smallvec = "1.6.0"
 static_assertions = "1.1.0"
 stc_arc_cow = {path = "../stc_arc_cow"}
 stc_ts_ast_rnode = {path = "../stc_ts_ast_rnode"}

--- a/crates/stc_ts_types/src/id.rs
+++ b/crates/stc_ts_types/src/id.rs
@@ -27,8 +27,8 @@ impl Id {
         &self.sym
     }
 
-    pub fn ctxt(&self) -> &SyntaxContext {
-        &self.ctxt
+    pub const fn ctxt(&self) -> SyntaxContext {
+        self.ctxt
     }
 
     pub fn sym(&self) -> &JsWord {

--- a/crates/stc_ts_types/src/name.rs
+++ b/crates/stc_ts_types/src/name.rs
@@ -44,6 +44,10 @@ impl Name {
     pub fn inner(&self) -> (&Id, &[JsWord]) {
         (&self.0, &self.1)
     }
+
+    pub fn last(&self) -> &JsWord {
+        self.1.last().unwrap_or_else(|| self.0.sym())
+    }
 }
 
 impl Debug for Name {

--- a/crates/stc_ts_types/src/name.rs
+++ b/crates/stc_ts_types/src/name.rs
@@ -13,15 +13,13 @@ use swc_common::{iter::IdentifyLast, SyntaxContext};
 
 use crate::Id;
 
-type Inner = SmallVec<[Id; 4]>;
-
 /// Efficient alternative for names with variable length like `foo.bar.baz.qux`.
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct Name(Inner);
+pub struct Name(Id, Vec<JsWord>);
 
 impl Name {
     pub fn new(name: JsWord, ctxt: SyntaxContext) -> Self {
-        Self(smallvec![Id::new(name, ctxt)])
+        Self(Id::new(name, ctxt), vec![])
     }
 
     pub fn get_ctxt(&self) -> SyntaxContext {

--- a/crates/stc_ts_types/src/name.rs
+++ b/crates/stc_ts_types/src/name.rs
@@ -23,15 +23,15 @@ impl Name {
     }
 
     pub fn get_ctxt(&self) -> SyntaxContext {
-        *self.0[0].ctxt()
+        *self.0.ctxt()
     }
 
     pub fn push(&mut self, sym: JsWord) {
-        self.0.push(Id::word(sym))
+        self.1.push(Id::word(sym))
     }
 
     pub fn top(&self) -> Id {
-        self.0[0].clone()
+        self.0.clone()
     }
 
     #[allow(clippy::len_without_is_empty)]

--- a/crates/stc_ts_types/src/name.rs
+++ b/crates/stc_ts_types/src/name.rs
@@ -48,6 +48,12 @@ impl Name {
     pub fn last(&self) -> &JsWord {
         self.1.last().unwrap_or_else(|| self.0.sym())
     }
+
+    pub fn slice_to(&self, end: usize) -> Name {
+        let mut v = self.1.clone();
+        v.truncate(end - 1);
+        Name(self.0.clone(), v)
+    }
 }
 
 impl Debug for Name {

--- a/crates/stc_ts_types/src/name.rs
+++ b/crates/stc_ts_types/src/name.rs
@@ -33,12 +33,15 @@ impl Name {
         self.0.clone()
     }
 
-    #[allow(clippy::len_without_is_empty)]
     pub fn len(&self) -> usize {
         self.1.len() + 1
     }
 
-    pub fn as_ids(&self) -> (&Id, &[JsWord]) {
+    pub const fn is_empty(&self) -> bool {
+        false
+    }
+
+    pub fn inner(&self) -> (&Id, &[JsWord]) {
         (&self.0, &self.1)
     }
 }

--- a/crates/stc_ts_types/src/name.rs
+++ b/crates/stc_ts_types/src/name.rs
@@ -3,7 +3,6 @@ use std::{
     fmt::{self, Debug, Formatter},
 };
 
-use smallvec::{smallvec, SmallVec};
 use stc_ts_ast_rnode::{
     RComputedPropName, RExpr, RIdent, RLit, RMemberExpr, RMemberProp, ROptChainBase, ROptChainExpr, RParenExpr, RThisExpr, RTsEntityName,
     RTsThisType, RTsThisTypeOrIdent,
@@ -22,12 +21,12 @@ impl Name {
         Self(Id::new(name, ctxt), vec![])
     }
 
-    pub fn get_ctxt(&self) -> SyntaxContext {
-        *self.0.ctxt()
+    pub const fn get_ctxt(&self) -> SyntaxContext {
+        self.0.ctxt()
     }
 
     pub fn push(&mut self, sym: JsWord) {
-        self.1.push(Id::word(sym))
+        self.1.push(sym)
     }
 
     pub fn top(&self) -> Id {
@@ -36,22 +35,21 @@ impl Name {
 
     #[allow(clippy::len_without_is_empty)]
     pub fn len(&self) -> usize {
-        self.0.len()
+        self.1.len() + 1
     }
 
-    pub fn as_ids(&self) -> &[Id] {
-        &self.0
+    pub fn as_ids(&self) -> (&Id, &[JsWord]) {
+        (&self.0, &self.1)
     }
 }
 
 impl Debug for Name {
     #[cold]
     fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), fmt::Error> {
-        for (last, s) in self.0.iter().identify_last() {
-            write!(f, "{}", s)?;
-            if !last {
-                write!(f, ".")?;
-            }
+        write!(f, "{}", self.0)?;
+
+        for s in self.1.iter() {
+            write!(f, ".{}", s)?;
         }
 
         Ok(())


### PR DESCRIPTION
**Description:**

This PR reduces memory usage of `Name` and optimizes for cases where the `Name` consists of a single `Id`.