### PR TITLE
refactor: Move type-specific metadata to own types

### DIFF
--- a/crates/stc_ts_file_analyzer/src/analyzer/convert/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/convert/mod.rs
@@ -588,10 +588,7 @@ impl Analyzer<'_, '_> {
             span,
             elems: t.elem_types.validate_with(self)?,
             metadata: TupleMetadata {
-                common: CommonTypeMetadata {
-                    prevent_tuple_to_array: true,
-                    ..Default::default()
-                },
+                prevent_tuple_to_array: true,
                 ..Default::default()
             },
             tracker: Default::default(),

--- a/crates/stc_ts_file_analyzer/src/analyzer/scope/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/scope/mod.rs
@@ -1662,11 +1662,13 @@ impl Analyzer<'_, '_> {
     }
 
     pub(super) fn is_expansion_prevented(&self, ty: &Type) -> bool {
-        if ty.metadata().ignore_no_expand {
-            return false;
-        }
-        if ty.metadata().no_expand {
-            return true;
+        if let Type::Ref(r) = ty.normalize() {
+            if r.metadata.ignore_no_expand {
+                return false;
+            }
+            if r.metadata.no_expand {
+                return true;
+            }
         }
 
         false

--- a/crates/stc_ts_type_ops/src/expansion/mod.rs
+++ b/crates/stc_ts_type_ops/src/expansion/mod.rs
@@ -10,9 +10,9 @@ impl VisitMut<Ref> for ExpansionPreventer {
         ty.visit_mut_children_with(self);
 
         if self.is_for_ignoring {
-            ty.metadata.common.ignore_no_expand = true;
+            ty.metadata.ignore_no_expand = true;
         } else {
-            ty.metadata.common.no_expand = true;
+            ty.metadata.no_expand = true;
         }
     }
 }

--- a/crates/stc_ts_type_ops/src/tuple_normalization.rs
+++ b/crates/stc_ts_type_ops/src/tuple_normalization.rs
@@ -8,7 +8,7 @@ pub fn normalize_tuples(ty: &mut Type) {
         ty,
         |ty| {
             if let Type::Tuple(tuple) = ty.normalize() {
-                if tuple.metadata.common.prevent_tuple_to_array {
+                if tuple.metadata.prevent_tuple_to_array {
                     return false;
                 }
 

--- a/crates/stc_ts_type_ops/src/tuple_to_array/metadata.rs
+++ b/crates/stc_ts_type_ops/src/tuple_to_array/metadata.rs
@@ -10,7 +10,9 @@ pub fn prevent_tuple_to_array(ty: &mut Type) {
         |ty| ty.is_tuple(),
         |ty| {
             let mut ty = ty.take();
-            ty.metadata_mut().prevent_tuple_to_array = true;
+            if let Some(tuple) = ty.as_tuple_mut() {
+                tuple.metadata.prevent_tuple_to_array = true;
+            }
             Some(ty)
         },
     )

--- a/crates/stc_ts_types/src/lib.rs
+++ b/crates/stc_ts_types/src/lib.rs
@@ -281,7 +281,7 @@ impl Clone for Type {
 }
 
 #[cfg(target_pointer_width = "64")]
-assert_eq_size!(Type, [u8; 120]);
+assert_eq_size!(Type, [u8; 112]);
 
 impl TypeEq for Type {
     fn type_eq(&self, other: &Self) -> bool {
@@ -568,7 +568,7 @@ pub struct Instance {
 }
 
 #[cfg(target_pointer_width = "64")]
-assert_eq_size!(Instance, [u8; 40]);
+assert_eq_size!(Instance, [u8; 32]);
 
 #[derive(Debug, Clone, PartialEq, Spanned, EqIgnoreSpan, TypeEq, Visit, Serialize, Deserialize)]
 pub struct LitType {
@@ -581,7 +581,7 @@ pub struct LitType {
 }
 
 #[cfg(target_pointer_width = "64")]
-assert_eq_size!(LitType, [u8; 104]);
+assert_eq_size!(LitType, [u8; 96]);
 
 #[derive(Debug, Clone, PartialEq, Eq, Spanned, EqIgnoreSpan, TypeEq, Visit, Serialize, Deserialize)]
 pub struct KeywordType {
@@ -595,7 +595,7 @@ pub struct KeywordType {
 }
 
 #[cfg(target_pointer_width = "64")]
-assert_eq_size!(KeywordType, [u8; 32]);
+assert_eq_size!(KeywordType, [u8; 28]);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Spanned, EqIgnoreSpan, TypeEq, Visit, Serialize, Deserialize)]
 pub struct Symbol {
@@ -607,7 +607,7 @@ pub struct Symbol {
 }
 
 #[cfg(target_pointer_width = "64")]
-assert_eq_size!(Symbol, [u8; 56]);
+assert_eq_size!(Symbol, [u8; 48]);
 
 /// Type of form `...T` .
 ///
@@ -623,7 +623,7 @@ pub struct RestType {
 }
 
 #[cfg(target_pointer_width = "64")]
-assert_eq_size!(RestType, [u8; 40]);
+assert_eq_size!(RestType, [u8; 32]);
 
 #[derive(Debug, Clone, PartialEq, Spanned, EqIgnoreSpan, TypeEq, Visit, Serialize, Deserialize)]
 pub struct OptionalType {
@@ -635,7 +635,7 @@ pub struct OptionalType {
 }
 
 #[cfg(target_pointer_width = "64")]
-assert_eq_size!(OptionalType, [u8; 40]);
+assert_eq_size!(OptionalType, [u8; 32]);
 
 #[derive(Debug, Clone, PartialEq, Spanned, EqIgnoreSpan, TypeEq, Visit, Serialize, Deserialize)]
 pub struct IndexedAccessType {
@@ -685,7 +685,7 @@ pub struct InferType {
 }
 
 #[cfg(target_pointer_width = "64")]
-assert_eq_size!(InferType, [u8; 96]);
+assert_eq_size!(InferType, [u8; 80]);
 
 impl Debug for InferType {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), fmt::Error> {
@@ -703,7 +703,7 @@ pub struct QueryType {
 }
 
 #[cfg(target_pointer_width = "64")]
-assert_eq_size!(QueryType, [u8; 40]);
+assert_eq_size!(QueryType, [u8; 32]);
 
 #[derive(Debug, Clone, PartialEq, Spanned, FromVariant, EqIgnoreSpan, TypeEq, Visit, Serialize, Deserialize)]
 pub enum QueryExpr {
@@ -724,7 +724,7 @@ pub struct ImportType {
 }
 
 #[cfg(target_pointer_width = "64")]
-assert_eq_size!(ImportType, [u8; 104]);
+assert_eq_size!(ImportType, [u8; 96]);
 
 #[derive(Debug, Clone, PartialEq, Spanned, EqIgnoreSpan, TypeEq, Visit, Serialize, Deserialize)]
 pub struct Namespace {
@@ -748,7 +748,7 @@ pub struct Module {
 }
 
 #[cfg(target_pointer_width = "64")]
-assert_eq_size!(Module, [u8; 80]);
+assert_eq_size!(Module, [u8; 72]);
 
 /// Enum **definition**.
 #[derive(Debug, Clone, PartialEq, Spanned, EqIgnoreSpan, TypeEq, Visit, Serialize, Deserialize)]
@@ -789,7 +789,7 @@ pub struct Class {
 }
 
 #[cfg(target_pointer_width = "64")]
-assert_eq_size!(Class, [u8; 40]);
+assert_eq_size!(Class, [u8; 32]);
 
 #[derive(Debug, Clone, PartialEq, Spanned, EqIgnoreSpan, TypeEq, Visit, Serialize, Deserialize)]
 pub struct ClassDef {
@@ -877,7 +877,7 @@ pub struct Mapped {
 }
 
 #[cfg(target_pointer_width = "64")]
-assert_eq_size!(Mapped, [u8; 112]);
+assert_eq_size!(Mapped, [u8; 104]);
 
 #[derive(Clone, PartialEq, Spanned, EqIgnoreSpan, TypeEq, Visit, Serialize, Deserialize)]
 pub struct Conditional {
@@ -892,7 +892,7 @@ pub struct Conditional {
 }
 
 #[cfg(target_pointer_width = "64")]
-assert_eq_size!(Conditional, [u8; 64]);
+assert_eq_size!(Conditional, [u8; 56]);
 
 impl Debug for Conditional {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
@@ -972,7 +972,7 @@ pub struct Alias {
 }
 
 #[cfg(target_pointer_width = "64")]
-assert_eq_size!(Alias, [u8; 48]);
+assert_eq_size!(Alias, [u8; 40]);
 
 #[derive(Debug, Clone, PartialEq, Spanned, EqIgnoreSpan, TypeEq, Visit, Serialize, Deserialize)]
 pub struct Interface {
@@ -987,7 +987,7 @@ pub struct Interface {
 }
 
 #[cfg(target_pointer_width = "64")]
-assert_eq_size!(Interface, [u8; 104]);
+assert_eq_size!(Interface, [u8; 96]);
 
 #[derive(Debug, Clone, PartialEq, Spanned, EqIgnoreSpan, TypeEq, Visit, Serialize, Deserialize)]
 pub struct TypeLit {
@@ -1160,7 +1160,7 @@ pub struct Array {
 }
 
 #[cfg(target_pointer_width = "64")]
-assert_eq_size!(Array, [u8; 40]);
+assert_eq_size!(Array, [u8; 32]);
 
 /// a | b
 #[derive(Clone, PartialEq, Spanned, EqIgnoreSpan, TypeEq, Visit, Serialize, Deserialize)]
@@ -1173,7 +1173,7 @@ pub struct Union {
 }
 
 #[cfg(target_pointer_width = "64")]
-assert_eq_size!(Union, [u8; 56]);
+assert_eq_size!(Union, [u8; 48]);
 
 impl Debug for Union {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -1222,7 +1222,7 @@ pub struct Intersection {
 }
 
 #[cfg(target_pointer_width = "64")]
-assert_eq_size!(Intersection, [u8; 56]);
+assert_eq_size!(Intersection, [u8; 48]);
 
 impl Debug for Intersection {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -1276,7 +1276,7 @@ pub struct EnumVariant {
 }
 
 #[cfg(target_pointer_width = "64")]
-assert_eq_size!(EnumVariant, [u8; 56]);
+assert_eq_size!(EnumVariant, [u8; 48]);
 
 #[derive(Debug, Clone, PartialEq, Spanned, EqIgnoreSpan, TypeEq, Visit, Serialize, Deserialize)]
 pub struct Function {
@@ -1290,7 +1290,7 @@ pub struct Function {
 }
 
 #[cfg(target_pointer_width = "64")]
-assert_eq_size!(Function, [u8; 104]);
+assert_eq_size!(Function, [u8; 96]);
 
 #[derive(Debug, Clone, PartialEq, Spanned, EqIgnoreSpan, TypeEq, Visit, Serialize, Deserialize)]
 pub struct Constructor {
@@ -2697,7 +2697,7 @@ pub struct StaticThis {
 }
 
 #[cfg(target_pointer_width = "64")]
-assert_eq_size!(StaticThis, [u8; 28]);
+assert_eq_size!(StaticThis, [u8; 24]);
 
 #[derive(Debug, Clone, PartialEq, Eq, Spanned, EqIgnoreSpan, TypeEq, Visit, Serialize, Deserialize)]
 pub struct ThisType {
@@ -2708,7 +2708,7 @@ pub struct ThisType {
 }
 
 #[cfg(target_pointer_width = "64")]
-assert_eq_size!(ThisType, [u8; 28]);
+assert_eq_size!(ThisType, [u8; 24]);
 
 #[derive(Debug, Clone, PartialEq, Spanned, EqIgnoreSpan, TypeEq, Visit, Serialize, Deserialize)]
 pub struct TplType {
@@ -2748,7 +2748,7 @@ impl From<RTplElement> for TplElem {
 }
 
 #[cfg(target_pointer_width = "64")]
-assert_eq_size!(TplType, [u8; 80]);
+assert_eq_size!(TplType, [u8; 72]);
 
 #[derive(Debug, Clone, PartialEq, EqIgnoreSpan, TypeEq, Serialize, Deserialize)]
 pub struct Freezed {

--- a/crates/stc_ts_types/src/metadata.rs
+++ b/crates/stc_ts_types/src/metadata.rs
@@ -83,11 +83,6 @@ pub struct CommonTypeMetadata {
 
     pub prevent_converting_to_children: bool,
 
-    /// This can be ignored based on the context.
-    pub no_expand: bool,
-    /// This can be ignored based on the context.
-    pub ignore_no_expand: bool,
-
     pub contains_infer_type: bool,
 
     /// If this mark is applied, type will not be inferred (based on constraint)
@@ -226,6 +221,11 @@ impl_traits!(IndexedAccessTypeMetadata);
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct RefMetadata {
+    /// This can be ignored based on the context.
+    pub no_expand: bool,
+    /// This can be ignored based on the context.
+    pub ignore_no_expand: bool,
+
     pub common: CommonTypeMetadata,
 }
 

--- a/crates/stc_ts_types/src/metadata.rs
+++ b/crates/stc_ts_types/src/metadata.rs
@@ -105,9 +105,6 @@ pub struct CommonTypeMetadata {
     /// generalized.
     pub prevent_generalization: bool,
 
-    /// TODO(kdy1): Move this to [TupleMetadata]
-    pub prevent_tuple_to_array: bool,
-
     pub destructure_key: DestructureId,
 }
 
@@ -143,6 +140,8 @@ impl_traits!(LitTypeMetadata);
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct TupleMetadata {
+    pub prevent_tuple_to_array: bool,
+
     pub common: CommonTypeMetadata,
 }
 


### PR DESCRIPTION
**Description:**

 - Moved `prevent_tuple_to_array` to `TupleMetadata` from `CommonMetadata`.
 - Moved `no_expand` to `RefMetadata` from `CommonMetadata`.
 - Moved `ignore_no_expand` to `RefMetadata` from `CommonMetadata`.