### PR TITLE
fix(ts/analyzer): improve type-guard of 'in' operator

### DIFF
--- a/crates/stc_ts_file_analyzer/src/analyzer/expr/bin.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/expr/bin.rs
@@ -881,8 +881,9 @@ impl Analyzer<'_, '_> {
                             let new_ty = self.narrow_types_with_property(span, &rt, &property, None)?.fixed().freezed();
 
                             self.add_deep_type_fact(span, name.clone(), new_ty.clone(), true);
-
-                            self.cur_facts.false_facts.excludes.entry(name).or_default().push(new_ty);
+                            if rt.is_union_type() {
+                                self.cur_facts.false_facts.excludes.entry(name).or_default().push(new_ty);
+                            }
                         }
                     }
                 }

--- a/crates/stc_ts_type_checker/tests/conformance/expressions/typeGuards/typeGuardOfFromPropNameInUnionType.error-diff.json
+++ b/crates/stc_ts_type_checker/tests/conformance/expressions/typeGuards/typeGuardOfFromPropNameInUnionType.error-diff.json
@@ -2,15 +2,13 @@
   "required_errors": {},
   "required_error_lines": {},
   "extra_errors": {
-    "TS2339": 4,
+    "TS2339": 2,
     "TS2304": 1
   },
   "extra_error_lines": {
     "TS2339": [
       38,
-      67,
-      102,
-      104
+      67
     ],
     "TS2304": [
       74

--- a/crates/stc_ts_type_checker/tests/conformance/expressions/typeGuards/typeGuardOfFromPropNameInUnionType.stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/conformance/expressions/typeGuards/typeGuardOfFromPropNameInUnionType.stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
     required_error: 0,
     matched_error: 0,
-    extra_error: 5,
+    extra_error: 3,
     panic: 0,
 }

--- a/crates/stc_ts_type_checker/tests/tsc-stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/tsc-stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
     required_error: 3790,
     matched_error: 6211,
-    extra_error: 869,
+    extra_error: 867,
     panic: 107,
 }


### PR DESCRIPTION
<!-- Note: CI script will automatically rebase your PR so please do not rebase unless required -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**
If `i` were an index signature, false facts should not be created unlike a union type. This caused the checker to be unable to access the type of `i` in the else clause.
```
interface Indexed {
  [s: string]: any;
}

function f(i: Indexed) {
  if ("a" in i) {
    return i.a;
  } 
  return "c" in i && i.c; // error: i is inferred as never
}
```
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**BREAKING CHANGE:**

<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG. Add description or remove entirely if not breaking.

You may need to update `MIGRATION.md` for the breaking changes.
-->

**Related issue (if exists):**
