### PR TITLE
feat: Add type facts for LHS of `instanceof`

### DIFF
--- a/crates/stc_ts_file_analyzer/src/analyzer/expr/bin.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/expr/bin.rs
@@ -532,10 +532,8 @@ impl Analyzer<'_, '_> {
             }
 
             op!("instanceof") => {
-                dbg!("instanceof");
                 if !self.is_builtin {
                     if let Ok(name) = Name::try_from(&**left) {
-                        dbg!(&name);
                         // typeGuardsTypeParameters.ts says
                         //
                         // Type guards involving type parameters produce intersection types
@@ -556,7 +554,6 @@ impl Analyzer<'_, '_> {
                         let ty = self.validate_rhs_of_instanceof(span, &rt, rt.clone());
 
                         for len in 1..=name.len() {
-                            dbg!(name.slice_to(len));
                             *self.cur_facts.true_facts.facts.entry(name.slice_to(len)).or_default() |=
                                 TypeFacts::NENull & TypeFacts::NEUndefined & TypeFacts::NEUndefinedOrNull;
                         }
@@ -608,8 +605,6 @@ impl Analyzer<'_, '_> {
                                 self.cur_facts.false_facts.excludes.entry(name).or_default().push(filtered_ty);
                             }
                         }
-                    } else {
-                        dbg!(&**left);
                     }
                 }
             }

--- a/crates/stc_ts_file_analyzer/src/analyzer/expr/bin.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/expr/bin.rs
@@ -44,6 +44,12 @@ use crate::{
 #[validator]
 impl Analyzer<'_, '_> {
     fn validate(&mut self, e: &RBinExpr, type_ann: Option<&Type>) -> VResult<Type> {
+        self.validate_bin_expr(e, type_ann)
+    }
+}
+
+impl Analyzer<'_, '_> {
+    fn validate_bin_expr(&mut self, e: &RBinExpr, type_ann: Option<&Type>) -> VResult<Type> {
         let RBinExpr {
             span,
             op,
@@ -980,9 +986,7 @@ impl Analyzer<'_, '_> {
             }
         }
     }
-}
 
-impl Analyzer<'_, '_> {
     fn add_type_facts_for_typeof(&mut self, span: Span, l: &RExpr, r: &RExpr, is_eq: bool, l_ty: &Type, r_ty: &Type) -> VResult<()> {
         if !self.ctx.in_cond {
             return Ok(());

--- a/crates/stc_ts_file_analyzer/src/analyzer/expr/bin.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/expr/bin.rs
@@ -532,8 +532,10 @@ impl Analyzer<'_, '_> {
             }
 
             op!("instanceof") => {
+                dbg!("instanceof");
                 if !self.is_builtin {
                     if let Ok(name) = Name::try_from(&**left) {
+                        dbg!(&name);
                         // typeGuardsTypeParameters.ts says
                         //
                         // Type guards involving type parameters produce intersection types
@@ -552,6 +554,12 @@ impl Analyzer<'_, '_> {
 
                         //
                         let ty = self.validate_rhs_of_instanceof(span, &rt, rt.clone());
+
+                        for len in 1..=name.len() {
+                            dbg!(name.slice_to(len));
+                            *self.cur_facts.true_facts.facts.entry(name.slice_to(len)).or_default() |=
+                                TypeFacts::NENull & TypeFacts::NEUndefined & TypeFacts::NEUndefinedOrNull;
+                        }
 
                         // typeGuardsWithInstanceOfByConstructorSignature.ts
                         //
@@ -600,6 +608,8 @@ impl Analyzer<'_, '_> {
                                 self.cur_facts.false_facts.excludes.entry(name).or_default().push(filtered_ty);
                             }
                         }
+                    } else {
+                        dbg!(&**left);
                     }
                 }
             }

--- a/crates/stc_ts_file_analyzer/src/analyzer/expr/bin.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/expr/bin.rs
@@ -553,6 +553,10 @@ impl Analyzer<'_, '_> {
                         //
                         let ty = self.validate_rhs_of_instanceof(span, &rt, rt.clone());
 
+                        // `o` cannot be null in the following code
+                        // if (o?.baz instanceof Error) {
+                        //     o.baz;
+                        // }
                         for len in 1..=name.len() {
                             *self.cur_facts.true_facts.facts.entry(name.slice_to(len)).or_default() |=
                                 TypeFacts::NENull & TypeFacts::NEUndefined & TypeFacts::NEUndefinedOrNull;

--- a/crates/stc_ts_file_analyzer/src/analyzer/expr/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/expr/mod.rs
@@ -4020,8 +4020,8 @@ impl Analyzer<'_, '_> {
 
         if let TypeOfMode::RValue = type_mode {
             if let Some(name) = &name {
-                if let Some(ty) = self.scope.get_type_from_name(name) {
-                    debug_assert_ne!(ty.span(), DUMMY_SP);
+                if let Some(mut ty) = self.scope.get_type_from_name(name) {
+                    ty.respan(span);
                     return Ok(ty);
                 }
             }

--- a/crates/stc_ts_file_analyzer/src/analyzer/expr/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/expr/mod.rs
@@ -3279,6 +3279,11 @@ impl Analyzer<'_, '_> {
                 .context("tried to get type of a name with len == 1"),
 
             _ => {
+                let ctx = Ctx {
+                    in_opt_chain: true,
+                    ..self.ctx
+                };
+
                 let last_sym = name.last().clone();
 
                 let obj = self
@@ -3286,6 +3291,7 @@ impl Analyzer<'_, '_> {
                     .context("tried to get type of &names[..-1]")?;
 
                 let ty = self
+                    .with_ctx(ctx)
                     .access_property(
                         span,
                         &obj,

--- a/crates/stc_ts_type_checker/tests/conformance/controlFlow/controlFlowOptionalChain.stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/conformance/controlFlow/controlFlowOptionalChain.stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
     required_error: 18,
     matched_error: 43,
-    extra_error: 31,
+    extra_error: 27,
     panic: 0,
 }

--- a/crates/stc_ts_type_checker/tests/tsc-stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/tsc-stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
     required_error: 4185,
     matched_error: 5889,
-    extra_error: 796,
+    extra_error: 792,
     panic: 18,
 }


### PR DESCRIPTION
**Description:**

In the code below, `o` cannot be `null` in the `cons` of the if statement.

```ts
function f21(o: Thing | null) {
    if (o?.baz instanceof Error) {
        o.baz;
    }
}
```