### PR TITLE
fix: Don't remove type params from functions in args

### DIFF
--- a/crates/stc_ts_file_analyzer/src/analyzer/expr/call_new.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/expr/call_new.rs
@@ -11,7 +11,7 @@ use stc_ts_ast_rnode::{
 };
 use stc_ts_env::MarkExt;
 use stc_ts_errors::{
-    debug::{dump_type_as_string, dump_type_map, force_dump_type_as_string, print_type},
+    debug::{dump_type_as_string, dump_type_map, force_dump_type_as_string, print_backtrace, print_type},
     DebugExt, ErrorKind,
 };
 use stc_ts_file_analyzer_macros::extra_validator;
@@ -2623,6 +2623,8 @@ impl Analyzer<'_, '_> {
         ret_ty.fix();
         ret_ty.freeze();
 
+        dbg!(&type_params, &type_args);
+        print_backtrace();
         let is_type_arg_count_fine = {
             let type_arg_check_res = self.validate_type_args_count(span, type_params, type_args);
 
@@ -2642,25 +2644,26 @@ impl Analyzer<'_, '_> {
             let mut default_unknown_map = HashMap::with_capacity_and_hasher(type_params.len(), Default::default());
 
             if type_ann.is_none() && self.ctx.reevaluating_call_or_new {
-                for at in spread_arg_types {
-                    if let Type::Function(Function {
-                        type_params: Some(type_params),
-                        ..
-                    }) = at.ty.normalize()
-                    {
-                        for tp in type_params.params.iter() {
-                            default_unknown_map.insert(
-                                tp.name.clone(),
-                                Type::Keyword(KeywordType {
-                                    span: tp.span,
-                                    kind: TsKeywordTypeKind::TsUnknownKeyword,
-                                    metadata: Default::default(),
-                                    tracker: Default::default(),
-                                }),
-                            );
-                        }
-                    }
-                }
+                // for at in spread_arg_types {
+                //     if let Type::Function(Function {
+                //         type_params: Some(type_params),
+                //         ..
+                //     }) = at.ty.normalize()
+                //     {
+                //         for tp in type_params.params.iter() {
+                //             default_unknown_map.insert(
+                //                 tp.name.clone(),
+                //                 Type::Keyword(KeywordType {
+                //                     span: tp.span,
+                //                     kind:
+                // TsKeywordTypeKind::TsUnknownKeyword,
+                //                     metadata: Default::default(),
+                //                     tracker: Default::default(),
+                //                 }),
+                //             );
+                //         }
+                //     }
+                // }
             }
 
             for param in type_params {

--- a/crates/stc_ts_file_analyzer/src/analyzer/expr/call_new.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/expr/call_new.rs
@@ -1,5 +1,5 @@
 //! Handles new expressions and call expressions.
-use std::{borrow::Cow, collections::HashMap};
+use std::borrow::Cow;
 
 use fxhash::FxHashMap;
 use itertools::Itertools;
@@ -11,16 +11,16 @@ use stc_ts_ast_rnode::{
 };
 use stc_ts_env::MarkExt;
 use stc_ts_errors::{
-    debug::{dump_type_as_string, dump_type_map, force_dump_type_as_string, print_backtrace, print_type},
+    debug::{dump_type_as_string, dump_type_map, force_dump_type_as_string, print_type},
     DebugExt, ErrorKind,
 };
 use stc_ts_file_analyzer_macros::extra_validator;
 use stc_ts_generics::type_param::finder::TypeParamUsageFinder;
 use stc_ts_type_ops::{generalization::prevent_generalize, is_str_lit_or_union, Fix};
 use stc_ts_types::{
-    type_id::SymbolId, Alias, Array, Class, ClassDef, ClassMember, ClassProperty, CommonTypeMetadata, Function, Id, IdCtx,
-    IndexedAccessType, Instance, Interface, Intersection, Key, KeywordType, KeywordTypeMetadata, LitType, QueryExpr, QueryType, Ref,
-    StaticThis, Symbol, TypeParamDecl, Union, UnionMetadata,
+    type_id::SymbolId, Alias, Array, Class, ClassDef, ClassMember, ClassProperty, CommonTypeMetadata, Id, IdCtx, IndexedAccessType,
+    Instance, Interface, Intersection, Key, KeywordType, KeywordTypeMetadata, LitType, QueryExpr, QueryType, Ref, StaticThis, Symbol,
+    TypeParamDecl, Union, UnionMetadata,
 };
 use stc_ts_utils::PatExt;
 use stc_utils::{cache::Freeze, dev_span, ext::TypeVecExt};
@@ -2623,8 +2623,6 @@ impl Analyzer<'_, '_> {
         ret_ty.fix();
         ret_ty.freeze();
 
-        dbg!(&type_params, &type_args);
-        print_backtrace();
         let is_type_arg_count_fine = {
             let type_arg_check_res = self.validate_type_args_count(span, type_params, type_args);
 
@@ -2640,32 +2638,6 @@ impl Analyzer<'_, '_> {
         debug!("get_return_type: \ntype_params = {:?}\nret_ty = {:?}", type_params, ret_ty);
 
         if let Some(type_params) = type_params {
-            // Type parameters should default to `unknown`.
-            let mut default_unknown_map = HashMap::with_capacity_and_hasher(type_params.len(), Default::default());
-
-            if type_ann.is_none() && self.ctx.reevaluating_call_or_new {
-                // for at in spread_arg_types {
-                //     if let Type::Function(Function {
-                //         type_params: Some(type_params),
-                //         ..
-                //     }) = at.ty.normalize()
-                //     {
-                //         for tp in type_params.params.iter() {
-                //             default_unknown_map.insert(
-                //                 tp.name.clone(),
-                //                 Type::Keyword(KeywordType {
-                //                     span: tp.span,
-                //                     kind:
-                // TsKeywordTypeKind::TsUnknownKeyword,
-                //                     metadata: Default::default(),
-                //                     tracker: Default::default(),
-                //                 }),
-                //             );
-                //         }
-                //     }
-                // }
-            }
-
             for param in type_params {
                 info!("({}) Defining {}", self.scope.depth(), param.name);
 
@@ -2963,12 +2935,6 @@ impl Analyzer<'_, '_> {
             self.add_required_type_params(&mut ty);
 
             print_type("Return, after adding type params", &ty);
-
-            if type_ann.is_none() {
-                info!("Defaulting type parameters to unknown:\n{}", dump_type_map(&default_unknown_map));
-
-                ty = self.expand_type_params(&default_unknown_map, ty, Default::default())?;
-            }
 
             ty.reposition(span);
             ty.freeze();

--- a/crates/stc_ts_file_analyzer/tests/tsc/issues/0xxx/979/1.ts
+++ b/crates/stc_ts_file_analyzer/tests/tsc/issues/0xxx/979/1.ts
@@ -1,0 +1,18 @@
+function someGenerics7<A, B, C>(
+    a: (a: A) => A,
+    b: (b: B) => B,
+    c: (c: C) => C
+) { }
+
+function someGenerics8<T>(n: T): T {
+    return n;
+}
+
+var x = someGenerics8(someGenerics7); // return type should be inferred as someGenerics7, as T -> someGenerics7
+
+// stc infers x as (a: (a: unknown) => unknown, b: (b: unknown) => unknown, c: (c: unknown) => unknown) => void; (AFAICT)
+// but it should be <A#3#0, B#3#0, C#3#0>(a: (a: A#3) => A, b: (b: B#3) => B, c: (c: C#3) => C) => void
+
+x<string>(null, null, null); // No error from stc, should be 2558 Expected 3 arguments but got 1
+
+export { }

--- a/crates/stc_ts_file_analyzer/tests/tsc/issues/0xxx/979/1.tsc-errors.json
+++ b/crates/stc_ts_file_analyzer/tests/tsc/issues/0xxx/979/1.tsc-errors.json
@@ -1,0 +1,8 @@
+[
+  {
+    "file": "tests/tsc/issues/0xxx/979/1.ts",
+    "line": 16,
+    "col": 3,
+    "code": 2558
+  }
+]


### PR DESCRIPTION
**Description:**


**Related issue:**

 - Closes https://github.com/dudykr/stc/issues/979.