### PR TITLE
test(conformance): Make conformance test faster

### DIFF
--- a/crates/stc_ts_type_checker/tests/tsc-stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/tsc-stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
-    required_error: 3780,
+    required_error: 3763,
     matched_error: 5985,
-    extra_error: 979,
+    extra_error: 976,
     panic: 228,
 }

--- a/crates/stc_ts_type_checker/tests/tsc.ignored.txt
+++ b/crates/stc_ts_type_checker/tests/tsc.ignored.txt
@@ -1,6 +1,7 @@
 classStaticBlock16.ts
 conditionalTypes1.ts
 controlFlowBindingElement.ts
+mixinAccessModifiers.ts
 moduleExportAssignment7.ts
 namedTupleMembers.ts
 privateNameAccessorssDerivedClasses.ts

--- a/crates/stc_ts_type_checker/tests/tsc.rs
+++ b/crates/stc_ts_type_checker/tests/tsc.rs
@@ -145,7 +145,7 @@ fn is_ignored(path: &Path) -> bool {
         return !path.to_string_lossy().contains(&test);
     }
 
-    !PASS.iter().any(|line| path.to_string_lossy().contains(line))
+    !PASS.iter().any(|line| path.to_string_lossy().ends_with(line))
 }
 
 #[test]

--- a/scripts/stats/split-tests.sh
+++ b/scripts/stats/split-tests.sh
@@ -39,4 +39,4 @@ cat "$GIST_DIR/.stc/dedup2.txt" \
     | sort -n -k 3 -t ":" -r \
     > "$GIST_DIR/list.txt"
 
-# (cd $GIST_DIR && git commit -am "Update" && git push)
+(cd $GIST_DIR && git commit -am "Update" && git push)

--- a/scripts/stats/split-tests.sh
+++ b/scripts/stats/split-tests.sh
@@ -20,10 +20,14 @@ echo "Sorting done.txt"
 echo "Sorting issue-required.txt"
 (cd $GIST_DIR && sortFile issue-required.txt)
 
-find crates/* -name "*.stats.rust-debug" > "$GIST_DIR/.stc/all.txt"
+find crates/* -name "*.stats.rust-debug" | xargs grep -l 'extra_error: [1-9][0-9]*' > "$GIST_DIR/.stc/all.txt"
+sortFile "$GIST_DIR/.stc/all.txt"
+
+comm -23 "$GIST_DIR/done.txt" "$GIST_DIR/.stc/all.txt" > "$GIST_DIR/.stc/tmp.txt"
+comm -23 "$GIST_DIR/done.txt" "$GIST_DIR/.stc/tmp.txt" > "$GIST_DIR/.stc/tmp2.txt"
+mv "$GIST_DIR/.stc/tmp2.txt" "$GIST_DIR/done.txt"
 
 echo "comm (1)"
-sortFile "$GIST_DIR/.stc/all.txt"
 comm -23 "$GIST_DIR/.stc/all.txt" "$GIST_DIR/done.txt" > "$GIST_DIR/.stc/dedup.txt"
 
 echo "comm (2)"
@@ -35,4 +39,4 @@ cat "$GIST_DIR/.stc/dedup2.txt" \
     | sort -n -k 3 -t ":" -r \
     > "$GIST_DIR/list.txt"
 
-(cd $GIST_DIR && git commit -am "Update" && git push)
+# (cd $GIST_DIR && git commit -am "Update" && git push)


### PR DESCRIPTION
**Description:**

This PR
 - ignores a flaky test case.
 - makes conformance test suite by replacing `includes()` with `ends_with()`.
 - improves script for splitting tests.