### PR TITLE
feat: Use correct error code for overload resolution failure

### DIFF
--- a/crates/stc_ts_file_analyzer/src/analyzer/expr/call_new.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/expr/call_new.rs
@@ -2992,9 +2992,12 @@ impl Analyzer<'_, '_> {
                                             ..Default::default()
                                         },
                                     )
-                                    .convert_err(|err| ErrorKind::WrongArgType {
-                                        span: arg.span(),
-                                        inner: box err.into(),
+                                    .map_err(|err| {
+                                        ErrorKind::WrongArgType {
+                                            span: arg.span(),
+                                            inner: box err,
+                                        }
+                                        .into()
                                     })
                                     .context("tried to assign to first element of a tuple type of a parameter");
 

--- a/crates/stc_ts_file_analyzer/src/analyzer/expr/call_new.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/expr/call_new.rs
@@ -2412,7 +2412,8 @@ impl Analyzer<'_, '_> {
         }
 
         // Check if all candidates are failed.
-        if type_args.is_none()
+        if !args.is_empty()
+            && type_args.is_none()
             && !opts.skip_check_for_overloads
             && callable.len() > 1
             && callable

--- a/crates/stc_ts_type_checker/tests/conformance/types/union/unionTypeCallSignatures.stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/conformance/types/union/unionTypeCallSignatures.stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
-    required_error: 10,
-    matched_error: 18,
-    extra_error: 2,
+    required_error: 9,
+    matched_error: 19,
+    extra_error: 1,
     panic: 0,
 }

--- a/crates/stc_ts_type_checker/tests/conformance/types/union/unionTypeCallSignatures.stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/conformance/types/union/unionTypeCallSignatures.stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
-    required_error: 11,
-    matched_error: 17,
-    extra_error: 3,
+    required_error: 10,
+    matched_error: 18,
+    extra_error: 2,
     panic: 0,
 }

--- a/crates/stc_ts_type_checker/tests/conformance/types/union/unionTypeConstructSignatures.stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/conformance/types/union/unionTypeConstructSignatures.stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
-    required_error: 10,
-    matched_error: 18,
-    extra_error: 2,
+    required_error: 9,
+    matched_error: 19,
+    extra_error: 1,
     panic: 0,
 }

--- a/crates/stc_ts_type_checker/tests/conformance/types/union/unionTypeConstructSignatures.stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/conformance/types/union/unionTypeConstructSignatures.stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
-    required_error: 11,
-    matched_error: 17,
-    extra_error: 3,
+    required_error: 10,
+    matched_error: 18,
+    extra_error: 2,
     panic: 0,
 }

--- a/crates/stc_ts_type_checker/tests/tsc-stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/tsc-stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
-    required_error: 4197,
-    matched_error: 5877,
-    extra_error: 724,
+    required_error: 4193,
+    matched_error: 5881,
+    extra_error: 720,
     panic: 18,
 }


### PR DESCRIPTION
**Description:**

 - Check for empty arguments while determining overload.
 - Change the error code for 

```ts
var unionOfDifferentReturnType1: { (a: number): number; (a: string): string; } | { (a: number): Date; (a: string): boolean; };
unionOfDifferentReturnType1(true); // error in type of parameter
unionOfDifferentReturnType1(); // error missing parameter
```