### PR TITLE
feat: Improve handling of deep type guards

### DIFF
--- a/crates/stc_ts_file_analyzer/src/analyzer/expr/function.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/expr/function.rs
@@ -200,6 +200,19 @@ impl Analyzer<'_, '_> {
                             });
                         }
                     }
+                    ty @ Type::Ref(..) => {
+                        let ty = self.normalize(Some(span), Cow::Borrowed(ty), Default::default());
+                        if let Ok(ty) = ty {
+                            if let ty @ Type::Union(..) = ty.normalize() {
+                                temp_els.push(TupleElement {
+                                    span: param.span,
+                                    label: None,
+                                    ty: Box::new(ty.clone().freezed()),
+                                    tracker: Default::default(),
+                                });
+                            }
+                        }
+                    }
                     _ => {}
                 }
             }

--- a/crates/stc_ts_file_analyzer/tests/pass/controlFlow/dependentDestructuredVariables/5.swc-stderr
+++ b/crates/stc_ts_file_analyzer/tests/pass/controlFlow/dependentDestructuredVariables/5.swc-stderr
@@ -1,0 +1,188 @@
+
+  x Type
+   ,-[$DIR/tests/pass/controlFlow/dependentDestructuredVariables/5.ts:8:3]
+ 8 | switch (op) {
+   :         ^^
+   `----
+
+Error: 
+  > ("add" | "concat")
+
+  x Type
+   ,-[$DIR/tests/pass/controlFlow/dependentDestructuredVariables/5.ts:9:5]
+ 9 | case "add":
+   :      ^^^^^
+   `----
+
+Error: 
+  > boolean
+
+  x Type
+    ,-[$DIR/tests/pass/controlFlow/dependentDestructuredVariables/5.ts:10:7]
+ 10 | console.log(args.a + args.b);
+    : ^^^^^^^
+    `----
+
+Error: 
+  > Console
+
+  x Type
+    ,-[$DIR/tests/pass/controlFlow/dependentDestructuredVariables/5.ts:10:7]
+ 10 | console.log(args.a + args.b);
+    :             ^^^^
+    `----
+
+Error: 
+  > {
+  |     a: number;
+  |     b: number;
+  | }
+
+  x Type
+    ,-[$DIR/tests/pass/controlFlow/dependentDestructuredVariables/5.ts:10:7]
+ 10 | console.log(args.a + args.b);
+    :             ^^^^^^
+    `----
+
+Error: 
+  > number
+
+  x Type
+    ,-[$DIR/tests/pass/controlFlow/dependentDestructuredVariables/5.ts:10:7]
+ 10 | console.log(args.a + args.b);
+    :                      ^^^^
+    `----
+
+Error: 
+  > {
+  |     a: number;
+  |     b: number;
+  | }
+
+  x Type
+    ,-[$DIR/tests/pass/controlFlow/dependentDestructuredVariables/5.ts:10:7]
+ 10 | console.log(args.a + args.b);
+    :                      ^^^^^^
+    `----
+
+Error: 
+  > number
+
+  x Type
+    ,-[$DIR/tests/pass/controlFlow/dependentDestructuredVariables/5.ts:10:7]
+ 10 | console.log(args.a + args.b);
+    :             ^^^^^^^^^^^^^^^
+    `----
+
+Error: 
+  > number
+
+  x Type
+    ,-[$DIR/tests/pass/controlFlow/dependentDestructuredVariables/5.ts:10:7]
+ 10 | console.log(args.a + args.b);
+    : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    `----
+
+Error: 
+  > void
+
+  x Type
+    ,-[$DIR/tests/pass/controlFlow/dependentDestructuredVariables/5.ts:12:5]
+ 12 | case "concat":
+    :      ^^^^^^^^
+    `----
+
+Error: 
+  > boolean
+
+  x Type
+    ,-[$DIR/tests/pass/controlFlow/dependentDestructuredVariables/5.ts:13:7]
+ 13 | console.log(args.firstArr.concat(args.secondArr));
+    : ^^^^^^^
+    `----
+
+Error: 
+  > Console
+
+  x Type
+    ,-[$DIR/tests/pass/controlFlow/dependentDestructuredVariables/5.ts:13:7]
+ 13 | console.log(args.firstArr.concat(args.secondArr));
+    :             ^^^^
+    `----
+
+Error: 
+  > {
+  |     firstArr: any[];
+  |     secondArr: any[];
+  | }
+
+  x Type
+    ,-[$DIR/tests/pass/controlFlow/dependentDestructuredVariables/5.ts:13:7]
+ 13 | console.log(args.firstArr.concat(args.secondArr));
+    :             ^^^^^^^^^^^^^
+    `----
+
+Error: 
+  > any[]
+
+  x Type
+    ,-[$DIR/tests/pass/controlFlow/dependentDestructuredVariables/5.ts:13:7]
+ 13 | console.log(args.firstArr.concat(args.secondArr));
+    :                                  ^^^^
+    `----
+
+Error: 
+  > {
+  |     firstArr: any[];
+  |     secondArr: any[];
+  | }
+
+  x Type
+    ,-[$DIR/tests/pass/controlFlow/dependentDestructuredVariables/5.ts:13:7]
+ 13 | console.log(args.firstArr.concat(args.secondArr));
+    :                                  ^^^^^^^^^^^^^^
+    `----
+
+Error: 
+  > any[]
+
+  x Type
+    ,-[$DIR/tests/pass/controlFlow/dependentDestructuredVariables/5.ts:13:7]
+ 13 | console.log(args.firstArr.concat(args.secondArr));
+    :             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    `----
+
+Error: 
+  > any[]
+
+  x Type
+    ,-[$DIR/tests/pass/controlFlow/dependentDestructuredVariables/5.ts:13:7]
+ 13 | console.log(args.firstArr.concat(args.secondArr));
+    : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    `----
+
+Error: 
+  > void
+
+  x Type
+    ,-[$DIR/tests/pass/controlFlow/dependentDestructuredVariables/5.ts:7:1]
+  7 | ,-> const reducer: (...args: ReducerArgs) => void = (op, args) => {
+  8 | |     switch (op) {
+  9 | |       case "add":
+ 10 | |         console.log(args.a + args.b);
+ 11 | |         break;
+ 12 | |       case "concat":
+ 13 | |         console.log(args.firstArr.concat(args.secondArr));
+ 14 | |         break;
+ 15 | |     }
+ 16 | `-> };
+    `----
+
+Error: 
+  > (op: ("add" | "concat"), args: ({
+  |     a: number;
+  |     b: number;
+  | } | {
+  |     firstArr: any[];
+  |     secondArr: any[];
+  | })) => void

--- a/crates/stc_ts_file_analyzer/tests/pass/controlFlow/dependentDestructuredVariables/5.ts
+++ b/crates/stc_ts_file_analyzer/tests/pass/controlFlow/dependentDestructuredVariables/5.ts
@@ -1,0 +1,16 @@
+//@strict: true
+
+type ReducerArgs =
+  | ["add", { a: number; b: number }]
+  | ["concat", { firstArr: any[]; secondArr: any[] }];
+
+const reducer: (...args: ReducerArgs) => void = (op, args) => {
+  switch (op) {
+    case "add":
+      console.log(args.a + args.b);
+      break;
+    case "concat":
+      console.log(args.firstArr.concat(args.secondArr));
+      break;
+  }
+};

--- a/crates/stc_ts_type_checker/tests/conformance/controlFlow/dependentDestructuredVariables.stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/conformance/controlFlow/dependentDestructuredVariables.stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
     required_error: 2,
     matched_error: 0,
-    extra_error: 9,
+    extra_error: 3,
     panic: 0,
 }

--- a/crates/stc_ts_type_checker/tests/tsc-stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/tsc-stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
     required_error: 4198,
     matched_error: 5876,
-    extra_error: 743,
+    extra_error: 737,
     panic: 18,
 }


### PR DESCRIPTION
**Description:**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**BREAKING CHANGE:**

The following forms have been processed.
```ts
//@strict: true

type ReducerArgs =
  | ["add", { a: number; b: number }]
  | ["concat", { firstArr: any[]; secondArr: any[] }];

const reducer: (...args: ReducerArgs) => void = (op, args) => {
  switch (op) {
    case "add":
      console.log(args.a + args.b);
      break;
    case "concat":
      console.log(args.firstArr.concat(args.secondArr));
      break;
  }
};
```
