### PR TITLE
refactor: Cleanup

### DIFF
--- a/crates/stc_ts_base_type_ops/src/fix.rs
+++ b/crates/stc_ts_base_type_ops/src/fix.rs
@@ -44,8 +44,9 @@ where
 macro_rules! impl_fix {
     ($T:ty) => {
         impl Fix for $T {
-            #[cfg_attr(debug_assertions, tracing::instrument(skip_all))]
             fn fix(&mut self) {
+                let _tracing = stc_utils::dev_span!("fix");
+
                 self.visit_mut_with(&mut Fixer);
             }
         }

--- a/crates/stc_ts_env/src/lib.rs
+++ b/crates/stc_ts_env/src/lib.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 use stc_ts_errors::{Error, ErrorKind};
 use stc_ts_type_ops::Fix;
 use stc_ts_types::{Id, Type};
-use stc_utils::cache::Freeze;
+use stc_utils::{cache::Freeze, dev_span};
 use string_enum::StringEnum;
 use swc_atoms::JsWord;
 use swc_common::{Span, Spanned, DUMMY_SP};
@@ -92,8 +92,9 @@ impl Env {
         }
     }
 
-    #[cfg_attr(debug_assertions, tracing::instrument(skip_all))]
     pub fn get_global_var(&self, span: Span, name: &JsWord) -> Result<Type, Error> {
+        let _tracing = dev_span!("get_global_var");
+
         if let Some(ty) = self.global_vars.lock().get(name) {
             debug_assert!(ty.is_clone_cheap(), "{:?}", *ty);
             return Ok((*ty).clone());
@@ -111,8 +112,9 @@ impl Env {
         .into())
     }
 
-    #[cfg_attr(debug_assertions, tracing::instrument(skip_all))]
     pub fn get_global_type(&self, span: Span, name: &JsWord) -> Result<Type, Error> {
+        let _tracing = dev_span!("get_global_type");
+
         if let Some(ty) = self.global_types.lock().get(name) {
             debug_assert!(ty.is_clone_cheap(), "{:?}", *ty);
             return Ok((*ty).clone());

--- a/crates/stc_ts_file_analyzer/src/analyzer/assign/function.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/assign/function.rs
@@ -8,7 +8,7 @@ use stc_ts_errors::{
     DebugExt, ErrorKind,
 };
 use stc_ts_types::{ClassDef, Constructor, FnParam, Function, KeywordType, LitType, Type, TypeElement, TypeParamDecl};
-use stc_utils::{cache::Freeze, debug_ctx};
+use stc_utils::cache::Freeze;
 use swc_atoms::js_word;
 use swc_common::{Spanned, SyntaxContext, TypeEq};
 use swc_ecma_ast::TsKeywordTypeKind;

--- a/crates/stc_ts_file_analyzer/src/analyzer/assign/function.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/assign/function.rs
@@ -8,7 +8,7 @@ use stc_ts_errors::{
     DebugExt, ErrorKind,
 };
 use stc_ts_types::{ClassDef, Constructor, FnParam, Function, KeywordType, LitType, Type, TypeElement, TypeParamDecl};
-use stc_utils::cache::Freeze;
+use stc_utils::{cache::Freeze, debug_ctx};
 use swc_atoms::js_word;
 use swc_common::{Spanned, SyntaxContext, TypeEq};
 use swc_ecma_ast::TsKeywordTypeKind;

--- a/crates/stc_ts_file_analyzer/src/analyzer/assign/function.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/assign/function.rs
@@ -404,11 +404,7 @@ impl Analyzer<'_, '_> {
     /// b = a; // error
     /// ```
     pub(super) fn assign_to_function(&mut self, data: &mut AssignData, lt: &Type, l: &Function, r: &Type, opts: AssignOpts) -> VResult<()> {
-        let _tracing = if cfg!(debug_assertions) {
-            Some(tracing::span!(tracing::Level::ERROR, "assign_to_function").entered())
-        } else {
-            None
-        };
+        let _tracing = dev_span!("assign_to_function");
 
         let span = opts.span;
         let r = r.normalize();
@@ -521,11 +517,7 @@ impl Analyzer<'_, '_> {
         r: &Type,
         opts: AssignOpts,
     ) -> VResult<()> {
-        let _tracing = if cfg!(debug_assertions) {
-            Some(tracing::span!(tracing::Level::ERROR, "assign_to_constructor").entered())
-        } else {
-            None
-        };
+        let _tracing = dev_span!("assign_to_constructor");
 
         let span = opts.span;
         let r = r.normalize();
@@ -654,11 +646,7 @@ impl Analyzer<'_, '_> {
     ///
     ///  - `string` is assignable to `...args: any[]`.
     fn assign_param(&mut self, data: &mut AssignData, l: &FnParam, r: &FnParam, opts: AssignOpts) -> VResult<()> {
-        let _tracing = if cfg!(debug_assertions) {
-            Some(tracing::span!(tracing::Level::ERROR, "assign_param").entered())
-        } else {
-            None
-        };
+        let _tracing = dev_span!("assign_param");
 
         let span = opts.span;
         debug_assert!(!opts.span.is_dummy(), "Cannot assign function parameters with dummy span");
@@ -682,11 +670,7 @@ impl Analyzer<'_, '_> {
 
     /// Implementation of `assign_param`.
     fn assign_param_type(&mut self, data: &mut AssignData, l: &Type, r: &Type, opts: AssignOpts) -> VResult<()> {
-        let _tracing = if cfg!(debug_assertions) {
-            Some(tracing::span!(tracing::Level::ERROR, "assign_param_type").entered())
-        } else {
-            None
-        };
+        let _tracing = dev_span!("assign_param_type");
 
         let span = opts.span;
         debug_assert!(!opts.span.is_dummy(), "Cannot assign function parameters with dummy span");
@@ -826,11 +810,7 @@ impl Analyzer<'_, '_> {
     ///
     /// So, it's an error if `l.params.len() < r.params.len()`.
     pub(crate) fn assign_params(&mut self, data: &mut AssignData, l: &[FnParam], r: &[FnParam], opts: AssignOpts) -> VResult<()> {
-        let _tracing = if cfg!(debug_assertions) {
-            Some(tracing::span!(tracing::Level::ERROR, "assign_params").entered())
-        } else {
-            None
-        };
+        let _tracing = dev_span!("assign_params");
 
         let span = opts.span;
 

--- a/crates/stc_ts_file_analyzer/src/analyzer/assign/function.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/assign/function.rs
@@ -8,7 +8,7 @@ use stc_ts_errors::{
     DebugExt, ErrorKind,
 };
 use stc_ts_types::{ClassDef, Constructor, FnParam, Function, KeywordType, LitType, Type, TypeElement, TypeParamDecl};
-use stc_utils::cache::Freeze;
+use stc_utils::{cache::Freeze, dev_span};
 use swc_atoms::js_word;
 use swc_common::{Spanned, SyntaxContext, TypeEq};
 use swc_ecma_ast::TsKeywordTypeKind;
@@ -39,11 +39,7 @@ impl Analyzer<'_, '_> {
         r_ret_ty: Option<&Type>,
         opts: AssignOpts,
     ) -> VResult<()> {
-        let _tracing = if cfg!(debug_assertions) {
-            Some(tracing::span!(tracing::Level::ERROR, "assign_to_fn_like").entered())
-        } else {
-            None
-        };
+        let _tracing = dev_span!("assign_to_fn_like");
 
         let span = opts.span.with_ctxt(SyntaxContext::empty());
 

--- a/crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs
@@ -654,11 +654,7 @@ impl Analyzer<'_, '_> {
                     right_ident: opts.right_ident_span,
                     cause: vec![],
                 }
-                .context(format!(
-                    "LHS (final): {}\nRHS (final): {}",
-                    force_dump_type_as_string(to),
-                    force_dump_type_as_string(rhs)
-                )));
+                .context("fail!() called"));
             }};
         }
 

--- a/crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs
@@ -1518,10 +1518,10 @@ impl Analyzer<'_, '_> {
                 }
             }
 
-            Type::Intersection(Intersection { types, .. }) => {
+            Type::Intersection(Intersection { types: rhs_types, .. }) => {
                 if !opts.do_not_normalize_intersection_on_rhs {
                     // Filter out `never` types
-                    if let Some(new) = self.normalize_intersection_types(span, types, NormalizeTypeOpts { ..Default::default() })? {
+                    if let Some(new) = self.normalize_intersection_types(span, rhs_types, NormalizeTypeOpts { ..Default::default() })? {
                         return self
                             .assign_inner(
                                 data,
@@ -1535,13 +1535,13 @@ impl Analyzer<'_, '_> {
                             .context("tried to assign a normalized intersection type to another type");
                     }
                 }
-                if let Some(new) = self.normalize_intersection_types(span, types, NormalizeTypeOpts { ..Default::default() })? {
+                if let Some(new) = self.normalize_intersection_types(span, rhs_types, NormalizeTypeOpts { ..Default::default() })? {
                     if new.is_never() && to.is_never() {
                         return Ok(());
                     }
                 }
 
-                let results = types
+                let results = rhs_types
                     .iter()
                     .map(|rhs| {
                         self.assign_inner(
@@ -1566,7 +1566,7 @@ impl Analyzer<'_, '_> {
                     }
                 }
 
-                let use_single_error = types.iter().all(|ty| ty.is_interface());
+                let use_single_error = rhs_types.iter().all(|ty| ty.is_interface());
                 let errors = results.into_iter().map(Result::unwrap_err).collect();
 
                 if use_single_error {

--- a/crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs
@@ -1535,11 +1535,6 @@ impl Analyzer<'_, '_> {
                             .context("tried to assign a normalized intersection type to another type");
                     }
                 }
-                if let Some(new_rhs) = self.normalize_intersection_types(span, rhs_types, NormalizeTypeOpts { ..Default::default() })? {
-                    if new_rhs.is_never() && to.is_never() {
-                        return Ok(());
-                    }
-                }
 
                 let results = rhs_types
                     .iter()

--- a/crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs
@@ -10,7 +10,7 @@ use stc_ts_types::{
     LitType, Mapped, Operator, PropertySignature, QueryExpr, QueryType, Ref, RestType, StringMapping, ThisType, Tuple, TupleElement, Type,
     TypeElement, TypeLit, TypeParam,
 };
-use stc_utils::{cache::Freeze, stack};
+use stc_utils::{cache::Freeze, dev_span, stack};
 use swc_atoms::js_word;
 use swc_common::{EqIgnoreSpan, Span, Spanned, TypeEq, DUMMY_SP};
 use swc_ecma_ast::{TruePlusMinus::*, *};
@@ -2454,8 +2454,7 @@ impl Analyzer<'_, '_> {
                             let li = index;
                             let ri = min(index, r_max);
 
-                            #[cfg(debug_assertions)]
-                            let _tracing = tracing::error_span!("assign_tuple_to_tuple", li = li, ri = ri).entered();
+                            let _tracing = dev_span!("assign_tuple_to_tuple", li = li, ri = ri);
 
                             let l_elem_type = self.access_property(
                                 span,

--- a/crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs
@@ -14,7 +14,7 @@ use stc_utils::{cache::Freeze, dev_span, stack};
 use swc_atoms::js_word;
 use swc_common::{EqIgnoreSpan, Span, Spanned, TypeEq, DUMMY_SP};
 use swc_ecma_ast::{TruePlusMinus::*, *};
-use tracing::{debug, error, info, span, Level};
+use tracing::{debug, error, info};
 
 use crate::{
     analyzer::{
@@ -613,14 +613,7 @@ impl Analyzer<'_, '_> {
             unreachable!("cannot assign with dummy span")
         }
 
-        let _tracing = if cfg!(debug_assertions) {
-            let lhs = dump_type_as_string(to);
-            let rhs = dump_type_as_string(rhs);
-
-            Some(span!(Level::ERROR, "assign", lhs = &*lhs, rhs = &*rhs).entered())
-        } else {
-            None
-        };
+        let _tracing = dev_span!("assign", lhs = &*dump_type_as_string(to), rhs = &*dump_type_as_string(rhs));
 
         // It's valid to assign any to everything.
         if rhs.is_any() {

--- a/crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs
@@ -14,7 +14,7 @@ use stc_utils::{cache::Freeze, dev_span, stack};
 use swc_atoms::js_word;
 use swc_common::{EqIgnoreSpan, Span, Spanned, TypeEq, DUMMY_SP};
 use swc_ecma_ast::{TruePlusMinus::*, *};
-use tracing::{debug, error, info, span, Level};
+use tracing::{debug, error, info};
 
 use crate::{
     analyzer::{
@@ -207,7 +207,7 @@ impl Analyzer<'_, '_> {
     }
 
     /// Used to validate assignments like `a += b`.
-    pub(crate) fn assign_with_op(&mut self, span: Span, op: AssignOp, lhs: &Type, rhs: &Type) -> VResult<()> {
+    pub(crate) fn assign_with_operator(&mut self, span: Span, op: AssignOp, lhs: &Type, rhs: &Type) -> VResult<()> {
         debug_assert_ne!(op, op!("="));
 
         let l = self.normalize(

--- a/crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs
@@ -208,7 +208,7 @@ impl Analyzer<'_, '_> {
     }
 
     /// Used to validate assignments like `a += b`.
-    pub(crate) fn assign_with_op(&mut self, span: Span, op: AssignOp, lhs: &Type, rhs: &Type) -> VResult<()> {
+    pub(crate) fn assign_with_operator(&mut self, span: Span, op: AssignOp, lhs: &Type, rhs: &Type) -> VResult<()> {
         debug_assert_ne!(op, op!("="));
 
         let l = self.normalize(

--- a/crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs
@@ -1535,8 +1535,8 @@ impl Analyzer<'_, '_> {
                             .context("tried to assign a normalized intersection type to another type");
                     }
                 }
-                if let Some(new) = self.normalize_intersection_types(span, rhs_types, NormalizeTypeOpts { ..Default::default() })? {
-                    if new.is_never() && to.is_never() {
+                if let Some(new_rhs) = self.normalize_intersection_types(span, rhs_types, NormalizeTypeOpts { ..Default::default() })? {
+                    if new_rhs.is_never() && to.is_never() {
                         return Ok(());
                     }
                 }

--- a/crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs
@@ -5,13 +5,12 @@ use stc_ts_errors::{
     debug::{dump_type_as_string, force_dump_type_as_string},
     DebugExt, ErrorKind,
 };
-use stc_ts_file_analyzer_macros::context;
 use stc_ts_types::{
     Array, Conditional, EnumVariant, IdCtx, Instance, Interface, Intersection, IntrinsicKind, Key, KeywordType, KeywordTypeMetadata,
     LitType, Mapped, Operator, PropertySignature, QueryExpr, QueryType, Ref, RestType, StringMapping, ThisType, Tuple, TupleElement, Type,
     TypeElement, TypeLit, TypeParam,
 };
-use stc_utils::{cache::Freeze, stack};
+use stc_utils::{cache::Freeze, dev_span, stack};
 use swc_atoms::js_word;
 use swc_common::{EqIgnoreSpan, Span, Spanned, TypeEq, DUMMY_SP};
 use swc_ecma_ast::{TruePlusMinus::*, *};
@@ -618,7 +617,7 @@ impl Analyzer<'_, '_> {
             let lhs = dump_type_as_string(to);
             let rhs = dump_type_as_string(rhs);
 
-            Some(span!(Level::ERROR, "assign", lhs = &*lhs, rhs = &*rhs).entered())
+            Some(dev_span!("assign", lhs = &*lhs, rhs = &*rhs))
         } else {
             None
         };
@@ -2774,57 +2773,59 @@ impl Analyzer<'_, '_> {
         Ok(())
     }
 
-    #[context("tried to extract keys")]
     fn extract_keys(&mut self, span: Span, ty: &Type) -> VResult<Type> {
-        let ty = self.normalize(
-            Some(span),
-            Cow::Borrowed(ty),
-            NormalizeTypeOpts {
-                normalize_keywords: true,
-                process_only_key: true,
-                ..Default::default()
-            },
-        )?;
-        let ty = ty.normalize();
+        (|| -> VResult<_> {
+            let ty = self.normalize(
+                Some(span),
+                Cow::Borrowed(ty),
+                NormalizeTypeOpts {
+                    normalize_keywords: true,
+                    process_only_key: true,
+                    ..Default::default()
+                },
+            )?;
+            let ty = ty.normalize();
 
-        if let Type::TypeLit(ty) = ty {
-            //
-            let mut keys = vec![];
-            for member in &ty.members {
-                if let TypeElement::Property(PropertySignature {
-                    span,
-                    key: Key::Normal { sym: key, .. },
-                    ..
-                }) = member
-                {
-                    keys.push(Type::Lit(LitType {
-                        span: *span,
-                        lit: RTsLit::Str(RStr {
+            if let Type::TypeLit(ty) = ty {
+                //
+                let mut keys = vec![];
+                for member in &ty.members {
+                    if let TypeElement::Property(PropertySignature {
+                        span,
+                        key: Key::Normal { sym: key, .. },
+                        ..
+                    }) = member
+                    {
+                        keys.push(Type::Lit(LitType {
                             span: *span,
-                            value: key.clone(),
-                            raw: None,
-                        }),
-                        metadata: Default::default(),
-                        tracker: Default::default(),
-                    }));
+                            lit: RTsLit::Str(RStr {
+                                span: *span,
+                                value: key.clone(),
+                                raw: None,
+                            }),
+                            metadata: Default::default(),
+                            tracker: Default::default(),
+                        }));
+                    }
                 }
+
+                return Ok(Type::new_union(span, keys));
             }
 
-            return Ok(Type::new_union(span, keys));
-        }
+            if let Some(ty) = self
+                .convert_type_to_type_lit(span, Cow::Borrowed(ty))?
+                .map(Cow::into_owned)
+                .map(Type::TypeLit)
+            {
+                return self.extract_keys(span, &ty);
+            }
 
-        if let Some(ty) = self
-            .convert_type_to_type_lit(span, Cow::Borrowed(ty))?
-            .map(Cow::into_owned)
-            .map(Type::TypeLit)
-        {
-            return self.extract_keys(span, &ty);
-        }
-
-        Err(ErrorKind::Unimplemented {
-            span,
-            msg: "Extract keys".to_string(),
-        })?
+            Err(ErrorKind::Unimplemented {
+                span,
+                msg: "Extract keys".to_string(),
+            })?
+        })()
+        .context("tried to extract keys")
     }
 
     /// Handles `P in 'foo' | 'bar'`. Note that `'foo' | 'bar'` part should be

--- a/crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs
@@ -832,24 +832,6 @@ impl Analyzer<'_, '_> {
             }
         }
 
-        if rhs.is_enum_type() {
-            let rhs = self
-                .normalize(
-                    Some(span),
-                    Cow::Borrowed(rhs),
-                    NormalizeTypeOpts {
-                        expand_enum_def: true,
-                        ..Default::default()
-                    },
-                )?
-                .freezed()
-                .into_owned()
-                .freezed();
-            if self.assign_inner(data, to, &rhs, opts).is_ok() {
-                return Ok(());
-            }
-        }
-
         match to {
             Type::Ref(Ref {
                 type_name: RTsEntityName::Ident(RIdent {
@@ -933,6 +915,7 @@ impl Analyzer<'_, '_> {
         }
 
         if rhs.is_mapped() {
+        if rhs.is_mapped() || rhs.is_enum_type() {
             let rhs = self
                 .normalize(
                     Some(opts.span),
@@ -942,6 +925,7 @@ impl Analyzer<'_, '_> {
                         preserve_global_this: true,
                         preserve_intersection: true,
                         preserve_union: true,
+                        expand_enum_def: true,
                         ..Default::default()
                     },
                 )?

--- a/crates/stc_ts_file_analyzer/src/analyzer/assign/tpl.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/assign/tpl.rs
@@ -3,6 +3,7 @@
 use stc_ts_ast_rnode::RTsLit;
 use stc_ts_errors::{debug::force_dump_type_as_string, ErrorKind};
 use stc_ts_types::{IntrinsicKind, LitType, StringMapping, TplType, Type};
+use stc_utils::dev_span;
 use swc_common::{Span, TypeEq};
 use swc_ecma_ast::TsKeywordTypeKind;
 
@@ -52,18 +53,11 @@ impl Analyzer<'_, '_> {
 
     /// Ported from `isValidTypeForTemplateLiteralPlaceholder` of `tsc`
     pub(crate) fn is_valid_type_for_tpl_lit_placeholder(&mut self, span: Span, source: &Type, target: &Type) -> VResult<bool> {
-        #[cfg(debug_assertions)]
-        let _tracing = {
-            let source = force_dump_type_as_string(source);
-            let target = force_dump_type_as_string(target);
-            tracing::span!(
-                tracing::Level::ERROR,
-                "is_valid_type_for_tpl_lit_placeholder",
-                source = tracing::field::display(&source),
-                target = tracing::field::display(&target),
-            )
-            .entered()
-        };
+        let _tracing = dev_span!(
+            "is_valid_type_for_tpl_lit_placeholder",
+            source = tracing::field::display(&force_dump_type_as_string(source)),
+            target = tracing::field::display(&force_dump_type_as_string(target)),
+        );
 
         if source.type_eq(target) || target.is_any() || target.is_kwd(TsKeywordTypeKind::TsStringKeyword) {
             return Ok(true);

--- a/crates/stc_ts_file_analyzer/src/analyzer/assign/type_el.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/assign/type_el.rs
@@ -12,7 +12,7 @@ use stc_ts_types::{
     Array, Class, ClassDef, ClassMember, Function, Key, KeywordType, LitType, MethodSignature, Operator, PropertySignature, Ref, TplType,
     Tuple, Type, TypeElement, TypeLit, TypeLitMetadata, TypeParamInstantiation, Union, UnionMetadata,
 };
-use stc_utils::{cache::Freeze, ext::SpanExt};
+use stc_utils::{cache::Freeze, dev_span, ext::SpanExt};
 use swc_atoms::js_word;
 use swc_common::{Span, Spanned, SyntaxContext, TypeEq, DUMMY_SP};
 use swc_ecma_ast::{Accessibility, TsKeywordTypeKind, TsTypeOperatorOp};
@@ -45,11 +45,7 @@ impl Analyzer<'_, '_> {
         lhs_metadata: TypeLitMetadata,
         opts: AssignOpts,
     ) -> VResult<()> {
-        let _tracing = if cfg!(debug_assertions) {
-            Some(tracing::span!(tracing::Level::ERROR, "assign_to_type_elements").entered())
-        } else {
-            None
-        };
+        let _tracing = dev_span!("assign_to_type_elements");
 
         let span = opts.span.with_ctxt(SyntaxContext::empty());
         // debug_assert!(!span.is_dummy());

--- a/crates/stc_ts_file_analyzer/src/analyzer/control_flow.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/control_flow.rs
@@ -18,6 +18,7 @@ use stc_ts_types::{name::Name, Array, ArrayMetadata, Id, Key, KeywordType, Keywo
 use stc_ts_utils::MapWithMut;
 use stc_utils::{
     cache::Freeze,
+    dev_span,
     ext::{SpanExt, TypeVecExt},
 };
 use swc_atoms::JsWord;
@@ -451,8 +452,9 @@ impl Analyzer<'_, '_> {
     /// `SafeSubscriber` or downgrade the type, like converting `Subscriber` |
     /// `SafeSubscriber` into `SafeSubscriber`. This behavior is controlled by
     /// the mark applied while handling type facts related to call.
-    #[cfg_attr(debug_assertions, tracing::instrument(skip_all))]
     fn adjust_ternary_type(&mut self, span: Span, mut types: Vec<Type>) -> VResult<Vec<Type>> {
+        let _tracing = dev_span!("adjust_ternary_type");
+
         types.iter_mut().for_each(|ty| {
             // Tuple -> Array
             if let Some(tuple) = ty.as_tuple_mut() {
@@ -493,8 +495,9 @@ impl Analyzer<'_, '_> {
         self.downcast_types(span, types)
     }
 
-    #[cfg_attr(debug_assertions, tracing::instrument(skip_all))]
     fn downcast_types(&mut self, span: Span, types: Vec<Type>) -> VResult<Vec<Type>> {
+        let _tracing = dev_span!("downcast_types");
+
         fn need_work(ty: &Type) -> bool {
             !matches!(
                 ty.normalize(),
@@ -553,8 +556,9 @@ impl Analyzer<'_, '_> {
     }
 
     /// Remove `SafeSubscriber` from `Subscriber` | `SafeSubscriber`.
-    #[cfg_attr(debug_assertions, tracing::instrument(skip_all))]
     fn remove_child_types(&mut self, span: Span, types: Vec<Type>) -> VResult<Vec<Type>> {
+        let _tracing = dev_span!("remove_child_types");
+
         let mut new = vec![];
 
         'outer: for (ai, ty) in types.iter().flat_map(|ty| ty.iter_union()).enumerate() {

--- a/crates/stc_ts_file_analyzer/src/analyzer/control_flow.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/control_flow.rs
@@ -753,7 +753,7 @@ impl Analyzer<'_, '_> {
                             },
                         )?
                     } else {
-                        self.assign_with_op(span, op, &lhs_ty, rhs_ty)?;
+                        self.assign_with_operator(span, op, &lhs_ty, rhs_ty)?;
                     }
 
                     if let RExpr::Ident(left) = &**expr {
@@ -801,7 +801,7 @@ impl Analyzer<'_, '_> {
                                 let lhs = self.type_of_var(&left.id, TypeOfMode::LValue, None);
 
                                 if let Ok(lhs) = lhs {
-                                    self.assign_with_op(span, op, &lhs, rhs_ty)?;
+                                    self.assign_with_operator(span, op, &lhs, rhs_ty)?;
                                 }
                             }
                             _ => Err(ErrorKind::InvalidOperatorForLhs { span, op })?,

--- a/crates/stc_ts_file_analyzer/src/analyzer/convert/interface.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/convert/interface.rs
@@ -2,7 +2,7 @@ use std::borrow::Cow;
 
 use stc_ts_errors::ErrorKind;
 use stc_ts_types::{TsExpr, Type, TypeElement, TypeLit};
-use stc_utils::cache::Freeze;
+use stc_utils::{cache::Freeze, dev_span};
 use swc_common::{Span, TypeEq, DUMMY_SP};
 
 use crate::{
@@ -11,8 +11,9 @@ use crate::{
 };
 
 impl Analyzer<'_, '_> {
-    #[cfg_attr(debug_assertions, tracing::instrument(skip_all))]
     pub(super) fn report_error_for_wrong_interface_inheritance(&mut self, span: Span, body: &[TypeElement], parent: &[TsExpr]) {
+        let _tracing = dev_span!("report_error_for_wrong_interface_inheritance");
+
         if self.config.is_builtin || self.config.is_dts {
             return;
         }
@@ -68,8 +69,9 @@ impl Analyzer<'_, '_> {
         }
     }
 
-    #[cfg_attr(debug_assertions, tracing::instrument(skip_all))]
     pub(crate) fn report_error_for_conflicting_parents(&mut self, span: Span, parent: &[TsExpr]) {
+        let _tracing = dev_span!("report_error_for_conflicting_parents");
+
         if self.config.is_builtin || self.config.is_dts {
             return;
         }

--- a/crates/stc_ts_file_analyzer/src/analyzer/convert/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/convert/mod.rs
@@ -1141,8 +1141,9 @@ impl Analyzer<'_, '_> {
         }
     }
 
-    #[cfg_attr(debug_assertions, tracing::instrument(skip_all))]
     fn report_error_for_duplicate_params(&mut self, params: &[FnParam]) {
+        let _tracing = dev_span!("report_error_for_duplicate_params");
+
         if self.config.is_builtin {
             return;
         }
@@ -1175,8 +1176,9 @@ impl Analyzer<'_, '_> {
     }
 
     #[extra_validator]
-    #[cfg_attr(debug_assertions, tracing::instrument(skip_all))]
     fn report_error_for_type_param_usages_in_static_members(&mut self, i: &RIdent) {
+        let _tracing = dev_span!("report_error_for_type_param_usages_in_static_members");
+
         let span = i.span;
         let id = i.into();
         let static_method = self.scope.first(|scope| {

--- a/crates/stc_ts_file_analyzer/src/analyzer/convert/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/convert/mod.rs
@@ -22,7 +22,7 @@ use stc_ts_types::{
     TypeParamInstantiation,
 };
 use stc_ts_utils::{find_ids_in_pat, PatExt};
-use stc_utils::{cache::Freeze, AHashSet};
+use stc_utils::{cache::Freeze, dev_span, AHashSet};
 use swc_atoms::js_word;
 use swc_common::{Spanned, SyntaxContext, TypeEq, DUMMY_SP};
 use swc_ecma_ast::TsKeywordTypeKind;
@@ -1102,8 +1102,9 @@ impl Analyzer<'_, '_> {
 }
 
 impl Analyzer<'_, '_> {
-    #[cfg_attr(debug_assertions, tracing::instrument(skip_all))]
     fn report_error_for_duplicate_type_elements(&mut self, elems: &[TypeElement]) {
+        let _tracing = dev_span!("report_error_for_duplicate_type_elements");
+
         if self.config.is_builtin {
             return;
         }

--- a/crates/stc_ts_file_analyzer/src/analyzer/export.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/export.rs
@@ -8,7 +8,7 @@ use stc_ts_errors::{DebugExt, ErrorKind};
 use stc_ts_file_analyzer_macros::extra_validator;
 use stc_ts_types::{Id, IdCtx, ModuleId};
 use stc_ts_utils::find_ids_in_pat;
-use stc_utils::cache::Freeze;
+use stc_utils::{cache::Freeze, dev_span};
 use swc_atoms::{js_word, JsWord};
 use swc_common::{Span, Spanned, DUMMY_SP};
 use swc_ecma_ast::*;
@@ -168,11 +168,12 @@ impl Analyzer<'_, '_> {
 impl Analyzer<'_, '_> {
     /// Currently noop because we need to know if a function is last item among
     /// overloads
-    #[cfg_attr(debug_assertions, tracing::instrument(skip_all))]
     fn report_errors_for_duplicated_exports_of_var(&mut self, span: Span, sym: JsWord) {
         if self.ctx.reevaluating() {
             return;
         }
+        let _tracing = dev_span!("report_errors_for_duplicated_exports_of_var");
+
         let v = self.data.for_module.exports_spans.entry((sym.clone(), IdCtx::Var)).or_default();
         v.push(span);
 
@@ -189,8 +190,9 @@ impl Analyzer<'_, '_> {
     }
 
     #[extra_validator]
-    #[cfg_attr(debug_assertions, tracing::instrument(skip_all))]
     fn export_var(&mut self, span: Span, name: Id, orig_name: Option<Id>, check_duplicate: bool) {
+        let _tracing = dev_span!("export_var", name = tracing::field::debug(&name));
+
         if check_duplicate {
             self.report_errors_for_duplicated_exports_of_var(span, name.sym().clone());
         }
@@ -207,8 +209,9 @@ impl Analyzer<'_, '_> {
     /// Note: We don't freeze types at here because doing so may prevent proper
     /// finalization.
     #[extra_validator]
-    #[cfg_attr(debug_assertions, tracing::instrument(skip_all))]
     fn export_type(&mut self, span: Span, name: Id, orig_name: Option<Id>) {
+        let _tracing = dev_span!("export_type", name = tracing::field::debug(&name));
+
         let orig_name = orig_name.unwrap_or_else(|| name.clone());
 
         let types = match self.find_type(&orig_name) {

--- a/crates/stc_ts_file_analyzer/src/analyzer/expr/bin.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/expr/bin.rs
@@ -16,7 +16,7 @@ use stc_ts_types::{
     name::Name, Class, IdCtx, Intersection, Key, KeywordType, KeywordTypeMetadata, LitType, Ref, Tuple, TypeElement, TypeLit, TypeParam,
     TypeParamInstantiation, Union, UnionMetadata,
 };
-use stc_utils::{cache::Freeze, stack};
+use stc_utils::{cache::Freeze, dev_span, stack};
 use swc_atoms::js_word;
 use swc_common::{Span, Spanned, SyntaxContext, TypeEq};
 use swc_ecma_ast::{op, BinaryOp, TsKeywordTypeKind, TsTypeOperatorOp};
@@ -1274,11 +1274,7 @@ impl Analyzer<'_, '_> {
     /// Note that `C extends D` and `D extends C` are true because both of `C`
     /// and `D` are empty classes.
     fn narrow_with_instanceof(&mut self, span: Span, ty: Cow<Type>, orig_ty: &Type) -> VResult<Type> {
-        let _tracing = if cfg!(debug_assertions) {
-            Some(tracing::span!(tracing::Level::ERROR, "narrow_with_instanceof").entered())
-        } else {
-            None
-        };
+        let _tracing = dev_span!("narrow_with_instanceof");
 
         let mut orig_ty = self.normalize(
             Some(span),

--- a/crates/stc_ts_file_analyzer/src/analyzer/expr/call_new.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/expr/call_new.rs
@@ -23,7 +23,7 @@ use stc_ts_types::{
     StaticThis, Symbol, TypeParamDecl, Union, UnionMetadata,
 };
 use stc_ts_utils::PatExt;
-use stc_utils::{cache::Freeze, ext::TypeVecExt};
+use stc_utils::{cache::Freeze, dev_span, ext::TypeVecExt};
 use swc_atoms::js_word;
 use swc_common::{Span, Spanned, SyntaxContext, TypeEq, DUMMY_SP};
 use swc_ecma_ast::{Accessibility, TsKeywordTypeKind};
@@ -229,11 +229,7 @@ impl Analyzer<'_, '_> {
         type_args: Option<&RTsTypeParamInstantiation>,
         type_ann: Option<&Type>,
     ) -> VResult<Type> {
-        let _tracing = if cfg!(debug_assertions) {
-            Some(tracing::span!(tracing::Level::ERROR, "extract_call_new_expr_member").entered())
-        } else {
-            None
-        };
+        let _tracing = dev_span!("extract_call_new_expr_member");
 
         debug_assert_eq!(self.scope.kind(), ScopeKind::Call);
 
@@ -539,11 +535,7 @@ impl Analyzer<'_, '_> {
         type_ann: Option<&Type>,
         opts: CallOpts,
     ) -> VResult<Type> {
-        let _tracing = if cfg!(debug_assertions) {
-            Some(tracing::span!(tracing::Level::ERROR, "call_property").entered())
-        } else {
-            None
-        };
+        let _tracing = dev_span!("call_property");
 
         obj_type.assert_valid();
 

--- a/crates/stc_ts_file_analyzer/src/analyzer/expr/call_new.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/expr/call_new.rs
@@ -970,11 +970,7 @@ impl Analyzer<'_, '_> {
         type_ann: Option<&Type>,
         opts: CallOpts,
     ) -> VResult<Option<Type>> {
-        let _tracing = if cfg!(debug_assertions) {
-            Some(tracing::span!(tracing::Level::ERROR, "call_property_of_class").entered())
-        } else {
-            None
-        };
+        let _tracing = dev_span!("call_property_of_class");
 
         let candidates = {
             // TODO(kdy1): Deduplicate.
@@ -1164,11 +1160,7 @@ impl Analyzer<'_, '_> {
         type_ann: Option<&Type>,
         opts: CallOpts,
     ) -> VResult<Type> {
-        let _tracing = if cfg!(debug_assertions) {
-            Some(tracing::span!(tracing::Level::ERROR, "call_property_of_type_elements").entered())
-        } else {
-            None
-        };
+        let _tracing = dev_span!("call_property_of_type_elements");
 
         let span = span.with_ctxt(SyntaxContext::empty());
 
@@ -1836,11 +1828,7 @@ impl Analyzer<'_, '_> {
         type_args: Option<&TypeParamInstantiation>,
         type_ann: Option<&Type>,
     ) -> VResult<Type> {
-        let _tracing = if cfg!(debug_assertions) {
-            Some(tracing::span!(tracing::Level::ERROR, "call_type_element").entered())
-        } else {
-            None
-        };
+        let _tracing = dev_span!("call_type_element");
 
         let callee_span = callee_ty.span();
 
@@ -2355,11 +2343,7 @@ impl Analyzer<'_, '_> {
         type_ann: Option<&Type>,
         opts: SelectOpts,
     ) -> VResult<Option<Type>> {
-        let _tracing = if cfg!(debug_assertions) {
-            Some(tracing::span!(tracing::Level::ERROR, "select_and_invoke").entered())
-        } else {
-            None
-        };
+        let _tracing = dev_span!("select_and_invoke");
 
         let span = span.with_ctxt(SyntaxContext::empty());
 
@@ -2486,11 +2470,7 @@ impl Analyzer<'_, '_> {
         spread_arg_types: &[TypeOrSpread],
         type_ann: Option<&Type>,
     ) -> VResult<Type> {
-        let _tracing = if cfg!(debug_assertions) {
-            Some(tracing::span!(tracing::Level::ERROR, "get_return_type").entered())
-        } else {
-            None
-        };
+        let _tracing = dev_span!("get_return_type");
 
         let span = span.with_ctxt(SyntaxContext::empty());
 
@@ -3257,11 +3237,7 @@ impl Analyzer<'_, '_> {
     }
 
     fn narrow_with_predicate(&mut self, span: Span, orig_ty: &Type, new_ty: Type) -> VResult<Type> {
-        let _tracing = if cfg!(debug_assertions) {
-            Some(tracing::span!(tracing::Level::ERROR, "narrow_with_predicate").entered())
-        } else {
-            None
-        };
+        let _tracing = dev_span!("narrow_with_predicate");
 
         let span = span.with_ctxt(SyntaxContext::empty());
 
@@ -3399,11 +3375,7 @@ impl Analyzer<'_, '_> {
     }
 
     fn is_subtype_in_fn_call(&mut self, span: Span, arg: &Type, param: &Type) -> bool {
-        let _tracing = if cfg!(debug_assertions) {
-            Some(tracing::span!(tracing::Level::ERROR, "is_subtype_in_fn_call").entered())
-        } else {
-            None
-        };
+        let _tracing = dev_span!("is_subtype_in_fn_call");
 
         if arg.type_eq(param) {
             return true;
@@ -3448,11 +3420,7 @@ impl Analyzer<'_, '_> {
         arg_types: &[TypeOrSpread],
         spread_arg_types: &[TypeOrSpread],
     ) -> ArgCheckResult {
-        let _tracing = if cfg!(debug_assertions) {
-            Some(tracing::span!(tracing::Level::ERROR, "check_call_args").entered())
-        } else {
-            None
-        };
+        let _tracing = dev_span!("check_call_args");
 
         if self.validate_type_args_count(span, type_params, type_args).is_err() {
             return ArgCheckResult::WrongArgCount;

--- a/crates/stc_ts_file_analyzer/src/analyzer/expr/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/expr/mod.rs
@@ -3840,8 +3840,9 @@ impl Analyzer<'_, '_> {
         }
     }
 
-    #[cfg_attr(debug_assertions, tracing::instrument(skip_all))]
     pub(crate) fn type_of_ts_entity_name(&mut self, span: Span, n: &RExpr, type_args: Option<&TypeParamInstantiation>) -> VResult<Type> {
+        let _tracing = dev_span!("type_of_ts_entity_name");
+
         self.type_of_ts_entity_name_inner(span, n, type_args)
     }
 

--- a/crates/stc_ts_file_analyzer/src/analyzer/expr/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/expr/mod.rs
@@ -29,7 +29,7 @@ use stc_utils::{cache::Freeze, dev_span, ext::TypeVecExt, panic_ctx, stack};
 use swc_atoms::js_word;
 use swc_common::{SourceMapper, Span, Spanned, SyntaxContext, TypeEq, DUMMY_SP};
 use swc_ecma_ast::{op, EsVersion, TruePlusMinus, TsKeywordTypeKind, TsTypeOperatorOp, VarDeclKind};
-use tracing::{debug, info, warn, Level};
+use tracing::{debug, info, warn};
 
 use self::bin::extract_name_for_assignment;
 pub(crate) use self::{array::GetIteratorOpts, call_new::CallOpts};
@@ -639,11 +639,7 @@ impl Analyzer<'_, '_> {
     }
 
     pub(crate) fn validate_key(&mut self, prop: &RExpr, computed: bool) -> VResult<Key> {
-        let _tracing = if cfg!(debug_assertions) {
-            Some(tracing::span!(tracing::Level::ERROR, "validate_key").entered())
-        } else {
-            None
-        };
+        let _tracing = dev_span!("validate_key");
 
         if computed {
             prop.validate_with_default(self)
@@ -829,11 +825,7 @@ impl Analyzer<'_, '_> {
         members: &[TypeElement],
         opts: AccessPropertyOpts,
     ) -> VResult<Option<Type>> {
-        let _tracing = if cfg!(debug_assertions) {
-            Some(tracing::span!(tracing::Level::ERROR, "access_property_of_type_elements").entered())
-        } else {
-            None
-        };
+        let _tracing = dev_span!("access_property_of_type_elements");
 
         let mut matching_elements = vec![];
         let mut read_only_flag = false;
@@ -1065,9 +1057,8 @@ impl Analyzer<'_, '_> {
 
         let _tracing = if cfg!(debug_assertions) {
             let obj = dump_type_as_string(obj);
-            // let prop_ty = dump_type_as_string( &prop.ty());
 
-            Some(tracing::span!(Level::ERROR, "access_property", obj = &*obj, prop = tracing::field::debug(&prop)).entered())
+            Some(dev_span!("access_property", obj = &*obj, prop = tracing::field::debug(&prop)))
         } else {
             None
         };
@@ -3303,11 +3294,7 @@ impl Analyzer<'_, '_> {
         type_mode: TypeOfMode,
         type_args: Option<&TypeParamInstantiation>,
     ) -> VResult<Type> {
-        let _tracing = if cfg!(debug_assertions) {
-            Some(tracing::span!(tracing::Level::ERROR, "type_of_name").entered())
-        } else {
-            None
-        };
+        let _tracing = dev_span!("type_of_name");
 
         assert!(!name.is_empty(), "Cannot determine type of empty name");
 
@@ -3355,11 +3342,7 @@ impl Analyzer<'_, '_> {
 
     /// Returned type reflects conditional type facts.
     pub(super) fn type_of_var(&mut self, i: &RIdent, type_mode: TypeOfMode, type_args: Option<&TypeParamInstantiation>) -> VResult<Type> {
-        let _tracing = if cfg!(debug_assertions) {
-            Some(tracing::span!(tracing::Level::ERROR, "type_of_var").entered())
-        } else {
-            None
-        };
+        let _tracing = dev_span!("type_of_var");
 
         let span = i.span();
         let id: Id = i.into();

--- a/crates/stc_ts_file_analyzer/src/analyzer/expr/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/expr/mod.rs
@@ -688,11 +688,7 @@ impl Analyzer<'_, '_> {
     ///
     /// - `declared`: Key of declared property.
     pub(crate) fn key_matches(&mut self, span: Span, declared: &Key, cur: &Key, allow_union: bool) -> bool {
-        let _tracing = if cfg!(debug_assertions) {
-            Some(tracing::span!(tracing::Level::ERROR, "key_matches").entered())
-        } else {
-            None
-        };
+        let _tracing = dev_span!("key_matches");
 
         match declared {
             Key::Computed(..) => {}
@@ -3850,11 +3846,7 @@ impl Analyzer<'_, '_> {
     }
 
     fn type_of_ts_entity_name_inner(&mut self, span: Span, n: &RExpr, type_args: Option<&TypeParamInstantiation>) -> VResult<Type> {
-        let _tracing = if cfg!(debug_assertions) {
-            Some(tracing::span!(tracing::Level::ERROR, "type_of_ts_entity_name_inner").entered())
-        } else {
-            None
-        };
+        let _tracing = dev_span!("type_of_ts_entity_name_inner");
 
         let span = span.with_ctxt(SyntaxContext::empty());
         {

--- a/crates/stc_ts_file_analyzer/src/analyzer/expr/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/expr/mod.rs
@@ -25,7 +25,7 @@ use stc_ts_types::{
     KeywordType, KeywordTypeMetadata, LitType, LitTypeMetadata, Method, Module, ModuleTypeData, Operator, OptionalType, PropertySignature,
     QueryExpr, QueryType, QueryTypeMetadata, StaticThis, ThisType, TplElem, TplType, TplTypeMetadata, TypeParamInstantiation,
 };
-use stc_utils::{cache::Freeze, ext::TypeVecExt, panic_ctx, stack};
+use stc_utils::{cache::Freeze, dev_span, ext::TypeVecExt, panic_ctx, stack};
 use swc_atoms::js_word;
 use swc_common::{SourceMapper, Span, Spanned, SyntaxContext, TypeEq, DUMMY_SP};
 use swc_ecma_ast::{op, EsVersion, TruePlusMinus, TsKeywordTypeKind, TsTypeOperatorOp, VarDeclKind};
@@ -3242,11 +3242,7 @@ impl Analyzer<'_, '_> {
 
     /// Expand type parameters using `type_args`.
     pub(crate) fn expand_generics_with_type_args(&mut self, span: Span, ty: Type, type_args: &TypeParamInstantiation) -> VResult<Type> {
-        let _tracing = if cfg!(debug_assertions) {
-            Some(tracing::span!(tracing::Level::ERROR, "expand_generics_with_type_args").entered())
-        } else {
-            None
-        };
+        let _tracing = dev_span!("expand_generics_with_type_args");
 
         match ty.normalize() {
             Type::Interface(Interface { type_params, body, .. }) => {

--- a/crates/stc_ts_file_analyzer/src/analyzer/expr/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/expr/mod.rs
@@ -25,7 +25,7 @@ use stc_ts_types::{
     KeywordType, KeywordTypeMetadata, LitType, LitTypeMetadata, Method, Module, ModuleTypeData, Operator, OptionalType, PropertySignature,
     QueryExpr, QueryType, QueryTypeMetadata, StaticThis, ThisType, TplElem, TplType, TplTypeMetadata, TypeParamInstantiation,
 };
-use stc_utils::{cache::Freeze, debug_ctx, ext::TypeVecExt, stack};
+use stc_utils::{cache::Freeze, ext::TypeVecExt, panic_ctx, stack};
 use swc_atoms::js_word;
 use swc_common::{SourceMapper, Span, Spanned, SyntaxContext, TypeEq, DUMMY_SP};
 use swc_ecma_ast::{op, EsVersion, TruePlusMinus, TsKeywordTypeKind, TsTypeOperatorOp, VarDeclKind};
@@ -102,7 +102,7 @@ impl Analyzer<'_, '_> {
         type_ann: Option<&Type>,
     ) -> VResult<Type> {
         let _stack = stack::start(64);
-        let _ctx = debug_ctx!(format!(
+        let _ctx = panic_ctx!(format!(
             "validate {}\n{}\nExpr: {:?}",
             self.cm.span_to_string(e.span()),
             self.cm.span_to_snippet(e.span()).unwrap_or_else(|_| "no-source".into()),

--- a/crates/stc_ts_file_analyzer/src/analyzer/expr/object.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/expr/object.rs
@@ -58,11 +58,7 @@ impl Analyzer<'_, '_> {
     /// Type of `a` in the code above is `{ a: number, b?: undefined } | {
     /// a:number, b: string }`.
     pub(super) fn normalize_union(&mut self, ty: &mut Type, preserve_specified: bool) {
-        let _tracing = if cfg!(debug_assertions) {
-            Some(tracing::span!(tracing::Level::ERROR, "normalize_union").entered())
-        } else {
-            None
-        };
+        let _tracing = dev_span!("normalize_union");
 
         let start = Instant::now();
         ty.visit_mut_with(&mut ObjectUnionNormalizer { preserve_specified });
@@ -112,11 +108,7 @@ impl Analyzer<'_, '_> {
         prop: &RPropOrSpread,
         object_type: Option<&Type>,
     ) -> VResult<Type> {
-        let _tracing = if cfg!(debug_assertions) {
-            Some(tracing::span!(tracing::Level::ERROR, "append_prop_or_spread_to_type").entered())
-        } else {
-            None
-        };
+        let _tracing = dev_span!("append_prop_or_spread_to_type");
 
         match prop {
             RPropOrSpread::Spread(RSpreadElement { dot3_token, expr, .. }) => {

--- a/crates/stc_ts_file_analyzer/src/analyzer/expr/object.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/expr/object.rs
@@ -6,7 +6,7 @@ use stc_ts_errors::{DebugExt, ErrorKind};
 use stc_ts_file_analyzer_macros::validator;
 use stc_ts_type_ops::{union_normalization::ObjectUnionNormalizer, Fix};
 use stc_ts_types::{Accessor, Key, MethodSignature, PropertySignature, Type, TypeElement, TypeLit, TypeParam, Union, UnionMetadata};
-use stc_utils::cache::Freeze;
+use stc_utils::{cache::Freeze, dev_span};
 use swc_common::{Span, Spanned, SyntaxContext, TypeEq};
 use swc_ecma_ast::TsKeywordTypeKind;
 use tracing::debug;
@@ -189,11 +189,7 @@ impl Analyzer<'_, '_> {
     /// `{ a: number } + ( {b: number} | { c: number } )` => `{ a: number, b:
     /// number } | { a: number, c: number }`
     pub(crate) fn append_type(&mut self, span: Span, to: Type, rhs: Type, opts: AppendTypeOpts) -> VResult<Type> {
-        let _tracing = if cfg!(debug_assertions) {
-            Some(tracing::span!(tracing::Level::ERROR, "append_type").entered())
-        } else {
-            None
-        };
+        let _tracing = dev_span!("append_type");
 
         if to.is_any() || to.is_unknown() {
             return Ok(to);

--- a/crates/stc_ts_file_analyzer/src/analyzer/expr/object.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/expr/object.rs
@@ -68,8 +68,9 @@ impl Analyzer<'_, '_> {
         debug!("Normalized unions (time = {:?})", end - start);
     }
 
-    #[cfg_attr(debug_assertions, tracing::instrument(skip_all))]
     pub(crate) fn validate_type_literals(&mut self, ty: &Type, is_type_ann: bool) {
+        let _tracing = dev_span!("validate_type_literals");
+
         match ty.normalize() {
             Type::Union(ty) => {
                 for ty in &ty.types {
@@ -83,8 +84,9 @@ impl Analyzer<'_, '_> {
         }
     }
 
-    #[cfg_attr(debug_assertions, tracing::instrument(skip_all))]
     pub(crate) fn report_errors_for_mixed_optional_method_signatures(&mut self, elems: &[TypeElement]) {
+        let _tracing = dev_span!("report_errors_for_mixed_optional_method_signatures");
+
         let mut keys: Vec<(&Key, bool)> = vec![];
         for elem in elems {
             if let TypeElement::Method(MethodSignature { key, optional, .. }) = elem {

--- a/crates/stc_ts_file_analyzer/src/analyzer/expr/object.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/expr/object.rs
@@ -317,11 +317,7 @@ impl Analyzer<'_, '_> {
     }
 
     pub(crate) fn append_type_element(&mut self, to: Type, rhs: TypeElement) -> VResult<Type> {
-        let _tracing = if cfg!(debug_assertions) {
-            Some(tracing::span!(tracing::Level::ERROR, "append_type_element").entered())
-        } else {
-            None
-        };
+        let _tracing = dev_span!("append_type_element");
 
         if to.is_any() || to.is_unknown() {
             return Ok(to);

--- a/crates/stc_ts_file_analyzer/src/analyzer/expr/type_cast.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/expr/type_cast.rs
@@ -3,7 +3,7 @@ use std::borrow::Cow;
 use stc_ts_ast_rnode::{RTsAsExpr, RTsLit, RTsTypeAssertion};
 use stc_ts_errors::{DebugExt, ErrorKind};
 use stc_ts_types::{Interface, KeywordType, LitType, TypeElement, TypeParamInstantiation};
-use stc_utils::cache::Freeze;
+use stc_utils::{cache::Freeze, dev_span};
 use swc_common::{Span, Spanned, TypeEq};
 use swc_ecma_ast::TsKeywordTypeKind;
 
@@ -207,11 +207,7 @@ impl Analyzer<'_, '_> {
     }
 
     pub(crate) fn has_overlap(&mut self, span: Span, l: &Type, r: &Type, opts: CastableOpts) -> VResult<bool> {
-        let _tracing = if cfg!(debug_assertions) {
-            Some(tracing::span!(tracing::Level::ERROR, "has_overlap").entered())
-        } else {
-            None
-        };
+        let _tracing = dev_span!("has_overlap");
 
         let l = l.normalize();
         let r = r.normalize();
@@ -228,11 +224,7 @@ impl Analyzer<'_, '_> {
     /// - `l`: from
     /// - `r`: to
     pub(crate) fn castable(&mut self, span: Span, from: &Type, to: &Type, opts: CastableOpts) -> VResult<bool> {
-        let _tracing = if cfg!(debug_assertions) {
-            Some(tracing::span!(tracing::Level::ERROR, "castable").entered())
-        } else {
-            None
-        };
+        let _tracing = dev_span!("castable");
 
         let from = self
             .normalize(

--- a/crates/stc_ts_file_analyzer/src/analyzer/generalize.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/generalize.rs
@@ -8,7 +8,7 @@ use stc_ts_types::{
     KeywordTypeMetadata, LitType, LitTypeMetadata, Mapped, Operator, PropertySignature, TypeElement, TypeLit, TypeLitMetadata, TypeParam,
     Union,
 };
-use stc_utils::ext::TypeVecExt;
+use stc_utils::{dev_span, ext::TypeVecExt};
 use swc_atoms::js_word;
 use swc_common::{EqIgnoreSpan, Spanned};
 use swc_ecma_ast::{TsKeywordTypeKind, TsTypeOperatorOp};
@@ -20,8 +20,9 @@ impl Analyzer<'_, '_> {
     /// TODO(kdy1): Remove this.
     ///
     /// Check if it's okay to generalize `ty`.
-    #[cfg_attr(debug_assertions, tracing::instrument(skip_all))]
     pub(super) fn may_generalize(&self, ty: &Type) -> bool {
+        let _tracing = dev_span!("may_generalize");
+
         trace!("may_generalize({:?})", ty);
         match ty.normalize() {
             Type::Function(f) => {

--- a/crates/stc_ts_file_analyzer/src/analyzer/generalize.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/generalize.rs
@@ -47,13 +47,15 @@ impl Analyzer<'_, '_> {
         !ty.metadata().prevent_generalization
     }
 
-    #[cfg_attr(debug_assertions, tracing::instrument(skip_all))]
     pub(super) fn prevent_inference_while_simplifying(&self, ty: &mut Type) {
+        let _tracing = dev_span!("prevent_inference_while_simplifying");
+
         ty.visit_mut_with(&mut PreventComplexSimplification);
     }
 
-    #[cfg_attr(debug_assertions, tracing::instrument(skip_all))]
     pub(super) fn simplify(&self, ty: Type) -> Type {
+        let _tracing = dev_span!("simplify");
+
         info!("Simplifying {}", dump_type_as_string(&ty));
         ty.fold_with(&mut Simplifier { env: &self.env })
     }

--- a/crates/stc_ts_file_analyzer/src/analyzer/generic/expander.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/generic/expander.rs
@@ -40,13 +40,14 @@ pub(crate) struct ExtendsOpts {
 
 /// Generic expander.
 impl Analyzer<'_, '_> {
-    #[cfg_attr(debug_assertions, tracing::instrument(skip_all))]
     pub(in super::super) fn instantiate_type_params_using_args(
         &mut self,
         span: Span,
         type_params: &TypeParamDecl,
         type_args: &TypeParamInstantiation,
     ) -> VResult<FxHashMap<Id, Type>> {
+        let _tracing = dev_span!("instantiate_type_params_using_args");
+
         let mut params = FxHashMap::default();
 
         for (idx, param) in type_params.params.iter().enumerate() {

--- a/crates/stc_ts_file_analyzer/src/analyzer/generic/expander.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/generic/expander.rs
@@ -88,11 +88,12 @@ impl Analyzer<'_, '_> {
     ///z     T extends {
     ///          x: infer P extends number ? infer P : string;
     ///      } ? P : never
-    #[cfg_attr(debug_assertions, tracing::instrument(skip_all))]
     pub(in super::super) fn expand_type_params<T>(&mut self, params: &FxHashMap<Id, Type>, ty: T, opts: ExpandGenericOpts) -> VResult<T>
     where
         T: for<'aa> FoldWith<GenericExpander<'aa>> + Fix,
     {
+        let _tracing = dev_span!("expand_type_params");
+
         for param in params.values() {
             param.assert_valid();
             debug_assert!(param.is_clone_cheap());

--- a/crates/stc_ts_file_analyzer/src/analyzer/generic/expander.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/generic/expander.rs
@@ -7,7 +7,7 @@ use stc_ts_generics::{
 };
 use stc_ts_type_ops::Fix;
 use stc_ts_types::{Id, Interface, KeywordType, TypeParam, TypeParamDecl, TypeParamInstantiation};
-use stc_utils::{cache::Freeze, ext::SpanExt};
+use stc_utils::{cache::Freeze, dev_span, ext::SpanExt};
 use swc_common::{Span, Spanned, TypeEq};
 use swc_ecma_ast::*;
 use tracing::debug;
@@ -117,15 +117,11 @@ impl Analyzer<'_, '_> {
         let _tracing = if cfg!(debug_assertions) {
             let child = dump_type_as_string(child);
             let parent = dump_type_as_string(parent);
-            Some(
-                tracing::span!(
-                    tracing::Level::ERROR,
-                    "extends",
-                    child = tracing::field::display(&child),
-                    parent = tracing::field::display(&parent)
-                )
-                .entered(),
-            )
+            Some(dev_span!(
+                "extends",
+                child = tracing::field::display(&child),
+                parent = tracing::field::display(&parent)
+            ))
         } else {
             None
         };

--- a/crates/stc_ts_file_analyzer/src/analyzer/generic/inference.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/generic/inference.rs
@@ -21,7 +21,7 @@ use stc_utils::{cache::Freeze, dev_span};
 use swc_atoms::Atom;
 use swc_common::{EqIgnoreSpan, Span, Spanned, SyntaxContext, TypeEq};
 use swc_ecma_ast::{TsKeywordTypeKind, TsTypeOperatorOp};
-use tracing::{debug, error, info, Level};
+use tracing::{debug, error, info};
 
 use crate::{
     analyzer::{assign::AssignOpts, generic::InferData, Analyzer},

--- a/crates/stc_ts_file_analyzer/src/analyzer/generic/inference.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/generic/inference.rs
@@ -1447,8 +1447,7 @@ impl Analyzer<'_, '_> {
         inferred: &mut InferData,
         is_from_type_ann: bool,
     ) {
-        #[cfg(debug_assertions)]
-        let _tracing = tracing::span!(Level::ERROR, "prevent_generalization_of_top_level_types").entered();
+        let _tracing = dev_span!("prevent_generalization_of_top_level_types");
 
         if is_from_type_ann {
             if let Some(ret_ty) = ret_ty {
@@ -1480,8 +1479,7 @@ impl Analyzer<'_, '_> {
         inferred: &mut InferData,
         is_from_type_ann: bool,
     ) {
-        #[cfg(debug_assertions)]
-        let _tracing = tracing::span!(Level::ERROR, "prevent_generalization_of_inferred_types").entered();
+        let _tracing = dev_span!("prevent_generalization_of_inferred_types");
 
         for type_param in type_params {
             if !inferred.skip_generalization {

--- a/crates/stc_ts_file_analyzer/src/analyzer/generic/inference.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/generic/inference.rs
@@ -17,7 +17,7 @@ use stc_ts_types::{
     Array, ArrayMetadata, Class, ClassDef, ClassMember, Function, Id, Interface, KeywordType, KeywordTypeMetadata, LitType, Operator, Ref,
     TplElem, TplType, Type, TypeElement, TypeLit, TypeParam, TypeParamMetadata, Union,
 };
-use stc_utils::cache::Freeze;
+use stc_utils::{cache::Freeze, dev_span};
 use swc_atoms::Atom;
 use swc_common::{EqIgnoreSpan, Span, Spanned, SyntaxContext, TypeEq};
 use swc_ecma_ast::{TsKeywordTypeKind, TsTypeOperatorOp};
@@ -165,8 +165,7 @@ impl Analyzer<'_, '_> {
         matches: impl Fn(&mut Analyzer, &Type, &Type) -> bool,
         opts: InferTypeOpts,
     ) -> VResult<(Vec<Type>, Vec<Type>)> {
-        #[cfg(debug_assertions)]
-        let _tracing = tracing::span!(Level::ERROR, "infer_from_matching_types").entered();
+        let _tracing = dev_span!("infer_from_matching_types");
 
         let mut matched_sources: Vec<Type> = vec![];
         let mut matched_targets: Vec<Type> = vec![];
@@ -218,11 +217,7 @@ impl Analyzer<'_, '_> {
         arg: &Type,
         opts: InferTypeOpts,
     ) -> VResult<()> {
-        let _tracing = if cfg!(debug_assertions) {
-            Some(tracing::span!(tracing::Level::ERROR, "infer_type_using_union").entered())
-        } else {
-            None
-        };
+        let _tracing = dev_span!("infer_type_using_union");
 
         let (temp_sources, temp_targets) = self.infer_from_matching_types(
             span,
@@ -801,14 +796,12 @@ impl Analyzer<'_, '_> {
                     return Ok(());
                 }
 
-                let _tracing = tracing::span!(
-                    Level::ERROR,
+                let _tracing = dev_span!(
                     "infer_type: type param",
                     name = name.as_str(),
                     new = tracing::field::display(&dump_type_as_string(&arg)),
                     prev = tracing::field::display(&dump_type_as_string(&e.get().inferred_type))
-                )
-                .entered();
+                );
 
                 if opts.priority < e.get().priority {
                     e.get_mut().candidates = Default::default();

--- a/crates/stc_ts_file_analyzer/src/analyzer/generic/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/generic/mod.rs
@@ -323,11 +323,7 @@ impl Analyzer<'_, '_> {
         concrete: &Type,
         opts: InferTypeOpts,
     ) -> VResult<FxHashMap<Id, Type>> {
-        let _tracing = if cfg!(debug_assertions) {
-            Some(tracing::span!(tracing::Level::ERROR, "infer_ts_infer_types").entered())
-        } else {
-            None
-        };
+        let _tracing = dev_span!("infer_ts_infer_types");
 
         let mut inferred = InferData::default();
         self.infer_type(span, &mut inferred, base, concrete, opts)?;

--- a/crates/stc_ts_file_analyzer/src/analyzer/generic/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/generic/mod.rs
@@ -26,7 +26,7 @@ use stc_utils::{
 use swc_atoms::js_word;
 use swc_common::{EqIgnoreSpan, Span, Spanned, SyntaxContext, TypeEq, DUMMY_SP};
 use swc_ecma_ast::*;
-use tracing::{debug, error, info, span, trace, warn, Level};
+use tracing::{debug, error, info, trace, warn};
 
 use self::inference::{InferenceInfo, InferencePriority};
 pub(crate) use self::{expander::ExtendsOpts, inference::InferTypeOpts};
@@ -457,7 +457,7 @@ impl Analyzer<'_, '_> {
             let param_str = force_dump_type_as_string(param);
             let arg_str = force_dump_type_as_string(arg);
 
-            Some(span!(Level::ERROR, "infer_type", param = &*param_str, arg = &*arg_str).entered())
+            Some(dev_span!("infer_type", param = &*param_str, arg = &*arg_str))
         } else {
             None
         };
@@ -2150,11 +2150,7 @@ impl Analyzer<'_, '_> {
         let l_max = param.elems.len().saturating_sub(get_tuple_subtract_count(&arg.elems));
         let r_max = arg.elems.len().saturating_sub(get_tuple_subtract_count(&param.elems));
 
-        let _tracing = if cfg!(debug_assertions) {
-            Some(span!(Level::ERROR, "infer_type_using_tuple_and_tuple", l_max = l_max, r_max = r_max).entered())
-        } else {
-            None
-        };
+        let _tracing = dev_span!("infer_type_using_tuple_and_tuple", l_max = l_max, r_max = r_max);
 
         for index in 0..len {
             let li = min(index, l_max);

--- a/crates/stc_ts_file_analyzer/src/analyzer/generic/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/generic/mod.rs
@@ -21,7 +21,7 @@ use stc_ts_types::{
 use stc_ts_utils::MapWithMut;
 use stc_utils::{
     cache::{Freeze, ALLOW_DEEP_CLONE},
-    stack,
+    dev_span, stack,
 };
 use swc_atoms::js_word;
 use swc_common::{EqIgnoreSpan, Span, Spanned, SyntaxContext, TypeEq, DUMMY_SP};
@@ -103,7 +103,7 @@ impl Analyzer<'_, '_> {
         opts: InferTypeOpts,
     ) -> VResult<InferTypeResult> {
         #[cfg(debug_assertions)]
-        let _tracing = tracing::error_span!("infer_arg_types").entered();
+        let _tracing = dev_span!("infer_arg_types");
 
         warn!(
             "infer_arg_types: {:?}",
@@ -1401,8 +1401,7 @@ impl Analyzer<'_, '_> {
         arg: &Type,
         opts: InferTypeOpts,
     ) -> VResult<bool> {
-        #[cfg(debug_assertions)]
-        let _tracing = tracing::error_span!("infer_type_using_mapped_type").entered();
+        let _tracing = dev_span!("infer_type_using_mapped_type");
 
         match arg.normalize() {
             Type::Ref(arg) => {
@@ -2161,8 +2160,7 @@ impl Analyzer<'_, '_> {
             let li = min(index, l_max);
             let ri = min(index, r_max);
 
-            #[cfg(debug_assertions)]
-            let _tracing = tracing::error_span!("infer_type_using_tuple_and_tuple", li = li, ri = ri).entered();
+            let _tracing = dev_span!("infer_type_using_tuple_and_tuple", li = li, ri = ri);
 
             let l_elem_type = self.access_property(
                 span,

--- a/crates/stc_ts_file_analyzer/src/analyzer/pat.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/pat.rs
@@ -9,7 +9,7 @@ use stc_ts_types::{
     TypeElement, TypeLit, TypeLitMetadata,
 };
 use stc_ts_utils::PatExt;
-use stc_utils::{cache::Freeze, ext::TypeVecExt};
+use stc_utils::{cache::Freeze, dev_span, ext::TypeVecExt};
 use swc_atoms::js_word;
 use swc_common::{Spanned, TypeEq, DUMMY_SP};
 use swc_ecma_ast::*;
@@ -39,7 +39,6 @@ pub(super) enum PatMode {
 }
 
 impl Analyzer<'_, '_> {
-    #[cfg_attr(debug_assertions, tracing::instrument(skip_all))]
     pub(crate) fn mark_as_implicitly_typed(&mut self, ty: &mut Type) {
         ty.metadata_mut().implicit = true;
     }
@@ -48,8 +47,9 @@ impl Analyzer<'_, '_> {
         ty.metadata().implicit
     }
 
-    #[cfg_attr(debug_assertions, tracing::instrument(skip_all))]
     pub(crate) fn default_type_for_pat(&mut self, pat: &RPat) -> VResult<Type> {
+        let _tracing = dev_span!("default_type_for_pat");
+
         let span = pat.span();
         match pat {
             RPat::Array(arr) => {

--- a/crates/stc_ts_file_analyzer/src/analyzer/props.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/props.rs
@@ -234,8 +234,9 @@ impl Analyzer<'_, '_> {
         }
     }
 
-    #[cfg_attr(debug_assertions, tracing::instrument(skip_all))]
     fn is_type_valid_for_computed_key(&mut self, span: Span, ty: &Type) -> bool {
+        let _tracing = dev_span!("is_type_valid_for_computed_key");
+
         if (ty.metadata().resolved_from_var || ty.metadata().prevent_generalization) && (ty.is_str_lit() || ty.is_num_lit()) {
             return true;
         }

--- a/crates/stc_ts_file_analyzer/src/analyzer/props.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/props.rs
@@ -5,7 +5,7 @@ use stc_ts_ast_rnode::{RComputedPropName, RExpr, RGetterProp, RIdent, RMemberExp
 use stc_ts_errors::{ErrorKind, Errors};
 use stc_ts_file_analyzer_macros::extra_validator;
 use stc_ts_types::{Accessor, ComputedKey, Key, KeywordType, PrivateName, TypeParam};
-use stc_utils::cache::Freeze;
+use stc_utils::{cache::Freeze, dev_span};
 use swc_atoms::js_word;
 use swc_common::{Span, Spanned, SyntaxContext};
 use swc_ecma_ast::*;
@@ -201,8 +201,9 @@ impl Analyzer<'_, '_> {
     ///
     /// See: `computedPropertyNames32_ES5.ts`
     #[extra_validator]
-    #[cfg_attr(debug_assertions, tracing::instrument(skip_all))]
     pub(crate) fn report_error_for_usage_of_type_param_of_declaring_class(&mut self, used_type_params: &[TypeParam], span: Span) {
+        let _tracing = dev_span!("report_error_for_usage_of_type_param_of_declaring_class");
+
         debug_assert!(self.ctx.in_computed_prop_name);
 
         for used in used_type_params {

--- a/crates/stc_ts_file_analyzer/src/analyzer/scope/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/scope/mod.rs
@@ -545,8 +545,9 @@ impl Scope<'_> {
     }
 
     /// Add a type to the scope.
-    #[instrument(name = "Scope::register_type", skip_all)]
     fn register_type(&mut self, name: Id, ty: Type, should_override: bool) {
+        let _tracing = dev_span!("Scope::register_type");
+
         ty.assert_valid();
 
         let ty = ty.freezed();

--- a/crates/stc_ts_file_analyzer/src/analyzer/scope/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/scope/mod.rs
@@ -26,7 +26,7 @@ use stc_ts_types::{
 };
 use stc_utils::{
     cache::{Freeze, ALLOW_DEEP_CLONE},
-    stack,
+    dev_span, stack,
 };
 use swc_atoms::js_word;
 use swc_common::{util::move_map::MoveMap, Span, Spanned, SyntaxContext, TypeEq, DUMMY_SP};
@@ -706,11 +706,7 @@ impl Analyzer<'_, '_> {
     ///    assignment, and false if you are going to use it in user-visible
     ///    stuffs (e.g. type annotation for .d.ts file)
     pub(super) fn expand(&mut self, span: Span, ty: Type, opts: ExpandOpts) -> VResult<Type> {
-        let _tracing = if cfg!(debug_assertions) {
-            Some(tracing::span!(tracing::Level::ERROR, "expand").entered())
-        } else {
-            None
-        };
+        let _tracing = dev_span!("expand");
 
         if !self.config.is_builtin {
             debug_assert_ne!(span, DUMMY_SP, "expand: {:#?} cannot be expanded because it has empty span", ty);
@@ -788,11 +784,7 @@ impl Analyzer<'_, '_> {
     }
 
     pub(super) fn register_type(&mut self, name: Id, ty: Type) -> Type {
-        let _tracing = if cfg!(debug_assertions) {
-            Some(tracing::span!(tracing::Level::ERROR, "register_type").entered())
-        } else {
-            None
-        };
+        let _tracing = dev_span!("register_type");
 
         if cfg!(debug_assertions) {
             debug!("[({})/types] Registering: {:?}", self.scope.depth(), name);
@@ -1136,11 +1128,7 @@ impl Analyzer<'_, '_> {
     }
 
     fn find_local_type(&self, name: &Id) -> Option<ItemRef<Type>> {
-        let _tracing = if cfg!(debug_assertions) {
-            Some(tracing::span!(tracing::Level::ERROR, "find_local_type").entered())
-        } else {
-            None
-        };
+        let _tracing = dev_span!("find_local_type", name = tracing::field::debug(name));
 
         #[allow(dead_code)]
         static ANY: Lazy<Type> = Lazy::new(|| {

--- a/crates/stc_ts_file_analyzer/src/analyzer/scope/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/scope/mod.rs
@@ -31,7 +31,7 @@ use stc_utils::{
 use swc_atoms::js_word;
 use swc_common::{util::move_map::MoveMap, Span, Spanned, SyntaxContext, TypeEq, DUMMY_SP};
 use swc_ecma_ast::*;
-use tracing::{debug, error, info, instrument};
+use tracing::{debug, error, info};
 
 pub(crate) use self::vars::VarKind;
 use super::util::make_instance_type;
@@ -1811,8 +1811,9 @@ impl<'a> Scope<'a> {
     }
 
     /// This method does **not** handle imported types.
-    #[instrument(name = "Scope::find_type", skip(self))]
     fn find_type(&self, name: &Id) -> Option<ItemRef<Type>> {
+        let _tracing = dev_span!("Scope::find_type", name = tracing::field::debug(name));
+
         if cfg!(debug_assertions) {
             debug!("Analyzer.find_type('{}')", name);
         }
@@ -2192,8 +2193,9 @@ impl Expander<'_, '_, '_> {
         Ok(Some(Type::any(span, Default::default())))
     }
 
-    #[instrument(name = "Expander.expand_ref", skip(self, r, was_top_level))]
     fn expand_ref(&mut self, r: Ref, was_top_level: bool) -> VResult<Option<Type>> {
+        let _tracing = dev_span!("Expander::expand_ref");
+
         let trying_primitive_expansion = self.analyzer.scope.expand_triage_depth != 0;
 
         let Ref {
@@ -2227,8 +2229,9 @@ impl Expander<'_, '_, '_> {
         Ok(ty)
     }
 
-    #[instrument(name = "Expander.expand_type", skip(self, ty))]
     fn expand_type(&mut self, mut ty: Type) -> Type {
+        let _tracing = dev_span!("Expander::expand_type");
+
         match ty {
             Type::Keyword(..) | Type::Lit(..) => return ty,
             Type::Arc(..) => {

--- a/crates/stc_ts_file_analyzer/src/analyzer/scope/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/scope/mod.rs
@@ -1620,11 +1620,7 @@ impl Analyzer<'_, '_> {
         actual_ty: Option<Type>,
         default_ty: Option<Type>,
     ) -> VResult<Option<Type>> {
-        let _tracing = if cfg!(debug_assertions) {
-            Some(tracing::span!(tracing::Level::ERROR, "declare_complex_vars").entered())
-        } else {
-            None
-        };
+        let _tracing = dev_span!("declare_complex_vars");
 
         match pat {
             RPat::Assign(..) | RPat::Ident(..) | RPat::Array(..) | RPat::Object(..) | RPat::Rest(..) => self.add_vars(

--- a/crates/stc_ts_file_analyzer/src/analyzer/scope/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/scope/mod.rs
@@ -1101,8 +1101,9 @@ impl Analyzer<'_, '_> {
         ty
     }
 
-    #[instrument(skip(self))]
     pub fn find_type(&self, name: &Id) -> VResult<Option<ItemRef<Type>>> {
+        let _tracing = dev_span!("find_type", name = tracing::field::debug(name));
+
         if let Some(v) = self.find_local_type(name) {
             return Ok(Some(v));
         }

--- a/crates/stc_ts_file_analyzer/src/analyzer/scope/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/scope/mod.rs
@@ -1646,11 +1646,12 @@ impl Analyzer<'_, '_> {
     }
 
     /// Mark `ty` as not expanded by default.
-    #[cfg_attr(debug_assertions, tracing::instrument(skip_all))]
     pub(crate) fn prevent_expansion<T>(&self, ty: &mut T)
     where
         T: VisitMutWith<ExpansionPreventer>,
     {
+        let _tracing = dev_span!("prevent_expansion");
+
         if self.config.is_builtin {
             return;
         }

--- a/crates/stc_ts_file_analyzer/src/analyzer/scope/vars.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/scope/vars.rs
@@ -13,7 +13,7 @@ use stc_ts_types::{
     TupleMetadata, Type, TypeElement, TypeLit, TypeLitMetadata, TypeParam, TypeParamInstantiation, Union,
 };
 use stc_ts_utils::{run, PatExt};
-use stc_utils::{cache::Freeze, TryOpt};
+use stc_utils::{cache::Freeze, dev_span, TryOpt};
 use swc_common::{Span, Spanned, SyntaxContext, DUMMY_SP};
 use swc_ecma_ast::{TsKeywordTypeKind, VarDeclKind};
 use tracing::debug;
@@ -882,11 +882,7 @@ impl Analyzer<'_, '_> {
     }
 
     pub(crate) fn exclude_props(&mut self, span: Span, ty: &Type, keys: &[Key]) -> VResult<Type> {
-        let _tracing = if cfg!(debug_assertions) {
-            Some(tracing::span!(tracing::Level::ERROR, "exclude_props").entered())
-        } else {
-            None
-        };
+        let _tracing = dev_span!("exclude_props");
 
         let span = span.with_ctxt(SyntaxContext::empty());
 

--- a/crates/stc_ts_file_analyzer/src/analyzer/stmt/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/stmt/mod.rs
@@ -7,7 +7,7 @@ use stc_ts_types::{LitType, Type};
 use stc_utils::{dev_span, stack};
 use swc_common::{Spanned, DUMMY_SP};
 use swc_ecma_utils::Value::Known;
-use tracing::{instrument, trace, warn};
+use tracing::{trace, warn};
 
 use self::return_type::LoopBreakerFinder;
 use crate::{
@@ -141,8 +141,9 @@ impl Analyzer<'_, '_> {
 
 impl Analyzer<'_, '_> {
     /// Validate that parent interfaces are all resolved.
-    #[instrument(skip_all)]
     pub(super) fn resolve_parent_interfaces(&mut self, parents: &[RTsExprWithTypeArgs], is_for_interface: bool) {
+        let _tracing = dev_span!("resolve_parent_interfaces");
+
         if self.config.is_builtin {
             return;
         }

--- a/crates/stc_ts_file_analyzer/src/analyzer/stmt/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/stmt/mod.rs
@@ -4,10 +4,10 @@ use rnode::VisitWith;
 use stc_ts_ast_rnode::{RBlockStmt, RBool, RExpr, RExprStmt, RForStmt, RModuleItem, RStmt, RTsExprWithTypeArgs, RTsLit, RWithStmt};
 use stc_ts_errors::{DebugExt, ErrorKind};
 use stc_ts_types::{LitType, Type};
-use stc_utils::stack;
+use stc_utils::{dev_span, stack};
 use swc_common::{Spanned, DUMMY_SP};
 use swc_ecma_utils::Value::Known;
-use tracing::{instrument, span, trace, warn, Level};
+use tracing::{instrument, trace, warn};
 
 use self::return_type::LoopBreakerFinder;
 use crate::{
@@ -39,8 +39,7 @@ impl Analyzer<'_, '_> {
         let span = s.span();
         let line_col = self.line_col(span);
 
-        let tracing_span = span!(Level::ERROR, "Stmt", line_col = &*line_col);
-        let _tracing_guard = tracing_span.enter();
+        let _tracing = dev_span!("Stmt", line_col = &*line_col);
 
         warn!("Statement start");
         let start = Instant::now();

--- a/crates/stc_ts_file_analyzer/src/analyzer/stmt/return_type.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/stmt/return_type.rs
@@ -12,6 +12,7 @@ use stc_ts_types::{
 };
 use stc_utils::{
     cache::Freeze,
+    dev_span,
     ext::{SpanExt, TypeVecExt},
 };
 use swc_common::{Span, Spanned, SyntaxContext, TypeEq, DUMMY_SP};
@@ -62,11 +63,7 @@ impl Analyzer<'_, '_> {
         is_generator: bool,
         stmts: &Vec<RStmt>,
     ) -> VResult<Option<Type>> {
-        let _tracing = if cfg!(debug_assertions) {
-            Some(tracing::span!(tracing::Level::ERROR, "visit_stmts_for_return").entered())
-        } else {
-            None
-        };
+        let _tracing = dev_span!("visit_stmts_for_return");
 
         let marks = self.marks();
 

--- a/crates/stc_ts_file_analyzer/src/analyzer/types/mapped.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/types/mapped.rs
@@ -13,7 +13,10 @@ use stc_ts_types::{
     replace::replace_type, Array, Conditional, FnParam, Id, IndexSignature, IndexedAccessType, Key, KeywordType, LitType, Mapped, Operator,
     PropertySignature, RestType, Tuple, TupleElement, Type, TypeElement, TypeLit, TypeParam,
 };
-use stc_utils::cache::{Freeze, ALLOW_DEEP_CLONE};
+use stc_utils::{
+    cache::{Freeze, ALLOW_DEEP_CLONE},
+    dev_span,
+};
 use swc_common::{Span, Spanned, SyntaxContext, TypeEq};
 use swc_ecma_ast::{TruePlusMinus, TsKeywordTypeKind, TsTypeOperatorOp};
 use tracing::{debug, error, instrument};
@@ -139,11 +142,7 @@ impl Analyzer<'_, '_> {
         original_keyof_operand: &Type,
         m: &Mapped,
     ) -> VResult<Option<Type>> {
-        let _tracing = if cfg!(debug_assertions) {
-            Some(tracing::span!(tracing::Level::ERROR, "expand_mapped_type_with_keyof").entered())
-        } else {
-            None
-        };
+        let _tracing = dev_span!("expand_mapped_type_with_keyof");
 
         let keyof_operand = self
             .normalize(Some(span), Cow::Borrowed(keyof_operand), Default::default())

--- a/crates/stc_ts_file_analyzer/src/analyzer/types/mapped.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/types/mapped.rs
@@ -19,7 +19,7 @@ use stc_utils::{
 };
 use swc_common::{Span, Spanned, SyntaxContext, TypeEq};
 use swc_ecma_ast::{TruePlusMinus, TsKeywordTypeKind, TsTypeOperatorOp};
-use tracing::{debug, error, instrument};
+use tracing::{debug, error};
 
 use crate::{
     analyzer::{types::NormalizeTypeOpts, Analyzer},
@@ -36,8 +36,9 @@ impl Analyzer<'_, '_> {
     ///
     ///
     /// TODO(kdy1): Handle index signatures.
-    #[instrument(name = "expand_mapped", skip_all)]
     pub(crate) fn expand_mapped(&mut self, span: Span, m: &Mapped) -> VResult<Option<Type>> {
+        let _tracing = dev_span!("expand_mapped");
+
         let orig = dump_type_as_string(&ALLOW_DEEP_CLONE.set(&(), || Type::Mapped(m.clone())));
 
         let ty = self.expand_mapped_inner(span, m)?;

--- a/crates/stc_ts_file_analyzer/src/analyzer/types/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/types/mod.rs
@@ -1522,11 +1522,7 @@ impl Analyzer<'_, '_> {
     }
 
     pub(crate) fn can_be_undefined(&mut self, span: Span, ty: &Type, include_null: bool) -> VResult<bool> {
-        let _tracing = if cfg!(debug_assertions) {
-            Some(tracing::span!(tracing::Level::ERROR, "can_be_undefined", include_null = include_null).entered())
-        } else {
-            None
-        };
+        let _tracing = dev_span!("can_be_undefined", include_null = include_null);
 
         let ty = self
             .normalize(Some(span), Cow::Borrowed(ty), Default::default())

--- a/crates/stc_ts_file_analyzer/src/analyzer/types/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/types/mod.rs
@@ -24,6 +24,7 @@ use stc_ts_types::{
 use stc_ts_utils::run;
 use stc_utils::{
     cache::{Freeze, ALLOW_DEEP_CLONE},
+    dev_span,
     ext::{SpanExt, TypeVecExt},
     stack,
 };
@@ -2327,11 +2328,7 @@ impl Analyzer<'_, '_> {
             return Ok(());
         }
 
-        let _tracing = if cfg!(debug_assertions) {
-            Some(tracing::span!(tracing::Level::ERROR, "report_error_for_unresolved_type").entered())
-        } else {
-            None
-        };
+        let _tracing = dev_span!("report_error_for_unresolved_type");
 
         let l = left_of_expr(type_name);
         let l = match l {

--- a/crates/stc_ts_file_analyzer/src/analyzer/types/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/types/mod.rs
@@ -1667,11 +1667,7 @@ impl Analyzer<'_, '_> {
     }
 
     pub(crate) fn apply_type_facts(&mut self, name: &Name, ty: Type) -> Type {
-        let _tracing = if cfg!(debug_assertions) {
-            Some(tracing::span!(tracing::Level::ERROR, "apply_type_facts", name = tracing::field::debug(name)).entered())
-        } else {
-            None
-        };
+        let _tracing = dev_span!("apply_type_facts", name = tracing::field::debug(name));
 
         let type_facts = self.scope.get_type_facts(name) | self.cur_facts.true_facts.facts.get(name).copied().unwrap_or(TypeFacts::None);
 

--- a/crates/stc_ts_file_analyzer/src/analyzer/types/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/types/mod.rs
@@ -1581,8 +1581,9 @@ impl Analyzer<'_, '_> {
         Ok(Some(ty))
     }
 
-    #[instrument(skip_all)]
     pub(crate) fn create_prototype_of_class_def(&mut self, def: &ClassDef) -> VResult<TypeLit> {
+        let _tracing = dev_span!("create_prototype_of_class_def");
+
         let mut members = vec![];
 
         let type_params = def.type_params.as_ref().map(|decl| {

--- a/crates/stc_ts_file_analyzer/src/analyzer/types/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/types/mod.rs
@@ -94,7 +94,7 @@ impl Analyzer<'_, '_> {
         let _tracing = if cfg!(debug_assertions) {
             let ty = force_dump_type_as_string(&ty);
 
-            Some(span!(Level::ERROR, "normalize", ty = tracing::field::display(&ty)).entered())
+            Some(dev_span!("normalize", ty = tracing::field::display(&ty)))
         } else {
             None
         };
@@ -1383,7 +1383,7 @@ impl Analyzer<'_, '_> {
         let _tracing = if cfg!(debug_assertions) {
             let ty_str = force_dump_type_as_string(ty);
 
-            Some(span!(Level::ERROR, "instantiate_for_normalization", ty = &*ty_str).entered())
+            Some(dev_span!("instantiate_for_normalization", ty = &*ty_str))
         } else {
             None
         };

--- a/crates/stc_ts_file_analyzer/src/analyzer/types/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/types/mod.rs
@@ -1568,11 +1568,7 @@ impl Analyzer<'_, '_> {
     }
 
     pub(crate) fn expand_type_ann<'a>(&mut self, span: Span, ty: Option<&'a Type>) -> VResult<Option<Cow<'a, Type>>> {
-        let _tracing = if cfg!(debug_assertions) {
-            Some(tracing::span!(tracing::Level::ERROR, "expand_type_ann").entered())
-        } else {
-            None
-        };
+        let _tracing = dev_span!("expand_type_ann");
 
         let ty = match ty {
             Some(v) => v,
@@ -1641,11 +1637,7 @@ impl Analyzer<'_, '_> {
     /// Exclude types from `ty` using type facts with key `name`, for
     /// the current scope.
     pub(crate) fn exclude_types_using_fact(&mut self, span: Span, name: &Name, ty: &mut Type) {
-        let _tracing = if cfg!(debug_assertions) {
-            Some(tracing::span!(tracing::Level::ERROR, "exclude_types_using_fact").entered())
-        } else {
-            None
-        };
+        let _tracing = dev_span!("exclude_types_using_fact");
 
         debug_assert!(!span.is_dummy(), "exclude_types should not be called with a dummy span");
 
@@ -1687,11 +1679,7 @@ impl Analyzer<'_, '_> {
         if self.config.is_builtin {
             return Ok(None);
         }
-        let _tracing = if cfg!(debug_assertions) {
-            Some(tracing::span!(tracing::Level::ERROR, "collect_class_members").entered())
-        } else {
-            None
-        };
+        let _tracing = dev_span!("collect_class_members");
 
         let ty = ty.normalize();
         match ty {

--- a/crates/stc_ts_file_analyzer/src/analyzer/types/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/types/mod.rs
@@ -31,7 +31,7 @@ use stc_utils::{
 use swc_atoms::{js_word, Atom, JsWord};
 use swc_common::{util::take::Take, Span, Spanned, SyntaxContext, TypeEq};
 use swc_ecma_ast::{TsKeywordTypeKind, TsTypeOperatorOp};
-use tracing::{debug, error, instrument, span, Level};
+use tracing::{debug, error, instrument};
 
 use super::generic::InferTypeOpts;
 use crate::{

--- a/crates/stc_ts_file_analyzer/src/analyzer/types/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/types/mod.rs
@@ -31,7 +31,7 @@ use stc_utils::{
 use swc_atoms::{js_word, Atom, JsWord};
 use swc_common::{util::take::Take, Span, Spanned, SyntaxContext, TypeEq};
 use swc_ecma_ast::{TsKeywordTypeKind, TsTypeOperatorOp};
-use tracing::{debug, error, instrument};
+use tracing::{debug, error};
 
 use super::generic::InferTypeOpts;
 use crate::{

--- a/crates/stc_ts_file_analyzer/src/analyzer/util.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/util.rs
@@ -9,7 +9,7 @@ use stc_ts_types::{
     Class, ClassMetadata, Enum, EnumVariant, EnumVariantMetadata, Id, IndexedAccessType, Intersection, LitType, QueryExpr, QueryType, Ref,
     RefMetadata, Tuple, TypeElement, Union,
 };
-use stc_utils::cache::ALLOW_DEEP_CLONE;
+use stc_utils::{cache::ALLOW_DEEP_CLONE, dev_span};
 use swc_common::{EqIgnoreSpan, Span, Spanned, SyntaxContext};
 use swc_ecma_ast::TsKeywordTypeKind;
 use ty::TypeExt;
@@ -42,8 +42,9 @@ impl Analyzer<'_, '_> {
     }
 
     /// `span` and `callee` is used only for error reporting.
-    #[cfg_attr(debug_assertions, tracing::instrument(skip_all))]
     fn make_instance_from_type_elements(&mut self, span: Span, callee: &Type, elements: &[TypeElement]) -> VResult<Type> {
+        let _tracing = dev_span!("make_instance_from_type_elements");
+
         let mut ret_ty_vec = vec![];
         for member in elements {
             match member {
@@ -78,8 +79,9 @@ impl Analyzer<'_, '_> {
     ///
     ///
     /// TODO(kdy1): Use Cow
-    #[cfg_attr(debug_assertions, tracing::instrument(skip_all))]
     pub(super) fn make_instance_or_report(&mut self, span: Span, ty: &Type) -> Type {
+        let _tracing = dev_span!("make_instance_or_report");
+
         if span.is_dummy() {
             unreachable!("Cannot make an instance with dummy span")
         }

--- a/crates/stc_ts_file_analyzer/src/analyzer/util.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/util.rs
@@ -102,8 +102,9 @@ impl Analyzer<'_, '_> {
     }
 
     /// TODO(kdy1): Use Cow
-    #[cfg_attr(debug_assertions, tracing::instrument(skip_all))]
     pub(super) fn make_instance(&mut self, span: Span, ty: &Type) -> VResult<Type> {
+        let _tracing = dev_span!("make_instance");
+
         let ty = ty.normalize();
 
         let span = span.with_ctxt(SyntaxContext::empty());

--- a/crates/stc_ts_file_analyzer/src/ty/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/ty/mod.rs
@@ -1,18 +1,21 @@
 use rnode::FoldWith;
 use stc_ts_type_ops::{generalization::LitGeneralizer, tuple_to_array::TupleToArray, Fix};
 pub(crate) use stc_ts_types::*;
+use stc_utils::dev_span;
 use tracing::instrument;
 
 pub mod type_facts;
 
 pub trait TypeExt: Into<Type> {
-    #[instrument(skip_all)]
     fn generalize_lit(self) -> Type {
+        let _tracing = dev_span!("Type::generalize_lit");
+
         self.into().fold_with(&mut LitGeneralizer).fixed()
     }
 
-    #[instrument(skip_all)]
     fn generalize_tuple(self) -> Type {
+        let _tracing = dev_span!("Type::generalize_tuple");
+
         self.into().fold_with(&mut TupleToArray)
     }
 }

--- a/crates/stc_ts_file_analyzer/src/ty/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/ty/mod.rs
@@ -2,7 +2,6 @@ use rnode::FoldWith;
 use stc_ts_type_ops::{generalization::LitGeneralizer, tuple_to_array::TupleToArray, Fix};
 pub(crate) use stc_ts_types::*;
 use stc_utils::dev_span;
-use tracing::instrument;
 
 pub mod type_facts;
 

--- a/crates/stc_ts_file_analyzer/src/ty/type_facts.rs
+++ b/crates/stc_ts_file_analyzer/src/ty/type_facts.rs
@@ -9,10 +9,10 @@ use stc_ts_types::{
     KeywordTypeMetadata, LitType, Mapped, Type, TypeElement, TypeLit, Union, UnionMetadata,
 };
 use stc_ts_utils::MapWithMut;
-use stc_utils::{cache::Freeze, stack};
+use stc_utils::{cache::Freeze, dev_span, stack};
 use swc_common::{Span, Spanned, SyntaxContext, DUMMY_SP};
 use swc_ecma_ast::TsKeywordTypeKind;
-use tracing::{debug, instrument};
+use tracing::debug;
 
 use crate::{
     analyzer::{Analyzer, NormalizeTypeOpts},
@@ -25,11 +25,12 @@ impl Analyzer<'_, '_> {
     /// Those are preserved if
     ///
     ///  - it's Promise<T>
-    #[instrument(skip_all)]
     pub fn apply_type_facts_to_type(&mut self, facts: TypeFacts, mut ty: Type) -> Type {
         if self.config.is_builtin {
             return ty;
         }
+
+        let _tracing = dev_span!("apply_type_facts_to_type");
 
         if facts.contains(TypeFacts::TypeofEQNumber)
             || facts.contains(TypeFacts::TypeofEQString)

--- a/crates/stc_ts_file_analyzer/src/util/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/util/mod.rs
@@ -2,8 +2,8 @@ use rnode::VisitWith;
 use stc_ts_ast_rnode::{RBlockStmt, RBool, RModuleDecl, RModuleItem, RStmt, RTsEntityName, RTsLit};
 use stc_ts_type_ops::metadata::TypeFinder;
 use stc_ts_types::{KeywordType, KeywordTypeMetadata, LitType, Ref};
+use stc_utils::dev_span;
 use swc_ecma_ast::*;
-use tracing::instrument;
 
 use crate::ty::{Intersection, Type, Union};
 
@@ -33,7 +33,6 @@ impl ModuleItemOrStmt for RStmt {
 }
 
 /// Check if `ty` stores infer type in it.
-#[instrument(skip_all)]
 pub(crate) fn contains_infer_type<T>(n: &T) -> bool
 where
     T: VisitWith<TypeFinder>,
@@ -41,6 +40,8 @@ where
     fn check(ty: &Type) -> bool {
         ty.is_infer() || ty.metadata().contains_infer_type
     }
+
+    let _tracing = dev_span!("contains_infer_type");
 
     TypeFinder::find(n, check)
 }

--- a/crates/stc_ts_file_analyzer_macros/src/lib.rs
+++ b/crates/stc_ts_file_analyzer_macros/src/lib.rs
@@ -8,34 +8,7 @@ extern crate proc_macro;
 
 use pmutil::{Quote, ToTokensExt};
 use swc_macros_common::prelude::*;
-use syn::{
-    fold::Fold, Block, ExprTryBlock, FnArg, Ident, ImplItem, ImplItemMethod, ItemImpl, Lifetime, LitStr, ReturnType, Token, Type,
-    TypeReference,
-};
-
-#[proc_macro_attribute]
-pub fn context(arg: proc_macro::TokenStream, item: proc_macro::TokenStream) -> proc_macro::TokenStream {
-    let context_arg: LitStr = syn::parse(arg).unwrap();
-    let mut item: ImplItemMethod = syn::parse(item).expect("failed to parse input as an item");
-
-    let body = q!(
-        Vars {
-            body: &item.block,
-            context_arg
-        },
-        ({
-            let _ctx = stc_utils::debug_ctx!(context_arg.into());
-            let res: Result<_, stc_ts_errors::Error> = try { body };
-
-            res.context(context_arg)
-        })
-    )
-    .parse::<Block>();
-
-    item.block = body;
-
-    print("context", item.dump())
-}
+use syn::{fold::Fold, ExprTryBlock, FnArg, Ident, ImplItem, ImplItemMethod, ItemImpl, Lifetime, ReturnType, Token, Type, TypeReference};
 
 /// This macro converts
 ///

--- a/crates/stc_ts_type_ops/src/generalization/metadata.rs
+++ b/crates/stc_ts_type_ops/src/generalization/metadata.rs
@@ -1,10 +1,12 @@
 use stc_ts_errors::debug::dump_type_as_string;
 use stc_ts_types::{replace::replace_type, LitType, Type};
 use stc_ts_utils::MapWithMut;
+use stc_utils::dev_span;
 use tracing::{debug, instrument};
 
-#[instrument(skip_all)]
 pub fn prevent_generalize(ty: &mut Type) {
+    let _tracing = dev_span!("prevent_generalize");
+
     debug!("Prevent generalize: {}", dump_type_as_string(ty));
 
     replace_type(

--- a/crates/stc_ts_type_ops/src/generalization/metadata.rs
+++ b/crates/stc_ts_type_ops/src/generalization/metadata.rs
@@ -2,7 +2,7 @@ use stc_ts_errors::debug::dump_type_as_string;
 use stc_ts_types::{replace::replace_type, LitType, Type};
 use stc_ts_utils::MapWithMut;
 use stc_utils::dev_span;
-use tracing::{debug, instrument};
+use tracing::debug;
 
 pub fn prevent_generalize(ty: &mut Type) {
     let _tracing = dev_span!("prevent_generalize");

--- a/crates/stc_ts_type_ops/src/tuple_to_array/metadata.rs
+++ b/crates/stc_ts_type_ops/src/tuple_to_array/metadata.rs
@@ -1,10 +1,11 @@
 use stc_ts_types::{replace::replace_type, Type};
 use stc_ts_utils::MapWithMut;
-use tracing::instrument;
+use stc_utils::dev_span;
 
 /// TODO(kdy1): Optimize by visiting only tuple types.
-#[instrument(skip_all)]
 pub fn prevent_tuple_to_array(ty: &mut Type) {
+    let _tracing = dev_span!("prevent_tuple_to_array");
+
     replace_type(
         ty,
         |ty| ty.is_tuple(),

--- a/crates/stc_ts_type_ops/src/union_normalization.rs
+++ b/crates/stc_ts_type_ops/src/union_normalization.rs
@@ -9,11 +9,10 @@ use stc_ts_types::{
     CallSignature, FnParam, Function, FunctionMetadata, Key, KeywordType, PropertySignature, Type, TypeElement, TypeLit, TypeLitMetadata,
     TypeParamDecl, Union,
 };
-use stc_utils::{cache::Freeze, ext::TypeVecExt};
+use stc_utils::{cache::Freeze, dev_span, ext::TypeVecExt};
 use swc_atoms::JsWord;
 use swc_common::DUMMY_SP;
 use swc_ecma_ast::TsKeywordTypeKind;
-use tracing::instrument;
 
 /// See https://github.com/dudykr/stc/blob/e8f1daf0e336d978a1de5479ad9676093faf5921/crates/stc_ts_type_checker/tests/conformance/expressions/objectLiterals/objectLiteralNormalization.ts
 pub struct ObjectUnionNormalizer {
@@ -320,7 +319,6 @@ impl ObjectUnionNormalizer {
     }
 
     /// - `types`: Types of a union.
-    #[instrument(skip_all)]
     fn normalize_keys(&self, types: &mut Vec<Type>) {
         fn insert_property_to(ty: &mut Type, keys: &[JsWord], inexact: bool) {
             if let Some(ty) = ty.as_union_type_mut() {
@@ -419,6 +417,8 @@ impl ObjectUnionNormalizer {
                 }
             }
         }
+
+        let _tracing = dev_span!("normalize_keys");
 
         let deep = self.find_keys(&*types);
 

--- a/crates/stc_ts_types/src/lib.rs
+++ b/crates/stc_ts_types/src/lib.rs
@@ -34,7 +34,6 @@ use stc_ts_ast_rnode::{
 };
 use stc_utils::{
     cache::{Freeze, ALLOW_DEEP_CLONE},
-    debug_ctx,
     ext::TypeVecExt,
     panic_ctx,
 };
@@ -1347,7 +1346,7 @@ impl Type {
             return;
         }
 
-        let _ctx = debug_ctx!(format!("assert_clone_cheap: {:?}", self));
+        let _ctx = panic_ctx!(format!("assert_clone_cheap: {:?}", self));
 
         self.visit_with(&mut AssertCloneCheap);
     }

--- a/crates/stc_ts_types/src/lib.rs
+++ b/crates/stc_ts_types/src/lib.rs
@@ -34,7 +34,6 @@ use stc_ts_ast_rnode::{
 };
 use stc_utils::{
     cache::{Freeze, ALLOW_DEEP_CLONE},
-    dev_span,
     ext::TypeVecExt,
     panic_ctx,
 };

--- a/crates/stc_ts_types/src/lib.rs
+++ b/crates/stc_ts_types/src/lib.rs
@@ -34,6 +34,7 @@ use stc_ts_ast_rnode::{
 };
 use stc_utils::{
     cache::{Freeze, ALLOW_DEEP_CLONE},
+    dev_span,
     ext::TypeVecExt,
     panic_ctx,
 };
@@ -210,7 +211,7 @@ pub enum Type {
 }
 
 impl Clone for Type {
-    #[instrument(name = "Type::clone", skip(self))]
+    #[instrument(name = "Type::clone", skip_all)]
     fn clone(&self) -> Self {
         match self {
             Type::Arc(ty) => ty.clone().into(),

--- a/crates/stc_utils/src/error.rs
+++ b/crates/stc_utils/src/error.rs
@@ -1,57 +1,9 @@
-use std::cell::RefCell;
-
-use crate::panic_context;
-
+/// Creates an entered span for `tracing` on debug builds.
+/// On release builds, this is a no-op.
 #[macro_export]
 macro_rules! debug_ctx {
     ($s:expr) => {{
-        if cfg!(debug_assertions) {
-            Some($crate::error::span($s))
-        } else {
-            None
-        }
+        #[cfg(debug_assertions)]
+        tracing::error_span!($s).entered();
     }};
-}
-
-#[cfg(debug_assertions)]
-pub struct ContextGuard {
-    _panic_ctxt: panic_context::PanicContext,
-}
-
-#[cfg(debug_assertions)]
-impl Drop for ContextGuard {
-    fn drop(&mut self) {
-        with_ctx(|ctx| assert!(ctx.pop().is_some()))
-    }
-}
-
-#[cfg(not(debug_assertions))]
-#[inline(always)]
-pub fn span(_: String) -> () {}
-
-/// Add a context to created errors and configures a context for panic.
-#[cfg(debug_assertions)]
-pub fn span(msg: String) -> ContextGuard {
-    let msg = msg;
-    with_ctx(|ctx| ctx.push(msg.clone()));
-    ContextGuard {
-        _panic_ctxt: panic_context::new(msg),
-    }
-}
-
-#[cfg_attr(not(debug_assertions), inline(always))]
-pub fn current_context() -> Vec<String> {
-    #[cfg(not(debug_assertions))]
-    return vec![];
-
-    #[cfg(debug_assertions)]
-    with_ctx(|v| v.clone())
-}
-
-#[cfg(debug_assertions)]
-fn with_ctx<T>(f: impl FnOnce(&mut Vec<String>) -> T) -> T {
-    thread_local! {
-        static CTX: RefCell<Vec<String>> = RefCell::new(Vec::new());
-    }
-    CTX.with(|ctx| f(&mut ctx.borrow_mut()))
 }

--- a/crates/stc_utils/src/error.rs
+++ b/crates/stc_utils/src/error.rs
@@ -1,7 +1,7 @@
 /// Creates an entered span for `tracing` on debug builds.
 /// On release builds, this is a no-op.
 #[macro_export]
-macro_rules! debug_ctx {
+macro_rules! debug_span {
     ($s:expr) => {{
         #[cfg(debug_assertions)]
         tracing::error_span!($s).entered();

--- a/crates/stc_utils/src/error.rs
+++ b/crates/stc_utils/src/error.rs
@@ -1,9 +1,9 @@
 /// Creates an entered span for `tracing` on debug builds.
 /// On release builds, this is a no-op.
 #[macro_export]
-macro_rules! debug_span {
-    ($s:expr) => {{
+macro_rules! dev_span {
+    ($($tt:tt)*) => {{
         #[cfg(debug_assertions)]
-        tracing::error_span!($s).entered();
+        tracing::error_span!($($tt)*).entered();
     }};
 }

--- a/crates/stc_utils/src/error.rs
+++ b/crates/stc_utils/src/error.rs
@@ -4,6 +4,6 @@
 macro_rules! dev_span {
     ($($tt:tt)*) => {{
         #[cfg(debug_assertions)]
-        tracing::error_span!($($tt)*).entered();
+        tracing::error_span!($($tt)*).entered()
     }};
 }

--- a/crates/stc_utils/src/ext.rs
+++ b/crates/stc_utils/src/ext.rs
@@ -1,7 +1,8 @@
 #![allow(clippy::wrong_self_convention)]
 
 use swc_common::{Span, TypeEq};
-use tracing::instrument;
+
+use crate::dev_span;
 
 pub trait ValueExt: Sized {
     fn as_ok<E>(self) -> Result<Self, E> {
@@ -40,8 +41,9 @@ impl<T> TypeVecExt for Vec<T>
 where
     T: TypeEq,
 {
-    #[instrument(skip_all)]
     fn dedup_type(&mut self) {
+        let _tracing = dev_span!("dedup_type");
+
         let mut types: Vec<T> = Vec::with_capacity(self.capacity());
         for ty in self.drain(..) {
             if types.iter().any(|stored| stored.type_eq(&ty)) {


### PR DESCRIPTION
**Description:**

 - Rename variables.
 - Removes needless logic in `assign`.
 - Cleanup codes related to `tracing`, by using `dev_span!`.
 - Cleanup contexts.