### PR TITLE
fix: Improve selection of `TS2322` vs `TS2741`

### DIFF
--- a/crates/stc_ts_file_analyzer/src/analyzer/assign/class.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/assign/class.rs
@@ -1,7 +1,7 @@
 use std::borrow::Cow;
 
 use stc_ts_errors::{DebugExt, ErrorKind};
-use stc_ts_types::{Class, ClassDef, ClassMember, Type, TypeLitMetadata};
+use stc_ts_types::{Class, ClassDef, ClassMember, ClassProperty, Key, Method, Type, TypeLitMetadata};
 use stc_utils::cache::Freeze;
 use swc_common::EqIgnoreSpan;
 use swc_ecma_ast::Accessibility;
@@ -198,6 +198,17 @@ impl Analyzer<'_, '_> {
                     AssignOpts {
                         allow_unknown_rhs: Some(true),
                         is_assigning_to_class_members: true,
+                        report_assign_failure_for_missing_properties: opts.report_assign_failure_for_missing_properties
+                            || (l.def.body.iter().all(|p| {
+                                !matches!(
+                                    p,
+                                    ClassMember::Property(ClassProperty { key: Key::Private(..), .. })
+                                        | ClassMember::Method(Method { key: Key::Private(..), .. })
+                                )
+                            }) && match r.normalize() {
+                                Type::Interface(r) => !r.extends.is_empty(),
+                                _ => false,
+                            }),
                         ..opts
                     },
                 )

--- a/crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs
@@ -185,7 +185,7 @@ pub(crate) struct AssignOpts {
     pub do_not_normalize_intersection_on_rhs: bool,
 
     /// Use `TS2322` on missing properties.
-    pub report_assign_failure_for_missing_properties: bool,
+    pub report_assign_failure_for_missing_properties: Option<bool>,
 }
 
 #[derive(Default)]

--- a/crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs
@@ -184,6 +184,7 @@ pub(crate) struct AssignOpts {
     /// Used to prevent recursion
     pub do_not_normalize_intersection_on_rhs: bool,
 
+    /// Use `TS2322` on missing properties.
     pub report_assign_failure_for_missing_properties: bool,
 }
 

--- a/crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs
@@ -183,6 +183,8 @@ pub(crate) struct AssignOpts {
 
     /// Used to prevent recursion
     pub do_not_normalize_intersection_on_rhs: bool,
+
+    pub report_assign_failure_for_missing_properties: bool,
 }
 
 #[derive(Default)]

