### PR TITLE
fix: Index signature type inference

### DIFF
--- a/crates/stc_ts_file_analyzer/src/analyzer/generic/inference.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/generic/inference.rs
@@ -1212,7 +1212,10 @@ impl Analyzer<'_, '_> {
                     }
 
                     (TypeElement::Index(p), TypeElement::Index(a)) => {
-                        if p.params.type_eq(&a.params) {
+                        if p.params.type_eq(&a.params)
+                            || a.params[0].ty.is_kwd(TsKeywordTypeKind::TsStringKeyword)
+                                && p.params[0].ty.is_kwd(TsKeywordTypeKind::TsNumberKeyword)
+                        {
                             if let Some(pt) = &p.type_ann {
                                 if let Some(at) = &a.type_ann {
                                     self.infer_type(

--- a/crates/stc_ts_type_checker/tests/conformance/types/typeRelationships/typeInference/indexSignatureTypeInference.stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/conformance/types/typeRelationships/typeInference/indexSignatureTypeInference.stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
     required_error: 1,
     matched_error: 1,
-    extra_error: 1,
+    extra_error: 0,
     panic: 0,
 }

--- a/crates/stc_ts_type_checker/tests/tsc-stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/tsc-stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
     required_error: 4169,
     matched_error: 5905,
-    extra_error: 646,
+    extra_error: 645,
     panic: 18,
 }


### PR DESCRIPTION


<!-- Note: CI script will automatically rebase your PR so please do not rebase unless required -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**
 Allow infering types from string map interface arg to number map param https://github.com/dudykr/stc/issues/594

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->


<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG. Add description or remove entirely if not breaking.

You may need to update `MIGRATION.md` for the breaking changes.
-->

