### PR TITLE
Misc(.gitignore/analyzer): ignore typescript from scripts/check.sh

### DIFF
--- a/crates/stc_ts_type_checker/.gitignore
+++ b/crates/stc_ts_type_checker/.gitignore
@@ -3,3 +3,4 @@ tests/success.txt
 tests/done_sorted.txt
 
 tests/wip-stats.rust-debug
+typescript


### PR DESCRIPTION
**Description:**

If you run it for some reason, the file will be created.
But it's so big and beautiful that I can't put my git in it.
Ignore it because it is not a useful file.
