### PR TITLE
fix: Fix error code for mixed default exports

### DIFF
--- a/crates/stc_ts_errors/src/lib.rs
+++ b/crates/stc_ts_errors/src/lib.rs
@@ -594,6 +594,12 @@ pub enum ErrorKind {
     ExportMixedWithLocal {
         span: Span,
     },
+
+    /// TS2652
+    MixedDefaultExports {
+        span: Span,
+    },
+
     /// TS2420
     ClassIncorrectlyImplementsInterface {
         span: Span,
@@ -1874,6 +1880,8 @@ impl ErrorKind {
             ErrorKind::InvalidImplOfInterface { .. } => 2420,
 
             ErrorKind::ClassIncorrectlyImplementsInterface { .. } => 2420,
+
+            ErrorKind::MixedDefaultExports { .. } => 2652,
 
             ErrorKind::ExportMixedWithLocal { .. } => 2395,
 

--- a/crates/stc_ts_file_analyzer/src/analyzer/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/mod.rs
@@ -298,6 +298,9 @@ struct AnalyzerData {
     cache: TypeCache,
 
     checked_for_async_iterator: bool,
+
+    /// Used to check mixed default exports.
+    merged_default_exports: AHashSet<Id>,
 }
 
 /// Configuration for the analyzer.

--- a/crates/stc_ts_type_checker/tests/conformance.pass.txt
+++ b/crates/stc_ts_type_checker/tests/conformance.pass.txt
@@ -847,6 +847,7 @@ es6/memberFunctionDeclarations/MemberFunctionDeclaration2_es6.ts
 es6/memberFunctionDeclarations/MemberFunctionDeclaration3_es6.ts
 es6/memberFunctionDeclarations/MemberFunctionDeclaration7_es6.ts
 es6/modules/defaultExportWithOverloads01.ts
+es6/modules/defaultExportsCannotMerge04.ts
 es6/modules/importEmptyFromModuleNotExisted.ts
 es6/modules/multipleDefaultExports03.ts
 es6/newTarget/invalidNewTarget.es5.ts

--- a/crates/stc_ts_type_checker/tests/conformance/es6/modules/defaultExportsCannotMerge04.stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/conformance/es6/modules/defaultExportsCannotMerge04.stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
-    required_error: 2,
-    matched_error: 2,
-    extra_error: 1,
+    required_error: 0,
+    matched_error: 4,
+    extra_error: 0,
     panic: 0,
 }

--- a/crates/stc_ts_type_checker/tests/tsc-stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/tsc-stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
-    required_error: 4128,
-    matched_error: 5946,
-    extra_error: 637,
+    required_error: 4126,
+    matched_error: 5948,
+    extra_error: 636,
     panic: 17,
 }


### PR DESCRIPTION
**Description:**
Adds TS2652

I have to admit my approach is kind of naive and only fixes the `defaultExportsCannotMerge04` so it will need to be edited to satisfy other `defaultExportsCannotMerge...` cases (for example `export default class`)

I can work on the other ones too, but
1. I don't know how to enable them because running `./scripts/test.sh defaultExportsCannotMerge` runs only `defaultExportsCannotMerge04`
2. I want to get some feedback as this is my first contribution in Rust

Should we make this one pretty and merge or should we tackle all `defaultExportsCannotMerge...` in one PR?

Closes: #591