--- a/crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs
@@ -2397,7 +2397,22 @@ impl Analyzer<'_, '_> {
 
             Type::TypeLit(TypeLit { ref members, metadata, .. }) => {
                 return self
-                    .assign_to_type_elements(data, span, members, rhs, *metadata, opts)
+                    .assign_to_type_elements(
+                        data,
+                        span,
+                        members,
+                        rhs,
+                        *metadata,
+                        AssignOpts {
+                            report_assign_failure_for_missing_properties: opts.report_assign_failure_for_missing_properties.or_else(|| {
+                                match rhs.normalize() {
+                                    Type::Interface(r) if !r.extends.is_empty() => Some(true),
+                                    _ => None,
+                                }
+                            }),
+                            ..opts
+                        },
+                    )
                     .context("tried to assign a type to type elements");
             }
 

--- a/crates/stc_ts_file_analyzer/src/analyzer/assign/type_el.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/assign/type_el.rs
@@ -848,7 +848,7 @@ impl Analyzer<'_, '_> {
         }
 
         if !missing_fields.is_empty() {
-            if self.should_report_properties(span, lhs, rhs) {
+            if !opts.report_assign_failure_for_missing_properties || self.should_report_properties(span, lhs, rhs) {
                 errors.push(
                     ErrorKind::MissingFields {
                         span,

--- a/crates/stc_ts_file_analyzer/src/analyzer/assign/type_el.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/assign/type_el.rs
@@ -852,7 +852,11 @@ impl Analyzer<'_, '_> {
                 errors.push(
                     ErrorKind::ObjectAssignFailed {
                         span,
-                        errors: vec![ErrorKind::SimpleAssignFailed { span, cause: None }.into()],
+                        errors: vec![ErrorKind::MissingFields {
+                            span,
+                            fields: missing_fields,
+                        }
+                        .into()],
                     }
                     .into(),
                 )

--- a/crates/stc_ts_file_analyzer/src/analyzer/assign/type_el.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/assign/type_el.rs
@@ -237,11 +237,13 @@ impl Analyzer<'_, '_> {
                                             Some(match rhs.normalize() {
                                                 Type::Interface(r) => {
                                                     r.extends.is_empty()
-                                                        && r.body.iter().all(|el| match el {
-                                                            TypeElement::Index(..) => false,
-                                                            TypeElement::Property(PropertySignature { .. })
-                                                            | TypeElement::Method(MethodSignature { .. }) => false,
-                                                            _ => true,
+                                                        && r.body.iter().all(|el| {
+                                                            !matches!(
+                                                                el,
+                                                                TypeElement::Index(..)
+                                                                    | TypeElement::Property(PropertySignature { .. })
+                                                                    | TypeElement::Method(MethodSignature { .. })
+                                                            )
                                                         })
                                                 }
                                                 _ => false,

--- a/crates/stc_ts_file_analyzer/src/analyzer/assign/type_el.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/assign/type_el.rs
@@ -235,6 +235,12 @@ impl Analyzer<'_, '_> {
                                         || match rhs.normalize() {
                                             Type::Interface(r) => r.body.iter().all(|el| match el {
                                                 TypeElement::Index(..) => false,
+                                                TypeElement::Property(PropertySignature {
+                                                    key: Key::Computed(..), ..
+                                                })
+                                                | TypeElement::Method(MethodSignature {
+                                                    key: Key::Computed(..), ..
+                                                }) => false,
                                                 _ => true,
                                             }),
                                             _ => false,

--- a/crates/stc_ts_file_analyzer/src/analyzer/assign/type_el.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/assign/type_el.rs
@@ -848,7 +848,15 @@ impl Analyzer<'_, '_> {
         }
 
         if !missing_fields.is_empty() {
-            if !opts.report_assign_failure_for_missing_properties || self.should_report_properties(span, lhs, rhs) {
+            if opts.report_assign_failure_for_missing_properties {
+                errors.push(
+                    ErrorKind::ObjectAssignFailed {
+                        span,
+                        errors: vec![ErrorKind::SimpleAssignFailed { span, cause: None }.into()],
+                    }
+                    .into(),
+                )
+            } else if self.should_report_properties(span, lhs, rhs) {
                 errors.push(
                     ErrorKind::MissingFields {
                         span,

--- a/crates/stc_ts_file_analyzer/src/analyzer/assign/type_el.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/assign/type_el.rs
@@ -235,12 +235,15 @@ impl Analyzer<'_, '_> {
                                         .report_assign_failure_for_missing_properties
                                         .or_else(|| {
                                             Some(match rhs.normalize() {
-                                                Type::Interface(r) => r.body.iter().all(|el| match el {
-                                                    TypeElement::Index(..) => false,
-                                                    TypeElement::Property(PropertySignature { .. })
-                                                    | TypeElement::Method(MethodSignature { .. }) => false,
-                                                    _ => true,
-                                                }),
+                                                Type::Interface(r) => {
+                                                    r.extends.is_empty()
+                                                        && r.body.iter().all(|el| match el {
+                                                            TypeElement::Index(..) => false,
+                                                            TypeElement::Property(PropertySignature { .. })
+                                                            | TypeElement::Method(MethodSignature { .. }) => false,
+                                                            _ => true,
+                                                        })
+                                                }
                                                 _ => false,
                                             })
                                         }),

--- a/crates/stc_ts_file_analyzer/src/analyzer/assign/type_el.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/assign/type_el.rs
@@ -242,7 +242,9 @@ impl Analyzer<'_, '_> {
                                                     })
                                                     | TypeElement::Method(MethodSignature {
                                                         key: Key::Computed(..), ..
-                                                    }) => false,
+                                                    })
+                                                    | TypeElement::Property(PropertySignature { optional: true, .. })
+                                                    | TypeElement::Method(MethodSignature { optional: true, .. }) => false,
                                                     _ => true,
                                                 }),
                                                 _ => false,

--- a/crates/stc_ts_file_analyzer/src/analyzer/assign/type_el.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/assign/type_el.rs
@@ -237,14 +237,8 @@ impl Analyzer<'_, '_> {
                                             Some(match rhs.normalize() {
                                                 Type::Interface(r) => r.body.iter().all(|el| match el {
                                                     TypeElement::Index(..) => false,
-                                                    TypeElement::Property(PropertySignature {
-                                                        key: Key::Computed(..), ..
-                                                    })
-                                                    | TypeElement::Method(MethodSignature {
-                                                        key: Key::Computed(..), ..
-                                                    })
-                                                    | TypeElement::Property(PropertySignature { optional: true, .. })
-                                                    | TypeElement::Method(MethodSignature { optional: true, .. }) => false,
+                                                    TypeElement::Property(PropertySignature { .. })
+                                                    | TypeElement::Method(MethodSignature { .. }) => false,
                                                     _ => true,
                                                 }),
                                                 _ => false,

--- a/crates/stc_ts_file_analyzer/tests/base.rs
+++ b/crates/stc_ts_file_analyzer/tests/base.rs
@@ -243,7 +243,7 @@ fn compare(input: PathBuf) {
         .into_iter()
         .map(|err| StcError {
             line: err.line,
-            code: err.code,
+            code: ErrorKind::normalize_error_code(err.code),
         })
         .collect_vec();
     expected.sort();

--- a/crates/stc_ts_file_analyzer/tests/tsc/issues/0xxx/741/1.ts
+++ b/crates/stc_ts_file_analyzer/tests/tsc/issues/0xxx/741/1.ts
@@ -1,0 +1,27 @@
+interface StringTo<T> {
+    [x: string]: T;
+}
+
+interface NumberTo<T> {
+    [x: number]: T;
+}
+
+interface StringAndNumberTo<T> extends StringTo<T>, NumberTo<T> { }
+
+interface Obj {
+    hello: string;
+    world: number;
+}
+
+type NumberToNumber = NumberTo<number>;
+
+interface StringToAnyNumberToNumber extends StringTo<any>, NumberToNumber { }
+
+function f3(
+    sToAny: StringTo<any>,
+    nToNumber: NumberToNumber,
+    strToAnyNumToNum: StringToAnyNumberToNumber,
+    someObj: Obj
+) {
+    someObj = sToAny;
+}

--- a/crates/stc_ts_file_analyzer/tests/tsc/issues/0xxx/741/1.tsc-errors.json
+++ b/crates/stc_ts_file_analyzer/tests/tsc/issues/0xxx/741/1.tsc-errors.json
@@ -1,0 +1,8 @@
+[
+  {
+    "file": "tests/tsc/issues/0xxx/741/1.ts",
+    "line": 26,
+    "col": 5,
+    "code": 2739
+  }
+]

--- a/crates/stc_ts_type_checker/tests/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithObjectMembersAccessibility.error-diff.json
+++ b/crates/stc_ts_type_checker/tests/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithObjectMembersAccessibility.error-diff.json
@@ -1,23 +1,22 @@
 {
   "required_errors": {
-    "TS2322": 3
+    "TS2322": 1
   },
   "required_error_lines": {
     "TS2322": [
-      82,
-      100,
-      105
+      82
     ]
   },
   "extra_errors": {
-    "TS2741": 4
+    "TS2741": 1,
+    "TS2322": 1
   },
   "extra_error_lines": {
     "TS2741": [
-      82,
-      87,
-      100,
-      105
+      82
+    ],
+    "TS2322": [
+      87
     ]
   }
 }

--- a/crates/stc_ts_type_checker/tests/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithObjectMembersAccessibility.error-diff.json
+++ b/crates/stc_ts_type_checker/tests/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithObjectMembersAccessibility.error-diff.json
@@ -1,20 +1,10 @@
 {
-  "required_errors": {
-    "TS2322": 1
-  },
-  "required_error_lines": {
-    "TS2322": [
-      82
-    ]
-  },
+  "required_errors": {},
+  "required_error_lines": {},
   "extra_errors": {
-    "TS2741": 1,
     "TS2322": 1
   },
   "extra_error_lines": {
-    "TS2741": [
-      82
-    ],
     "TS2322": [
       87
     ]

--- a/crates/stc_ts_type_checker/tests/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithObjectMembersAccessibility.stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithObjectMembersAccessibility.stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
-    required_error: 3,
-    matched_error: 21,
-    extra_error: 4,
+    required_error: 1,
+    matched_error: 23,
+    extra_error: 2,
     panic: 0,
 }

--- a/crates/stc_ts_type_checker/tests/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithObjectMembersAccessibility.stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithObjectMembersAccessibility.stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
-    required_error: 1,
-    matched_error: 23,
-    extra_error: 2,
+    required_error: 0,
+    matched_error: 24,
+    extra_error: 1,
     panic: 0,
 }

--- a/crates/stc_ts_type_checker/tests/tsc-stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/tsc-stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
-    required_error: 3791,
-    matched_error: 6020,
-    extra_error: 1108,
+    required_error: 3788,
+    matched_error: 6023,
+    extra_error: 1105,
     panic: 100,
 }


### PR DESCRIPTION
**Description:**

This PR introduces `report_assign_failure_for_missing_properties` in `AssignOpts` which can be used to select between `TS2322` and `TS2471` for the caller side.

