### PR TITLE
chore: Reduce stack size to 8MB from 16MB for debug builds

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -99,4 +99,4 @@ jobs:
 
       - name: Run cargo test
         run: |
-          RUST_MIN_STACK=16777216 cargo test --all --features tracing/max_level_off
+          RUST_MIN_STACK=8388608 cargo test --all --features tracing/max_level_off

--- a/crates/stc_ts_file_analyzer/scripts/auto-unignore.sh
+++ b/crates/stc_ts_file_analyzer/scripts/auto-unignore.sh
@@ -5,7 +5,7 @@ set -o pipefail
 
 export CARGO_TERM_COLOR=always
 export RUST_BACKTRACE=1
-export RUST_MIN_STACK=$((16 * 1024 * 1024))
+export RUST_MIN_STACK=$((8 * 1024 * 1024))
 
 function cleanup {
     echo "Deleting cache for ignored tests"

--- a/crates/stc_ts_file_analyzer/scripts/base.sh
+++ b/crates/stc_ts_file_analyzer/scripts/base.sh
@@ -7,7 +7,7 @@ set -o pipefail
 
 export CARGO_TERM_COLOR=always
 export RUST_BACKTRACE=1
-export RUST_MIN_STACK=$((16 * 1024 * 1024))
+export RUST_MIN_STACK=$((8 * 1024 * 1024))
 
 # We prevent regression using faster checks
 touch ../stc_ts_file_analyzer/tests/base.rs

--- a/crates/stc_ts_file_analyzer/scripts/fast.sh
+++ b/crates/stc_ts_file_analyzer/scripts/fast.sh
@@ -7,7 +7,7 @@ set -eu
 
 export CARGO_TERM_COLOR=always
 export RUST_BACKTRACE=1
-export RUST_MIN_STACK=$((16 * 1024 * 1024))
+export RUST_MIN_STACK=$((8 * 1024 * 1024))
 
 # We prevent regression using faster checks
 RUST_LOG=off ./scripts/base.sh --features tracing/max_level_error $@

--- a/crates/stc_ts_file_analyzer/scripts/instrument/base.sh
+++ b/crates/stc_ts_file_analyzer/scripts/instrument/base.sh
@@ -6,7 +6,7 @@ set -eu
 export RUST_LOG=off
 export MIMALLOC_SHOW_STATS=1
 export CARGO_MANIFEST_DIR="$(pwd)"
-export RUST_MIN_STACK=$((16 * 1024 * 1024))
+export RUST_MIN_STACK=$((8 * 1024 * 1024))
 
 export STC_SKIP_EXEC=1
 

--- a/crates/stc_ts_type_checker/scripts/base.sh
+++ b/crates/stc_ts_type_checker/scripts/base.sh
@@ -7,7 +7,7 @@ set -o pipefail
 
 export CARGO_TERM_COLOR=always
 export RUST_BACKTRACE=1
-export RUST_MIN_STACK=$((16 * 1024 * 1024))
+export RUST_MIN_STACK=$((8 * 1024 * 1024))
 
 # We prevent regression using faster checks
 touch ../stc_ts_file_analyzer/tests/base.rs

--- a/crates/stc_ts_type_checker/scripts/check.sh
+++ b/crates/stc_ts_type_checker/scripts/check.sh
@@ -16,7 +16,7 @@ trap err_handler ERR
 
 export CARGO_TERM_COLOR=always
 export RUST_BACKTRACE=1
-export RUST_MIN_STACK=$((16 * 1024 * 1024))
+export RUST_MIN_STACK=$((8 * 1024 * 1024))
 
 # We prevent regression using faster checks
 RUST_LOG=off ./scripts/base.sh --features tracing/max_level_error

--- a/crates/stc_ts_type_checker/scripts/instrument/types-pkg.sh
+++ b/crates/stc_ts_type_checker/scripts/instrument/types-pkg.sh
@@ -6,7 +6,7 @@ set -eu
 export RUST_LOG=off
 export MIMALLOC_SHOW_STATS=1
 export CARGO_MANIFEST_DIR="$(pwd)"
-export RUST_MIN_STACK=$((16 * 1024 * 1024))
+export RUST_MIN_STACK=$((8 * 1024 * 1024))
 export CARGO_PROFILE_RELEASE_DEBUG=true
 export STC_SKIP_EXEC=1
 

--- a/crates/stc_ts_type_checker/scripts/test.sh
+++ b/crates/stc_ts_type_checker/scripts/test.sh
@@ -12,7 +12,7 @@ trap err_handler ERR
 
 export RUST_BACKTRACE=1
 export RUST_LOG=debug,swc_common=off
-export RUST_MIN_STACK=$((16 * 1024 * 1024))
+export RUST_MIN_STACK=$((8 * 1024 * 1024))
 
 # We prevent regression using faster checks
 RUST_LOG=error ./scripts/base.sh  --features tracing/max_level_error


### PR DESCRIPTION
**Description:**

As I refactored recursion of call/new expressions, we can now reduce the stack size.