### PR TITLE
potential fix to #592

### DIFF
--- a/crates/stc_ts_file_analyzer/src/analyzer/expr/call_new.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/expr/call_new.rs
@@ -3200,6 +3200,12 @@ impl Analyzer<'_, '_> {
                                 _ => {}
                             }
 
+                            if let RPat::Array(array_pat) = &param.pat {
+                                if param.ty.is_array() && array_pat.type_ann.is_none() && !arg.ty.is_array() {
+                                    return ErrorKind::NotArrayType { span: param.span() };
+                                }
+                            }
+
                             ErrorKind::WrongArgType {
                                 span: arg.span(),
                                 inner: box err.into(),

--- a/crates/stc_ts_file_analyzer/src/analyzer/scope/vars.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/scope/vars.rs
@@ -513,7 +513,9 @@ impl Analyzer<'_, '_> {
                     });
 
                     if let Some(ty) = &ty {
-                        if ty.normalize_instance().is_array() {
+                        let t = ty.normalize_instance();
+
+                        if t.is_array() || (t.is_tuple() && arr.type_ann.is_none() && self.ctx.is_calling_iife) {
                             real_ty = real_ty.fold_with(&mut TupleToArray);
                             real_ty.fix();
                         }

--- a/crates/stc_ts_type_checker/tests/conformance/es6/destructuring/destructuringAssignabilityCheck.stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/conformance/es6/destructuring/destructuringAssignabilityCheck.stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
-    required_error: 5,
-    matched_error: 3,
-    extra_error: 1,
+    required_error: 4,
+    matched_error: 4,
+    extra_error: 0,
     panic: 0,
 }

--- a/crates/stc_ts_type_checker/tests/tsc-stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/tsc-stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
-    required_error: 4178,
-    matched_error: 5896,
-    extra_error: 656,
+    required_error: 4177,
+    matched_error: 5897,
+    extra_error: 655,
     panic: 18,
 }


### PR DESCRIPTION
**Description:**

Potentially solves #592 . As far as I can tell, tuple types should be widened on iife if there's no type_ann . I tried to understand if there are other cases where they should be certainly widened but I couldn't find anything conclusive. Not sure if the changes are good enough to be mergeable. First time Im trying to contribute so I hope I didnt do anything horribly wrong.

Edit: I'm not sure if it's problematic that this error does not come from `get_iterator_inner` like in `tsc` but I couldn't figure out a way to do it from there

**Related issue (if exists):**
https://github.com/dudykr/stc/issues/592