### PR TITLE
test: Hide filename from comparison

### DIFF
--- a/crates/stc_ts_type_checker/tests/tsc.rs
+++ b/crates/stc_ts_type_checker/tests/tsc.rs
@@ -330,7 +330,7 @@ fn do_test(file_name: &Path, spec: TestSpec, use_target: bool) -> Result<(), Std
         }
     }
 
-    let full_ref_errors = expected_errors.clone();
+    let mut full_ref_errors = expected_errors.clone();
     let full_ref_err_cnt = full_ref_errors.len();
 
     let tester = Tester::new();
@@ -480,6 +480,22 @@ fn do_test(file_name: &Path, spec: TestSpec, use_target: bool) -> Result<(), Std
             fs::write(&error_diff_file_name, serde_json::to_string_pretty(&diff).unwrap()).expect("failed to write error diff file");
         }
     }
+
+    expected_errors.iter_mut().for_each(|err| {
+        err.file = None;
+    });
+
+    extra_errors.iter_mut().for_each(|err| {
+        err.file = None;
+    });
+
+    full_ref_errors.iter_mut().for_each(|err| {
+        err.file = None;
+    });
+
+    full_actual_errors.iter_mut().for_each(|err| {
+        err.file = None;
+    });
 
     if print_matched_errors() {
         eprintln!(


### PR DESCRIPTION
**Description:**

```
22 unmatched errors out of 61 errors. Got 25 extra errors.
Wanted: [TscError { file: Some("tests/cases/conformance/controlFlow/controlFlowOptionalChain.ts"), line: 13, col: 1, code: 2454 }, TscError { file: Some("tests/cases/conformance/controlFlow/controlFlowOptionalChain.ts"), line: 17, col: 1, code: 2454 }, TscError { file: Some("tests/cases/conformance/controlFlow/controlFlowOptionalChain.ts"), line: 21, col: 1, code: 2454 }, TscError { file: Some("tests/cases/conformance/controlFlow/controlFlowOptionalChain.ts"), line: 25, col: 1, code: 2454 }, TscError { file: Some("tests/cases/conformance/controlFlow/controlFlowOptionalChain.ts"), line: 38, col: 5, code: 2722 }, TscError { file: Some("tests/cases/conformance/controlFlow/controlFlowOptionalChain.ts"), line: 42, col: 1, code: 2722 }, TscError { file: Some("tests/cases/conformance/controlFlow/controlFlowOptionalChain.ts"), line: 86, col: 5, code: 2532 }, TscError { file: Some("tests/cases/conformance/controlFlow/controlFlowOptionalChain.ts"), line: 108, col: 5, code: 2532 }, TscError { file: Some("tests/cases/conformance/controlFlow/controlFlowOptionalChain.ts"), line: 115, col: 1, code: 2532 }, TscError { file: Some("tests/cases/conformance/controlFlow/controlFlowOptionalChain.ts"), line: 211, col: 9, code: 2532 }, TscError { file: Some("tests/cases/conformance/controlFlow/controlFlowOptionalChain.ts"), line: 214, col: 9, code: 2532 }, TscError { file: Some("tests/cases/conformance/controlFlow/controlFlowOptionalChain.ts"), line: 220, col: 9, code: 2532 }, TscError { file: Some("tests/cases/conformance/controlFlow/controlFlowOptionalChain.ts"), line: 223, col: 9, code: 2532 }, TscError { file: Some("tests/cases/conformance/controlFlow/controlFlowOptionalChain.ts"), line: 241, col: 9, code: 2532 }, TscError { file: Some("tests/cases/conformance/controlFlow/controlFlowOptionalChain.ts"), line: 244, col: 9, code: 2532 }, TscError { file: Some("tests/cases/conformance/controlFlow/controlFlowOptionalChain.ts"), line: 421, col: 9, code: 2532 }, TscError { file: Some("tests/cases/conformance/controlFlow/controlFlowOptionalChain.ts"), line: 424, col: 9, code: 2532 }, TscError { file: Some("tests/cases/conformance/controlFlow/controlFlowOptionalChain.ts"), line: 433, col: 9, code: 2532 }, TscError { file: Some("tests/cases/conformance/controlFlow/controlFlowOptionalChain.ts"), line: 436, col: 9, code: 2532 }, TscError { file: Some("tests/cases/conformance/controlFlow/controlFlowOptionalChain.ts"), line: 504, col: 13, code: 2532 }, TscError { file: Some("tests/cases/conformance/controlFlow/controlFlowOptionalChain.ts"), line: 518, col: 13, code: 2532 }, TscError { file: Some("tests/cases/conformance/controlFlow/controlFlowOptionalChain.ts"), line: 521, col: 13, code: 2532 }]
Unwanted: [TscError { file: Some("/Users/kdy1/projects/stc/crates/stc_ts_type_checker/tests/conformance/controlFlow/controlFlowOptionalChain.ts"), line: 84, col: 7, code: 2339 }, TscError { file: Some("/Users/kdy1/projects/stc/crates/stc_ts_type_checker/tests/conformance/controlFlow/controlFlowOptionalChain.ts"), line: 85, col: 7, code: 2339 }, TscError { file: Some("/Users/kdy1/projects/stc/crates/stc_ts_type_checker/tests/conformance/controlFlow/controlFlowOptionalChain.ts"), line: 86, col: 7, code: 2339 }, TscError { file: Some("/Users/kdy1/projects/stc/crates/stc_ts_type_checker/tests/conformance/controlFlow/controlFlowOptionalChain.ts"), line: 175, col: 8, code: 2532 }, TscError { file: Some("/Users/kdy1/projects/stc/crates/stc_ts_type_checker/tests/conformance/controlFlow/controlFlowOptionalChain.ts"), line: 184, col: 8, code: 2532 }, TscError { file: Some("/Users/kdy1/projects/stc/crates/stc_ts_type_checker/tests/conformance/controlFlow/controlFlowOptionalChain.ts"), line: 196, col: 8, code: 2531 }, TscError { file: Some("/Users/kdy1/projects/stc/crates/stc_ts_type_checker/tests/conformance/controlFlow/controlFlowOptionalChain.ts"), line: 205, col: 8, code: 2531 }, TscError { file: Some("/Users/kdy1/projects/stc/crates/stc_ts_type_checker/tests/conformance/controlFlow/controlFlowOptionalChain.ts"), line: 238, col: 8, code: 2532 }, TscError { file: Some("/Users/kdy1/projects/stc/crates/stc_ts_type_checker/tests/conformance/controlFlow/controlFlowOptionalChain.ts"), line: 253, col: 8, code: 2532 }, TscError { file: Some("/Users/kdy1/projects/stc/crates/stc_ts_type_checker/tests/conformance/controlFlow/controlFlowOptionalChain.ts"), line: 256, col: 8, code: 2532 }, TscError { file: Some("/Users/kdy1/projects/stc/crates/stc_ts_type_checker/tests/conformance/controlFlow/controlFlowOptionalChain.ts"), line: 259, col: 8, code: 2532 }, TscError { file: Some("/Users/kdy1/projects/stc/crates/stc_ts_type_checker/tests/conformance/controlFlow/controlFlowOptionalChain.ts"), line: 268, col: 8, code: 2532 }, TscError { file: Some("/Users/kdy1/projects/stc/crates/stc_ts_type_checker/tests/conformance/controlFlow/controlFlowOptionalChain.ts"), line: 289, col: 8, code: 2532 }, TscError { file: Some("/Users/kdy1/projects/stc/crates/stc_ts_type_checker/tests/conformance/controlFlow/controlFlowOptionalChain.ts"), line: 295, col: 8, code: 2531 }, TscError { file: Some("/Users/kdy1/projects/stc/crates/stc_ts_type_checker/tests/conformance/controlFlow/controlFlowOptionalChain.ts"), line: 298, col: 8, code: 2531 }, TscError { file: Some("/Users/kdy1/projects/stc/crates/stc_ts_type_checker/tests/conformance/controlFlow/controlFlowOptionalChain.ts"), line: 301, col: 8, code: 2531 }, TscError { file: Some("/Users/kdy1/projects/stc/crates/stc_ts_type_checker/tests/conformance/controlFlow/controlFlowOptionalChain.ts"), line: 367, col: 8, code: 2532 }, TscError { file: Some("/Users/kdy1/projects/stc/crates/stc_ts_type_checker/tests/conformance/controlFlow/controlFlowOptionalChain.ts"), line: 394, col: 8, code: 2532 }, TscError { file: Some("/Users/kdy1/projects/stc/crates/stc_ts_type_checker/tests/conformance/controlFlow/controlFlowOptionalChain.ts"), line: 409, col: 8, code: 2531 }, TscError { file: Some("/Users/kdy1/projects/stc/crates/stc_ts_type_checker/tests/conformance/controlFlow/controlFlowOptionalChain.ts"), line: 476, col: 8, code: 2532 }, TscError { file: Some("/Users/kdy1/projects/stc/crates/stc_ts_type_checker/tests/conformance/controlFlow/controlFlowOptionalChain.ts"), line: 480, col: 8, code: 2532 }, TscError { file: Some("/Users/kdy1/projects/stc/crates/stc_ts_type_checker/tests/conformance/controlFlow/controlFlowOptionalChain.ts"), line: 484, col: 8, code: 2532 }, TscError { file: Some("/Users/kdy1/projects/stc/crates/stc_ts_type_checker/tests/conformance/controlFlow/controlFlowOptionalChain.ts"), line: 488, col: 8, code: 2532 }, TscError { file: Some("/Users/kdy1/projects/stc/crates/stc_ts_type_checker/tests/conformance/controlFlow/controlFlowOptionalChain.ts"), line: 519, col: 12, code: 7027 }, TscError { file: Some("/Users/kdy1/projects/stc/crates/stc_ts_type_checker/tests/conformance/controlFlow/controlFlowOptionalChain.ts"), line: 522, col: 12, code: 7027 }]
thread 'conformance::controlFlow::controlFlowOptionalChain.ts' panicked at 'explicit panic', crates/stc_ts_type_checker/tests/tsc.rs:512:9
stack backtrace:
```

this is too hard to read