### PR TITLE
fix: Fix `keyof` of type parameters

### DIFF
--- a/crates/stc_ts_file_analyzer/src/analyzer/types/keyof.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/types/keyof.rs
@@ -5,8 +5,8 @@ use stc_ts_ast_rnode::{RIdent, RNumber, RTsEntityName, RTsLit};
 use stc_ts_errors::{debug::force_dump_type_as_string, DebugExt, ErrorKind};
 use stc_ts_type_ops::{is_str_lit_or_union, Fix};
 use stc_ts_types::{
-    Class, ClassMember, ClassProperty, KeywordType, KeywordTypeMetadata, LitType, Method, MethodSignature, PropertySignature, Ref, Type,
-    TypeElement, Union,
+    Class, ClassMember, ClassProperty, Index, KeywordType, KeywordTypeMetadata, LitType, Method, MethodSignature, PropertySignature, Ref,
+    Type, TypeElement, Union,
 };
 use stc_utils::{cache::Freeze, ext::TypeVecExt, try_cache};
 use swc_atoms::js_word;
@@ -347,13 +347,14 @@ impl Analyzer<'_, '_> {
                     return Ok(Type::new_union(span, key_types));
                 }
 
-                Type::Param(..) => {
-                    return Ok(Type::Keyword(KeywordType {
+                Type::Param(param) => {
+                    // keyof T
+                    return Ok(Type::Index(Index {
                         span,
-                        kind: TsKeywordTypeKind::TsStringKeyword,
+                        ty: box ty.clone().into_owned(),
                         metadata: Default::default(),
                         tracker: Default::default(),
-                    }))
+                    }));
                 }
 
                 Type::Mapped(m) => {

--- a/crates/stc_ts_file_analyzer/tests/pass/controlFlow/forInStmt/simple/2.swc-stderr
+++ b/crates/stc_ts_file_analyzer/tests/pass/controlFlow/forInStmt/simple/2.swc-stderr
@@ -8,7 +8,7 @@
    `----
 
 Error: 
-  > string
+  > keyof T
 
   x Type
    ,-[$DIR/tests/pass/controlFlow/forInStmt/simple/2.ts:5:1]
@@ -69,7 +69,7 @@ Error:
     `----
 
 Error: 
-  > string
+  > keyof T
 
   x Type
     ,-[$DIR/tests/pass/controlFlow/forInStmt/simple/2.ts:8:1]
@@ -117,7 +117,7 @@ Error:
     `----
 
 Error: 
-  > string
+  > keyof T
 
   x Type
     ,-[$DIR/tests/pass/controlFlow/forInStmt/simple/2.ts:11:1]

--- a/crates/stc_ts_file_analyzer/tests/pass/controlFlow/guard/typeParams/3.swc-stderr
+++ b/crates/stc_ts_file_analyzer/tests/pass/controlFlow/guard/typeParams/3.swc-stderr
@@ -45,7 +45,7 @@ Error:
     `----
 
 Error: 
-  > string
+  > keyof T
 
   x Type
     ,-[$DIR/tests/pass/controlFlow/guard/typeParams/3.ts:8:1]

--- a/crates/stc_ts_file_analyzer/tests/pass/exprs/bin/cmp/typeof/typeParam/3.swc-stderr
+++ b/crates/stc_ts_file_analyzer/tests/pass/exprs/bin/cmp/typeof/typeParam/3.swc-stderr
@@ -45,7 +45,7 @@ Error:
     `----
 
 Error: 
-  > string
+  > keyof T
 
   x Type
     ,-[$DIR/tests/pass/exprs/bin/cmp/typeof/typeParam/3.ts:8:1]


### PR DESCRIPTION
**Description:**

We should infer it as a `keyof T` instead of `string`.