### PR TITLE
refactor: Don't use `tracing::instrument` for large functions

### DIFF
--- a/crates/stc_ts_file_analyzer/src/analyzer/assign/function.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/assign/function.rs
@@ -407,8 +407,13 @@ impl Analyzer<'_, '_> {
     /// a = b;
     /// b = a; // error
     /// ```
-    #[cfg_attr(debug_assertions, tracing::instrument(skip_all))]
     pub(super) fn assign_to_function(&mut self, data: &mut AssignData, lt: &Type, l: &Function, r: &Type, opts: AssignOpts) -> VResult<()> {
+        let _tracing = if cfg!(debug_assertions) {
+            Some(tracing::span!(tracing::Level::ERROR, "assign_to_function").entered())
+        } else {
+            None
+        };
+
         let span = opts.span;
         let r = r.normalize();
 
@@ -512,7 +517,6 @@ impl Analyzer<'_, '_> {
     /// a18 = b18; // ok
     /// b18 = a18; // ok
     /// ```
-    #[cfg_attr(debug_assertions, tracing::instrument(skip_all))]
     pub(super) fn assign_to_constructor(
         &mut self,
         data: &mut AssignData,
@@ -521,6 +525,12 @@ impl Analyzer<'_, '_> {
         r: &Type,
         opts: AssignOpts,
     ) -> VResult<()> {
+        let _tracing = if cfg!(debug_assertions) {
+            Some(tracing::span!(tracing::Level::ERROR, "assign_to_constructor").entered())
+        } else {
+            None
+        };
+
         let span = opts.span;
         let r = r.normalize();
 
@@ -641,8 +651,13 @@ impl Analyzer<'_, '_> {
     /// # Notes
     ///
     ///  - `string` is assignable to `...args: any[]`.
-    #[cfg_attr(debug_assertions, tracing::instrument(skip_all))]
     fn assign_param(&mut self, data: &mut AssignData, l: &FnParam, r: &FnParam, opts: AssignOpts) -> VResult<()> {
+        let _tracing = if cfg!(debug_assertions) {
+            Some(tracing::span!(tracing::Level::ERROR, "assign_param").entered())
+        } else {
+            None
+        };
+
         let span = opts.span;
         debug_assert!(!opts.span.is_dummy(), "Cannot assign function parameters with dummy span");
 
@@ -664,8 +679,13 @@ impl Analyzer<'_, '_> {
     }
 
     /// Implementation of `assign_param`.
-    #[cfg_attr(debug_assertions, tracing::instrument(skip_all))]
     fn assign_param_type(&mut self, data: &mut AssignData, l: &Type, r: &Type, opts: AssignOpts) -> VResult<()> {
+        let _tracing = if cfg!(debug_assertions) {
+            Some(tracing::span!(tracing::Level::ERROR, "assign_param_type").entered())
+        } else {
+            None
+        };
+
         let span = opts.span;
         debug_assert!(!opts.span.is_dummy(), "Cannot assign function parameters with dummy span");
 
@@ -803,8 +823,13 @@ impl Analyzer<'_, '_> {
     /// ```
     ///
     /// So, it's an error if `l.params.len() < r.params.len()`.
-    #[cfg_attr(debug_assertions, tracing::instrument(skip_all))]
     pub(crate) fn assign_params(&mut self, data: &mut AssignData, l: &[FnParam], r: &[FnParam], opts: AssignOpts) -> VResult<()> {
+        let _tracing = if cfg!(debug_assertions) {
+            Some(tracing::span!(tracing::Level::ERROR, "assign_params").entered())
+        } else {
+            None
+        };
+
         let span = opts.span;
 
         let mut li = l.iter().filter(|p| {

--- a/crates/stc_ts_file_analyzer/src/analyzer/assign/function.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/assign/function.rs
@@ -27,7 +27,6 @@ use crate::{
 
 /// Methods to handle assignment to function types and constructor types.
 impl Analyzer<'_, '_> {
-    #[cfg_attr(debug_assertions, tracing::instrument(skip_all))]
     pub(crate) fn assign_to_fn_like(
         &mut self,
         data: &mut AssignData,
@@ -40,6 +39,12 @@ impl Analyzer<'_, '_> {
         r_ret_ty: Option<&Type>,
         opts: AssignOpts,
     ) -> VResult<()> {
+        let _tracing = if cfg!(debug_assertions) {
+            Some(tracing::span!(tracing::Level::ERROR, "assign_to_fn_like").entered())
+        } else {
+            None
+        };
+
         let span = opts.span.with_ctxt(SyntaxContext::empty());
 
         if let Some(r_ret_ty) = r_ret_ty {

--- a/crates/stc_ts_file_analyzer/src/analyzer/assign/type_el.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/assign/type_el.rs
@@ -33,7 +33,6 @@ impl Analyzer<'_, '_> {
     /// let a: A = foo;
     /// let b: { key: string } = foo;
     /// ```
-    #[cfg_attr(debug_assertions, tracing::instrument(skip_all))]
     pub(crate) fn assign_to_type_elements(
         &mut self,
         data: &mut AssignData,
@@ -43,6 +42,12 @@ impl Analyzer<'_, '_> {
         lhs_metadata: TypeLitMetadata,
         opts: AssignOpts,
     ) -> VResult<()> {
+        let _tracing = if cfg!(debug_assertions) {
+            Some(tracing::span!(tracing::Level::ERROR, "assign_to_type_elements").entered())
+        } else {
+            None
+        };
+
         let span = opts.span.with_ctxt(SyntaxContext::empty());
         // debug_assert!(!span.is_dummy());
 

--- a/crates/stc_ts_file_analyzer/src/analyzer/expr/bin.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/expr/bin.rs
@@ -1273,8 +1273,13 @@ impl Analyzer<'_, '_> {
     /// If we apply `instanceof C` to `v`, `v` becomes `T`.
     /// Note that `C extends D` and `D extends C` are true because both of `C`
     /// and `D` are empty classes.
-    #[cfg_attr(debug_assertions, tracing::instrument(skip_all))]
     fn narrow_with_instanceof(&mut self, span: Span, ty: Cow<Type>, orig_ty: &Type) -> VResult<Type> {
+        let _tracing = if cfg!(debug_assertions) {
+            Some(tracing::span!(tracing::Level::ERROR, "narrow_with_instanceof").entered())
+        } else {
+            None
+        };
+
         let mut orig_ty = self.normalize(
             Some(span),
             Cow::Borrowed(orig_ty),

--- a/crates/stc_ts_file_analyzer/src/analyzer/expr/call_new.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/expr/call_new.rs
@@ -956,7 +956,6 @@ impl Analyzer<'_, '_> {
         Ok(candidates)
     }
 
-    #[cfg_attr(debug_assertions, tracing::instrument(skip_all))]
     fn call_property_of_class(
         &mut self,
         span: Span,
@@ -973,6 +972,12 @@ impl Analyzer<'_, '_> {
         type_ann: Option<&Type>,
         opts: CallOpts,
     ) -> VResult<Option<Type>> {
+        let _tracing = if cfg!(debug_assertions) {
+            Some(tracing::span!(tracing::Level::ERROR, "call_property_of_class").entered())
+        } else {
+            None
+        };
+
         let candidates = {
             // TODO(kdy1): Deduplicate.
             // This is duplicated intentionally because of regressions.
@@ -1147,7 +1152,6 @@ impl Analyzer<'_, '_> {
         }
     }
 
-    #[cfg_attr(debug_assertions, tracing::instrument(skip_all))]
     fn call_property_of_type_elements(
         &mut self,
         kind: ExtractKind,
@@ -1163,6 +1167,12 @@ impl Analyzer<'_, '_> {
         type_ann: Option<&Type>,
         opts: CallOpts,
     ) -> VResult<Type> {
+        let _tracing = if cfg!(debug_assertions) {
+            Some(tracing::span!(tracing::Level::ERROR, "call_property_of_type_elements").entered())
+        } else {
+            None
+        };
+
         let span = span.with_ctxt(SyntaxContext::empty());
 
         // Candidates of the method call.
@@ -1775,7 +1785,6 @@ impl Analyzer<'_, '_> {
 
     /// Search for members and returns if there's a match
     #[inline(never)]
-    #[cfg_attr(debug_assertions, tracing::instrument(skip_all))]
     fn call_type_element(
         &mut self,
         span: Span,
@@ -1790,6 +1799,12 @@ impl Analyzer<'_, '_> {
         type_args: Option<&TypeParamInstantiation>,
         type_ann: Option<&Type>,
     ) -> VResult<Type> {
+        let _tracing = if cfg!(debug_assertions) {
+            Some(tracing::span!(tracing::Level::ERROR, "call_type_element").entered())
+        } else {
+            None
+        };
+
         let callee_span = callee_ty.span();
 
         let candidates = members
@@ -2289,7 +2304,6 @@ impl Analyzer<'_, '_> {
     }
 
     /// Returns [None] if nothing matched.
-    #[cfg_attr(not(debug_assertions), tracing::instrument(skip_all))]
     fn select_and_invoke(
         &mut self,
         span: Span,
@@ -2303,6 +2317,12 @@ impl Analyzer<'_, '_> {
         type_ann: Option<&Type>,
         opts: SelectOpts,
     ) -> VResult<Option<Type>> {
+        let _tracing = if cfg!(debug_assertions) {
+            Some(tracing::span!(tracing::Level::ERROR, "select_and_invoke").entered())
+        } else {
+            None
+        };
+
         let span = span.with_ctxt(SyntaxContext::empty());
 
         let mut callable = candidates

--- a/crates/stc_ts_file_analyzer/src/analyzer/expr/call_new.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/expr/call_new.rs
@@ -2405,7 +2405,6 @@ impl Analyzer<'_, '_> {
     ///  8. Type of the arrow function is `(a: number) => [number]`.
     ///  9. Type of the property `foo` is `<A, B>(a: A) => B` where A = `number`
     /// and B = `[number]`.
-    #[cfg_attr(debug_assertions, tracing::instrument(skip_all))]
     fn get_return_type(
         &mut self,
         span: Span,
@@ -2420,6 +2419,12 @@ impl Analyzer<'_, '_> {
         spread_arg_types: &[TypeOrSpread],
         type_ann: Option<&Type>,
     ) -> VResult<Type> {
+        let _tracing = if cfg!(debug_assertions) {
+            Some(tracing::span!(tracing::Level::ERROR, "get_return_type").entered())
+        } else {
+            None
+        };
+
         let span = span.with_ctxt(SyntaxContext::empty());
 
         // TODO(kdy1): Optimize by skipping clone if `this type` is not used.

--- a/crates/stc_ts_file_analyzer/src/analyzer/expr/call_new.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/expr/call_new.rs
@@ -3207,8 +3207,13 @@ impl Analyzer<'_, '_> {
         }
     }
 
-    #[cfg_attr(debug_assertions, tracing::instrument(skip_all))]
     fn narrow_with_predicate(&mut self, span: Span, orig_ty: &Type, new_ty: Type) -> VResult<Type> {
+        let _tracing = if cfg!(debug_assertions) {
+            Some(tracing::span!(tracing::Level::ERROR, "narrow_with_predicate").entered())
+        } else {
+            None
+        };
+
         let span = span.with_ctxt(SyntaxContext::empty());
 
         let orig_ty = self
@@ -3344,8 +3349,13 @@ impl Analyzer<'_, '_> {
         Ok(())
     }
 
-    #[cfg_attr(debug_assertions, tracing::instrument(skip_all))]
     fn is_subtype_in_fn_call(&mut self, span: Span, arg: &Type, param: &Type) -> bool {
+        let _tracing = if cfg!(debug_assertions) {
+            Some(tracing::span!(tracing::Level::ERROR, "is_subtype_in_fn_call").entered())
+        } else {
+            None
+        };
+
         if arg.type_eq(param) {
             return true;
         }
@@ -3369,7 +3379,6 @@ impl Analyzer<'_, '_> {
     /// `anyAssignabilityInInheritance.ts` says `any, not a subtype of number so
     /// it skips that overload, is a subtype of itself so it picks second (if
     /// truly ambiguous it would pick first overload)`
-    #[cfg_attr(debug_assertions, tracing::instrument(skip_all))]
     fn check_call_args(
         &mut self,
         span: Span,
@@ -3380,6 +3389,12 @@ impl Analyzer<'_, '_> {
         arg_types: &[TypeOrSpread],
         spread_arg_types: &[TypeOrSpread],
     ) -> ArgCheckResult {
+        let _tracing = if cfg!(debug_assertions) {
+            Some(tracing::span!(tracing::Level::ERROR, "check_call_args").entered())
+        } else {
+            None
+        };
+
         if self.validate_type_args_count(span, type_params, type_args).is_err() {
             return ArgCheckResult::WrongArgCount;
         }

--- a/crates/stc_ts_file_analyzer/src/analyzer/expr/call_new.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/expr/call_new.rs
@@ -220,7 +220,6 @@ impl Analyzer<'_, '_> {
     /// Calculates the return type of a new /call expression.
     ///
     /// This method check arguments
-    #[cfg_attr(debug_assertions, tracing::instrument(skip_all))]
     fn extract_call_new_expr_member(
         &mut self,
         span: Span,
@@ -231,6 +230,12 @@ impl Analyzer<'_, '_> {
         type_args: Option<&RTsTypeParamInstantiation>,
         type_ann: Option<&Type>,
     ) -> VResult<Type> {
+        let _tracing = if cfg!(debug_assertions) {
+            Some(tracing::span!(tracing::Level::ERROR, "extract_call_new_expr_member").entered())
+        } else {
+            None
+        };
+
         debug_assert_eq!(self.scope.kind(), ScopeKind::Call);
 
         let marks = self.marks();
@@ -528,7 +533,6 @@ impl Analyzer<'_, '_> {
     ///
     ///  - `expr`: Can be default if argument does not include an arrow
     ///    expression nor a function expression.
-    #[cfg_attr(debug_assertions, tracing::instrument(skip_all))]
     pub(super) fn call_property(
         &mut self,
         span: Span,
@@ -544,6 +548,12 @@ impl Analyzer<'_, '_> {
         type_ann: Option<&Type>,
         opts: CallOpts,
     ) -> VResult<Type> {
+        let _tracing = if cfg!(debug_assertions) {
+            Some(tracing::span!(tracing::Level::ERROR, "call_property").entered())
+        } else {
+            None
+        };
+
         obj_type.assert_valid();
 
         let span = span.with_ctxt(SyntaxContext::empty());

--- a/crates/stc_ts_file_analyzer/src/analyzer/expr/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/expr/mod.rs
@@ -635,8 +635,13 @@ impl Analyzer<'_, '_> {
         true
     }
 
-    #[cfg_attr(debug_assertions, tracing::instrument(skip_all))]
     pub(crate) fn validate_key(&mut self, prop: &RExpr, computed: bool) -> VResult<Key> {
+        let _tracing = if cfg!(debug_assertions) {
+            Some(tracing::span!(tracing::Level::ERROR, "validate_key").entered())
+        } else {
+            None
+        };
+
         if computed {
             prop.validate_with_default(self)
                 .and_then(|ty| {
@@ -683,8 +688,13 @@ impl Analyzer<'_, '_> {
     /// # Parameters
     ///
     /// - `declared`: Key of declared property.
-    #[cfg_attr(debug_assertions, tracing::instrument(skip_all))]
     pub(crate) fn key_matches(&mut self, span: Span, declared: &Key, cur: &Key, allow_union: bool) -> bool {
+        let _tracing = if cfg!(debug_assertions) {
+            Some(tracing::span!(tracing::Level::ERROR, "key_matches").entered())
+        } else {
+            None
+        };
+
         match declared {
             Key::Computed(..) => {}
             _ => {
@@ -809,7 +819,6 @@ impl Analyzer<'_, '_> {
         false
     }
 
-    #[cfg_attr(debug_assertions, tracing::instrument(skip_all))]
     fn access_property_of_type_elements(
         &mut self,
         span: Span,
@@ -819,6 +828,12 @@ impl Analyzer<'_, '_> {
         members: &[TypeElement],
         opts: AccessPropertyOpts,
     ) -> VResult<Option<Type>> {
+        let _tracing = if cfg!(debug_assertions) {
+            Some(tracing::span!(tracing::Level::ERROR, "access_property_of_type_elements").entered())
+        } else {
+            None
+        };
+
         let mut matching_elements = vec![];
         let mut read_only_flag = false;
         for el in members.iter() {
@@ -3206,8 +3221,13 @@ impl Analyzer<'_, '_> {
     }
 
     /// Expand type parameters using `type_args`.
-    #[cfg_attr(debug_assertions, tracing::instrument(skip_all))]
     pub(crate) fn expand_generics_with_type_args(&mut self, span: Span, ty: Type, type_args: &TypeParamInstantiation) -> VResult<Type> {
+        let _tracing = if cfg!(debug_assertions) {
+            Some(tracing::span!(tracing::Level::ERROR, "expand_generics_with_type_args").entered())
+        } else {
+            None
+        };
+
         match ty.normalize() {
             Type::Interface(Interface { type_params, body, .. }) => {
                 let mut params = HashMap::default();
@@ -3260,7 +3280,6 @@ impl Analyzer<'_, '_> {
         Ok(ty)
     }
 
-    #[cfg_attr(debug_assertions, tracing::instrument(skip_all))]
     pub(super) fn type_of_name(
         &mut self,
         span: Span,
@@ -3268,6 +3287,12 @@ impl Analyzer<'_, '_> {
         type_mode: TypeOfMode,
         type_args: Option<&TypeParamInstantiation>,
     ) -> VResult<Type> {
+        let _tracing = if cfg!(debug_assertions) {
+            Some(tracing::span!(tracing::Level::ERROR, "type_of_name").entered())
+        } else {
+            None
+        };
+
         assert!(!name.is_empty(), "Cannot determine type of empty name");
 
         let (top, symbols) = name.inner();
@@ -3313,8 +3338,13 @@ impl Analyzer<'_, '_> {
     }
 
     /// Returned type reflects conditional type facts.
-    #[cfg_attr(debug_assertions, tracing::instrument(skip_all))]
     pub(super) fn type_of_var(&mut self, i: &RIdent, type_mode: TypeOfMode, type_args: Option<&TypeParamInstantiation>) -> VResult<Type> {
+        let _tracing = if cfg!(debug_assertions) {
+            Some(tracing::span!(tracing::Level::ERROR, "type_of_var").entered())
+        } else {
+            None
+        };
+
         let span = i.span();
         let id: Id = i.into();
         let name: Name = i.into();
@@ -3820,8 +3850,13 @@ impl Analyzer<'_, '_> {
         self.type_of_ts_entity_name_inner(span, n, type_args)
     }
 
-    #[cfg_attr(debug_assertions, tracing::instrument(skip_all))]
     fn type_of_ts_entity_name_inner(&mut self, span: Span, n: &RExpr, type_args: Option<&TypeParamInstantiation>) -> VResult<Type> {
+        let _tracing = if cfg!(debug_assertions) {
+            Some(tracing::span!(tracing::Level::ERROR, "type_of_ts_entity_name_inner").entered())
+        } else {
+            None
+        };
+
         let span = span.with_ctxt(SyntaxContext::empty());
         {
             let res = self.report_error_for_unresolved_type(span, n, type_args);

--- a/crates/stc_ts_file_analyzer/src/analyzer/expr/object.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/expr/object.rs
@@ -57,8 +57,13 @@ impl Analyzer<'_, '_> {
     ///
     /// Type of `a` in the code above is `{ a: number, b?: undefined } | {
     /// a:number, b: string }`.
-    #[cfg_attr(debug_assertions, tracing::instrument(skip_all))]
     pub(super) fn normalize_union(&mut self, ty: &mut Type, preserve_specified: bool) {
+        let _tracing = if cfg!(debug_assertions) {
+            Some(tracing::span!(tracing::Level::ERROR, "normalize_union").entered())
+        } else {
+            None
+        };
+
         let start = Instant::now();
         ty.visit_mut_with(&mut ObjectUnionNormalizer { preserve_specified });
 
@@ -100,7 +105,6 @@ impl Analyzer<'_, '_> {
         }
     }
 
-    #[cfg_attr(debug_assertions, tracing::instrument(skip_all))]
     fn append_prop_or_spread_to_type(
         &mut self,
         known_keys: &mut Vec<Key>,
@@ -108,6 +112,12 @@ impl Analyzer<'_, '_> {
         prop: &RPropOrSpread,
         object_type: Option<&Type>,
     ) -> VResult<Type> {
+        let _tracing = if cfg!(debug_assertions) {
+            Some(tracing::span!(tracing::Level::ERROR, "append_prop_or_spread_to_type").entered())
+        } else {
+            None
+        };
+
         match prop {
             RPropOrSpread::Spread(RSpreadElement { dot3_token, expr, .. }) => {
                 let prop_ty: Type = expr.validate_with_default(self)?.freezed();
@@ -178,8 +188,13 @@ impl Analyzer<'_, '_> {
     ///
     /// `{ a: number } + ( {b: number} | { c: number } )` => `{ a: number, b:
     /// number } | { a: number, c: number }`
-    #[cfg_attr(debug_assertions, tracing::instrument(skip_all))]
     pub(crate) fn append_type(&mut self, span: Span, to: Type, rhs: Type, opts: AppendTypeOpts) -> VResult<Type> {
+        let _tracing = if cfg!(debug_assertions) {
+            Some(tracing::span!(tracing::Level::ERROR, "append_type").entered())
+        } else {
+            None
+        };
+
         if to.is_any() || to.is_unknown() {
             return Ok(to);
         }
@@ -312,8 +327,13 @@ impl Analyzer<'_, '_> {
         Ok(Type::new_intersection(span, vec![to, rhs]))
     }
 
-    #[cfg_attr(debug_assertions, tracing::instrument(skip_all))]
     pub(crate) fn append_type_element(&mut self, to: Type, rhs: TypeElement) -> VResult<Type> {
+        let _tracing = if cfg!(debug_assertions) {
+            Some(tracing::span!(tracing::Level::ERROR, "append_type_element").entered())
+        } else {
+            None
+        };
+
         if to.is_any() || to.is_unknown() {
             return Ok(to);
         }

--- a/crates/stc_ts_file_analyzer/src/analyzer/expr/type_cast.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/expr/type_cast.rs
@@ -206,8 +206,13 @@ impl Analyzer<'_, '_> {
             .convert_err(|err| ErrorKind::NonOverlappingTypeCast { span })
     }
 
-    #[cfg_attr(debug_assertions, tracing::instrument(skip_all))]
     pub(crate) fn has_overlap(&mut self, span: Span, l: &Type, r: &Type, opts: CastableOpts) -> VResult<bool> {
+        let _tracing = if cfg!(debug_assertions) {
+            Some(tracing::span!(tracing::Level::ERROR, "has_overlap").entered())
+        } else {
+            None
+        };
+
         let l = l.normalize();
         let r = r.normalize();
 
@@ -222,8 +227,13 @@ impl Analyzer<'_, '_> {
     ///
     /// - `l`: from
     /// - `r`: to
-    #[cfg_attr(debug_assertions, tracing::instrument(skip_all))]
     pub(crate) fn castable(&mut self, span: Span, from: &Type, to: &Type, opts: CastableOpts) -> VResult<bool> {
+        let _tracing = if cfg!(debug_assertions) {
+            Some(tracing::span!(tracing::Level::ERROR, "castable").entered())
+        } else {
+            None
+        };
+
         let from = self
             .normalize(
                 Some(span),

--- a/crates/stc_ts_file_analyzer/src/analyzer/generic/expander.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/generic/expander.rs
@@ -113,8 +113,13 @@ impl Analyzer<'_, '_> {
     }
 
     /// Returns `Some(true)` if `child` extends `parent`.
-    #[cfg_attr(debug_assertions, tracing::instrument(skip_all))]
     pub(crate) fn extends(&mut self, span: Span, child: &Type, parent: &Type, opts: ExtendsOpts) -> Option<bool> {
+        let _tracing = if cfg!(debug_assertions) {
+            Some(tracing::span!(tracing::Level::ERROR, "extends").entered())
+        } else {
+            None
+        };
+
         let child = child.normalize();
         let parent = parent.normalize();
 

--- a/crates/stc_ts_file_analyzer/src/analyzer/generic/inference.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/generic/inference.rs
@@ -199,7 +199,6 @@ impl Analyzer<'_, '_> {
     }
 
     /// Ported from `tsc`.
-    #[cfg_attr(debug_assertions, tracing::instrument(skip_all))]
     pub(super) fn infer_type_using_union(
         &mut self,
         span: Span,
@@ -208,6 +207,12 @@ impl Analyzer<'_, '_> {
         arg: &Type,
         opts: InferTypeOpts,
     ) -> VResult<()> {
+        let _tracing = if cfg!(debug_assertions) {
+            Some(tracing::span!(tracing::Level::ERROR, "infer_type_using_union").entered())
+        } else {
+            None
+        };
+
         let (temp_sources, temp_targets) = self.infer_from_matching_types(
             span,
             inferred,

--- a/crates/stc_ts_file_analyzer/src/analyzer/generic/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/generic/mod.rs
@@ -305,7 +305,6 @@ impl Analyzer<'_, '_> {
     }
 
     /// Handles `infer U`.
-    #[cfg_attr(debug_assertions, tracing::instrument(skip_all))]
     pub(super) fn infer_ts_infer_types(
         &mut self,
         span: Span,
@@ -313,6 +312,12 @@ impl Analyzer<'_, '_> {
         concrete: &Type,
         opts: InferTypeOpts,
     ) -> VResult<FxHashMap<Id, Type>> {
+        let _tracing = if cfg!(debug_assertions) {
+            Some(tracing::span!(tracing::Level::ERROR, "infer_ts_infer_types").entered())
+        } else {
+            None
+        };
+
         let mut inferred = InferData::default();
         self.infer_type(span, &mut inferred, base, concrete, opts)?;
         let mut map = self.finalize_inference(span, &[], inferred);

--- a/crates/stc_ts_file_analyzer/src/analyzer/scope/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/scope/mod.rs
@@ -540,7 +540,7 @@ impl Scope<'_> {
     }
 
     /// Add a type to the scope.
-    #[instrument(name = "Scope::register_type", skip(self, name, ty, should_override))]
+    #[instrument(name = "Scope::register_type", skip_all)]
     fn register_type(&mut self, name: Id, ty: Type, should_override: bool) {
         ty.assert_valid();
 

--- a/crates/stc_ts_file_analyzer/src/analyzer/scope/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/scope/mod.rs
@@ -692,8 +692,13 @@ impl Analyzer<'_, '_> {
     ///  - `expand_union` should be true if you are going to use it in
     ///    assignment, and false if you are going to use it in user-visible
     ///    stuffs (e.g. type annotation for .d.ts file)
-    #[cfg_attr(debug_assertions, tracing::instrument(skip_all))]
     pub(super) fn expand(&mut self, span: Span, ty: Type, opts: ExpandOpts) -> VResult<Type> {
+        let _tracing = if cfg!(debug_assertions) {
+            Some(tracing::span!(tracing::Level::ERROR, "expand").entered())
+        } else {
+            None
+        };
+
         if !self.is_builtin {
             debug_assert_ne!(span, DUMMY_SP, "expand: {:#?} cannot be expanded because it has empty span", ty);
         }
@@ -769,8 +774,13 @@ impl Analyzer<'_, '_> {
         }
     }
 
-    #[cfg_attr(debug_assertions, tracing::instrument(skip_all))]
     pub(super) fn register_type(&mut self, name: Id, ty: Type) -> Type {
+        let _tracing = if cfg!(debug_assertions) {
+            Some(tracing::span!(tracing::Level::ERROR, "register_type").entered())
+        } else {
+            None
+        };
+
         if cfg!(debug_assertions) {
             debug!("[({})/types] Registering: {:?}", self.scope.depth(), name);
         }
@@ -1091,8 +1101,13 @@ impl Analyzer<'_, '_> {
         Ok(None)
     }
 
-    #[cfg_attr(debug_assertions, tracing::instrument(skip_all))]
     fn find_local_type(&self, name: &Id) -> Option<ItemRef<Type>> {
+        let _tracing = if cfg!(debug_assertions) {
+            Some(tracing::span!(tracing::Level::ERROR, "find_local_type").entered())
+        } else {
+            None
+        };
+
         #[allow(dead_code)]
         static ANY: Lazy<Type> = Lazy::new(|| {
             Type::Keyword(KeywordType {
@@ -1601,7 +1616,6 @@ impl Analyzer<'_, '_> {
     }
 
     /// TODO(kdy1): Merge with declare_vars_*
-    #[cfg_attr(debug_assertions, tracing::instrument(skip_all))]
     pub fn declare_complex_vars(
         &mut self,
         kind: VarKind,
@@ -1610,6 +1624,12 @@ impl Analyzer<'_, '_> {
         actual_ty: Option<Type>,
         default_ty: Option<Type>,
     ) -> VResult<Option<Type>> {
+        let _tracing = if cfg!(debug_assertions) {
+            Some(tracing::span!(tracing::Level::ERROR, "declare_complex_vars").entered())
+        } else {
+            None
+        };
+
         match pat {
             RPat::Assign(..) | RPat::Ident(..) | RPat::Array(..) | RPat::Object(..) | RPat::Rest(..) => self.add_vars(
                 pat,

--- a/crates/stc_ts_file_analyzer/src/analyzer/scope/vars.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/scope/vars.rs
@@ -892,8 +892,13 @@ impl Analyzer<'_, '_> {
         }
     }
 
-    #[cfg_attr(debug_assertions, tracing::instrument(skip_all))]
     pub(crate) fn exclude_props(&mut self, span: Span, ty: &Type, keys: &[Key]) -> VResult<Type> {
+        let _tracing = if cfg!(debug_assertions) {
+            Some(tracing::span!(tracing::Level::ERROR, "exclude_props").entered())
+        } else {
+            None
+        };
+
         let span = span.with_ctxt(SyntaxContext::empty());
 
         let ty = (|| -> VResult<_> {

--- a/crates/stc_ts_file_analyzer/src/analyzer/stmt/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/stmt/mod.rs
@@ -142,7 +142,7 @@ impl Analyzer<'_, '_> {
 
 impl Analyzer<'_, '_> {
     /// Validate that parent interfaces are all resolved.
-    #[instrument(skip(self, parents))]
+    #[instrument(skip_all)]
     pub(super) fn resolve_parent_interfaces(&mut self, parents: &[RTsExprWithTypeArgs], is_for_interface: bool) {
         if self.is_builtin {
             return;

--- a/crates/stc_ts_file_analyzer/src/analyzer/stmt/return_type.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/stmt/return_type.rs
@@ -16,7 +16,7 @@ use stc_utils::{
 };
 use swc_common::{Span, Spanned, SyntaxContext, TypeEq, DUMMY_SP};
 use swc_ecma_ast::*;
-use tracing::{debug, instrument};
+use tracing::debug;
 
 use crate::{
     analyzer::{
@@ -55,7 +55,6 @@ impl AddAssign for ReturnValues {
 
 impl Analyzer<'_, '_> {
     /// This method returns `Generator` if `yield` is found.
-    #[instrument(skip(self, span, is_async, is_generator, stmts))]
     pub(in crate::analyzer) fn visit_stmts_for_return(
         &mut self,
         span: Span,
@@ -63,6 +62,12 @@ impl Analyzer<'_, '_> {
         is_generator: bool,
         stmts: &Vec<RStmt>,
     ) -> VResult<Option<Type>> {
+        let _tracing = if cfg!(debug_assertions) {
+            Some(tracing::span!(tracing::Level::ERROR, "visit_stmts_for_return").entered())
+        } else {
+            None
+        };
+
         let marks = self.marks();
 
         debug_assert_eq!(span.ctxt, SyntaxContext::empty());

--- a/crates/stc_ts_file_analyzer/src/analyzer/types/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/types/mod.rs
@@ -1479,8 +1479,13 @@ impl Analyzer<'_, '_> {
         }
     }
 
-    #[instrument(skip(self, span, ty))]
     pub(crate) fn can_be_undefined(&mut self, span: Span, ty: &Type, include_null: bool) -> VResult<bool> {
+        let _tracing = if cfg!(debug_assertions) {
+            Some(tracing::span!(tracing::Level::ERROR, "can_be_undefined", include_null = include_null).entered())
+        } else {
+            None
+        };
+
         let ty = self
             .normalize(Some(span), Cow::Borrowed(ty), Default::default())
             .context("tried to normalize to see if it can be undefined")?;
@@ -1524,8 +1529,13 @@ impl Analyzer<'_, '_> {
         })
     }
 
-    #[instrument(skip(self, span, ty))]
     pub(crate) fn expand_type_ann<'a>(&mut self, span: Span, ty: Option<&'a Type>) -> VResult<Option<Cow<'a, Type>>> {
+        let _tracing = if cfg!(debug_assertions) {
+            Some(tracing::span!(tracing::Level::ERROR, "expand_type_ann").entered())
+        } else {
+            None
+        };
+
         let ty = match ty {
             Some(v) => v,
             None => return Ok(None),

--- a/crates/stc_ts_file_analyzer/src/analyzer/types/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/types/mod.rs
@@ -1547,7 +1547,7 @@ impl Analyzer<'_, '_> {
         Ok(Some(ty))
     }
 
-    #[instrument(skip(self, def))]
+    #[instrument(skip_all)]
     pub(crate) fn create_prototype_of_class_def(&mut self, def: &ClassDef) -> VResult<TypeLit> {
         let mut members = vec![];
 
@@ -1602,8 +1602,13 @@ impl Analyzer<'_, '_> {
 
     /// Exclude types from `ty` using type facts with key `name`, for
     /// the current scope.
-    #[instrument(skip(self, span, name, ty))]
     pub(crate) fn exclude_types_using_fact(&mut self, span: Span, name: &Name, ty: &mut Type) {
+        let _tracing = if cfg!(debug_assertions) {
+            Some(tracing::span!(tracing::Level::ERROR, "exclude_types_using_fact").entered())
+        } else {
+            None
+        };
+
         debug_assert!(!span.is_dummy(), "exclude_types should not be called with a dummy span");
 
         let mut types_to_exclude = vec![];
@@ -1623,8 +1628,13 @@ impl Analyzer<'_, '_> {
         debug!("[types/facts] Excluded types: {} => {}", before, after);
     }
 
-    #[instrument(skip(self, name, ty))]
     pub(crate) fn apply_type_facts(&mut self, name: &Name, ty: Type) -> Type {
+        let _tracing = if cfg!(debug_assertions) {
+            Some(tracing::span!(tracing::Level::ERROR, "apply_type_facts", name = tracing::field::debug(name)).entered())
+        } else {
+            None
+        };
+
         let type_facts = self.scope.get_type_facts(name) | self.cur_facts.true_facts.facts.get(name).copied().unwrap_or(TypeFacts::None);
 
         debug!("[types/fact] Facts for {:?} is {:?}", name, type_facts);
@@ -1639,11 +1649,15 @@ impl Analyzer<'_, '_> {
     /// ## excluded
     ///
     /// Members of base class.
-    #[instrument(skip(self, excluded, ty))]
     pub(crate) fn collect_class_members(&mut self, excluded: &[&ClassMember], ty: &Type) -> VResult<Option<Vec<ClassMember>>> {
         if self.is_builtin {
             return Ok(None);
         }
+        let _tracing = if cfg!(debug_assertions) {
+            Some(tracing::span!(tracing::Level::ERROR, "collect_class_members").entered())
+        } else {
+            None
+        };
 
         let ty = ty.normalize();
         match ty {
@@ -2262,7 +2276,6 @@ impl Analyzer<'_, '_> {
         Ok(Type::StringMapping(ty.clone()))
     }
 
-    #[instrument(skip(self, span, type_name, type_args))]
     pub(crate) fn report_error_for_unresolved_type(
         &mut self,
         span: Span,
@@ -2272,6 +2285,12 @@ impl Analyzer<'_, '_> {
         if self.is_builtin {
             return Ok(());
         }
+
+        let _tracing = if cfg!(debug_assertions) {
+            Some(tracing::span!(tracing::Level::ERROR, "report_error_for_unresolved_type").entered())
+        } else {
+            None
+        };
 
         let l = left_of_expr(type_name);
         let l = match l {

--- a/crates/stc_ts_file_analyzer/src/ty/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/ty/mod.rs
@@ -6,12 +6,12 @@ use tracing::instrument;
 pub mod type_facts;
 
 pub trait TypeExt: Into<Type> {
-    #[instrument(skip(self,))]
+    #[instrument(skip_all)]
     fn generalize_lit(self) -> Type {
         self.into().fold_with(&mut LitGeneralizer).fixed()
     }
 
-    #[instrument(skip(self))]
+    #[instrument(skip_all)]
     fn generalize_tuple(self) -> Type {
         self.into().fold_with(&mut TupleToArray)
     }

--- a/crates/stc_ts_file_analyzer/src/util/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/util/mod.rs
@@ -33,7 +33,7 @@ impl ModuleItemOrStmt for RStmt {
 }
 
 /// Check if `ty` stores infer type in it.
-#[instrument(skip(n))]
+#[instrument(skip_all)]
 pub(crate) fn contains_infer_type<T>(n: &T) -> bool
 where
     T: VisitWith<TypeFinder>,

--- a/crates/stc_ts_type_ops/src/generalization/metadata.rs
+++ b/crates/stc_ts_type_ops/src/generalization/metadata.rs
@@ -2,7 +2,7 @@ use stc_ts_types::{replace::replace_type, LitType, Type};
 use stc_ts_utils::MapWithMut;
 use tracing::instrument;
 
-#[instrument(skip(ty))]
+#[instrument(skip_all)]
 pub fn prevent_generalize(ty: &mut Type) {
     replace_type(
         ty,

--- a/crates/stc_ts_type_ops/src/tuple_to_array/metadata.rs
+++ b/crates/stc_ts_type_ops/src/tuple_to_array/metadata.rs
@@ -3,7 +3,7 @@ use stc_ts_utils::MapWithMut;
 use tracing::instrument;
 
 /// TODO(kdy1): Optimize by visiting only tuple types.
-#[instrument(skip(ty))]
+#[instrument(skip_all)]
 pub fn prevent_tuple_to_array(ty: &mut Type) {
     replace_type(
         ty,

--- a/crates/stc_ts_types/src/lib.rs
+++ b/crates/stc_ts_types/src/lib.rs
@@ -2221,7 +2221,7 @@ impl Type {
     }
 
     /// `Type::Static` is normalized.
-    #[instrument(skip(self))]
+    #[instrument(skip_all)]
     pub fn normalize_mut(&mut self) -> &mut Type {
         if let Type::Arc(Freezed { ty }) = self {
             let ty = Arc::make_mut(ty);
@@ -2825,7 +2825,7 @@ impl TypeEq for Accessor {
 }
 
 pub trait Valid: Sized + VisitWith<ValidityChecker> {
-    #[instrument(skip(self))]
+    #[instrument(skip_all)]
     fn is_valid(&self) -> bool {
         let mut v = ValidityChecker { valid: true };
         self.visit_with(&mut v);
@@ -2934,7 +2934,7 @@ macro_rules! impl_freeze {
             }
 
             #[inline]
-            #[instrument(skip(self))]
+            #[instrument(skip_all)]
             fn freeze(&mut self) {
                 self.visit_mut_with(&mut Freezer);
             }

--- a/crates/stc_utils/src/ext.rs
+++ b/crates/stc_utils/src/ext.rs
@@ -40,7 +40,7 @@ impl<T> TypeVecExt for Vec<T>
 where
     T: TypeEq,
 {
-    #[instrument(skip(self))]
+    #[instrument(skip_all)]
     fn dedup_type(&mut self) {
         let mut types: Vec<T> = Vec::with_capacity(self.capacity());
         for ty in self.drain(..) {


### PR DESCRIPTION
**Description:**

rust-analyzer has a limit of the token count of an expanded item, and it results in no autocompletion if the function is large. To workaround it, this PR removes `tracing::instrument` in favor of `tracing::span!().entered()`.