### PR TITLE
test: Render errors for `base/errors` tests

### DIFF
--- a/crates/stc_ts_file_analyzer/tests/base.rs
+++ b/crates/stc_ts_file_analyzer/tests/base.rs
@@ -157,11 +157,12 @@ fn validate(input: &Path) -> Vec<StcError> {
 
 #[fixture("tests/errors/**/*.ts")]
 fn errors(input: PathBuf) {
-    let stderr = run_test(input, false, false).unwrap();
+    let stderr = run_test(input.clone(), false, false).unwrap();
 
     if stderr.is_empty() {
         panic!("Expected error, but got none");
     }
+    stderr.compare_to_file(input.with_extension(".swc-stderr")).unwrap();
 }
 
 // This invokes `tsc` to get expected result.

--- a/crates/stc_ts_file_analyzer/tests/base.rs
+++ b/crates/stc_ts_file_analyzer/tests/base.rs
@@ -225,110 +225,104 @@ fn run_test(file_name: PathBuf, want_error: bool, disable_logging: bool) -> Opti
     let filename = file_name.display().to_string();
     println!("{}", filename);
 
-    for case in parse_conformance_test(&file_name).unwrap() {
-        let result = testing::Tester::new()
-            .print_errors(|cm, handler| -> Result<(), _> {
-                let _tracing = if disable_logging {
-                    Some(tracing::subscriber::set_default(tracing::subscriber::NoSubscriber::default()))
-                } else {
-                    None
-                };
+    let case = parse_conformance_test(&file_name).unwrap().into_iter().next().unwrap();
 
-                let handler = Arc::new(handler);
-                let fm = cm.load_file(&file_name).unwrap();
-                let mut libs = vec![];
-                let ls = &[
-                    "es2020.full",
-                    "es2019.full",
-                    "es2018.full",
-                    "es2017.full",
-                    "es2016.full",
-                    "es2015.full",
-                ];
-                for s in ls {
-                    libs.extend(Lib::load(s))
-                }
-                libs.sort();
-                libs.dedup();
+    let result = testing::Tester::new()
+        .print_errors(|cm, handler| -> Result<(), _> {
+            let _tracing = if disable_logging {
+                Some(tracing::subscriber::set_default(tracing::subscriber::NoSubscriber::default()))
+            } else {
+                None
+            };
 
-                let env = Env::simple(case.rule, case.target, case.module_config, &libs);
-                let stable_env = env.shared().clone();
-                let generator = module_id::ModuleIdGenerator::default();
-                let path = Arc::new(FileName::Real(file_name.clone()));
+            let handler = Arc::new(handler);
+            let fm = cm.load_file(&file_name).unwrap();
+            let mut libs = vec![];
+            let ls = &[
+                "es2020.full",
+                "es2019.full",
+                "es2018.full",
+                "es2017.full",
+                "es2016.full",
+                "es2015.full",
+            ];
+            for s in ls {
+                libs.extend(Lib::load(s))
+            }
+            libs.sort();
+            libs.dedup();
 
-                let (module_id, top_level_mark) = generator.generate(&path);
+            let env = Env::simple(case.rule, case.target, case.module_config, &libs);
+            let stable_env = env.shared().clone();
+            let generator = module_id::ModuleIdGenerator::default();
+            let path = Arc::new(FileName::Real(file_name.clone()));
 
-                let mut storage = Single {
-                    parent: None,
-                    id: module_id,
-                    top_level_ctxt: SyntaxContext::empty().apply_mark(top_level_mark),
-                    path,
-                    is_dts: false,
-                    info: Default::default(),
-                };
+            let (module_id, top_level_mark) = generator.generate(&path);
 
-                let mut node_id_gen = NodeIdGenerator::default();
-                let comments = StcComments::default();
+            let mut storage = Single {
+                parent: None,
+                id: module_id,
+                top_level_ctxt: SyntaxContext::empty().apply_mark(top_level_mark),
+                path,
+                is_dts: false,
+                info: Default::default(),
+            };
 
-                let lexer = Lexer::new(
-                    Syntax::Typescript(TsConfig {
-                        tsx: filename.contains("tsx"),
-                        decorators: true,
-                        ..Default::default()
-                    }),
-                    EsVersion::Es2020,
-                    SourceFileInput::from(&*fm),
-                    Some(&comments),
+            let mut node_id_gen = NodeIdGenerator::default();
+            let comments = StcComments::default();
+
+            let lexer = Lexer::new(
+                Syntax::Typescript(TsConfig {
+                    tsx: filename.contains("tsx"),
+                    decorators: true,
+                    ..Default::default()
+                }),
+                EsVersion::Es2020,
+                SourceFileInput::from(&*fm),
+                Some(&comments),
+            );
+            let mut parser = Parser::new_from(lexer);
+            let module = parser.parse_module().unwrap();
+            let module = module.fold_with(&mut resolver(stable_env.marks().unresolved_mark(), top_level_mark, true));
+            let module = RModule::from_orig(&mut node_id_gen, module);
+            {
+                let mut analyzer = Analyzer::root(
+                    env,
+                    cm.clone(),
+                    Default::default(),
+                    box &mut storage,
+                    &NoopLoader,
+                    if want_error {
+                        None
+                    } else {
+                        Some(Debugger {
+                            cm,
+                            handler: handler.clone(),
+                        })
+                    },
                 );
-                let mut parser = Parser::new_from(lexer);
-                let module = parser.parse_module().unwrap();
-                let module = module.fold_with(&mut resolver(stable_env.marks().unresolved_mark(), top_level_mark, true));
-                let module = RModule::from_orig(&mut node_id_gen, module);
-                {
-                    let mut analyzer = Analyzer::root(
-                        env,
-                        cm.clone(),
-                        Default::default(),
-                        box &mut storage,
-                        &NoopLoader,
-                        if want_error {
-                            None
-                        } else {
-                            Some(Debugger {
-                                cm,
-                                handler: handler.clone(),
-                            })
-                        },
-                    );
 
-                    module.validate_with(&mut analyzer).unwrap();
-                }
-
-                if want_error {
-                    let errors = storage.take_errors();
-                    let errors = ErrorKind::flatten(errors.into());
-
-                    for err in errors {
-                        err.emit(&handler);
-                    }
-                }
-
-                Err(())
-            })
-            .unwrap_err();
-
-        if want_error {
-            if result.trim().is_empty() {
-                return None;
+                module.validate_with(&mut analyzer).unwrap();
             }
 
-            panic!("Failed to validate")
-        } else {
-            return Some(result);
-        }
+            if want_error {
+                let errors = storage.take_errors();
+                let errors = ErrorKind::flatten(errors.into());
+
+                for err in errors {
+                    err.emit(&handler);
+                }
+            }
+
+            Err(())
+        })
+        .unwrap_err();
+
+    if want_error && result.trim().is_empty() {
+        return None;
     }
 
-    None
+    Some(result)
 }
 
 #[testing::fixture("tests/visualize/**/*.ts", exclude(".*\\.\\.d.\\.ts"))]

--- a/crates/stc_ts_file_analyzer/tests/base.rs
+++ b/crates/stc_ts_file_analyzer/tests/base.rs
@@ -162,7 +162,7 @@ fn errors(input: PathBuf) {
     if stderr.is_empty() {
         panic!("Expected error, but got none");
     }
-    stderr.compare_to_file(input.with_extension(".swc-stderr")).unwrap();
+    stderr.compare_to_file(input.with_extension("swc-stderr")).unwrap();
 }
 
 // This invokes `tsc` to get expected result.

--- a/crates/stc_ts_file_analyzer/tests/base.rs
+++ b/crates/stc_ts_file_analyzer/tests/base.rs
@@ -157,7 +157,7 @@ fn validate(input: &Path) -> Vec<StcError> {
 
 #[fixture("tests/errors/**/*.ts")]
 fn errors(input: PathBuf) {
-    let stderr = run_test(input.clone(), false, false).unwrap();
+    let stderr = run_test(input.clone(), true, false).unwrap();
 
     if stderr.is_empty() {
         panic!("Expected error, but got none");

--- a/crates/stc_ts_file_analyzer/tests/errors/conformance/expressions/arrayLiterals/1.swc-stderr
+++ b/crates/stc_ts_file_analyzer/tests/errors/conformance/expressions/arrayLiterals/1.swc-stderr
@@ -1,0 +1,28 @@
+TS2322
+
+  x [33mcontext[0m: tried to assign from var decl (at crates/stc_ts_file_analyzer/src/analyzer/stmt/var_decl.rs:345:34)
+  | [33mcontext[0m:
+  | lhs = instanceof  [any, any, any];
+  | rhs = [];
+  | lhs (normalized) = [any, any, any];
+  | rhs (normalized) = []; (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:565:73)
+  | [33mcontext[0m: tried to assign to a tuple type (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:2416:22)
+  | [33mcontext[0m: LHS (final): [any, any, any];
+  | RHS (final): []; (at crates/stc_ts_file_analyzer/src/analyzer/assign/array.rs:62:21)
+  | AssignFailed {
+  |     span: Span {
+  |         lo: BytePos(
+  |             119,
+  |         ),
+  |         hi: BytePos(
+  |             143,
+  |         ),
+  |         ctxt: #0,
+  |     },
+  |     cause: [],
+  | }
+   ,-[$DIR/tests/errors/conformance/expressions/arrayLiterals/1.ts:2:1]
+ 2 | 
+ 3 | var a0: [any, any, any] = []; // Error
+   :     ^^^^^^^^^^^^^^^^^^^^^^^^
+   `----

--- a/crates/stc_ts_file_analyzer/tests/errors/conformance/types/primitives/invalidAssignmentsToVoid.swc-stderr
+++ b/crates/stc_ts_file_analyzer/tests/errors/conformance/types/primitives/invalidAssignmentsToVoid.swc-stderr
@@ -1,0 +1,331 @@
+TS2322
+
+  x [33mcontext[0m:
+  | lhs = void;
+  | rhs = 1;
+  | lhs (normalized) = void;
+  | rhs (normalized) = 1; (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:565:73)
+  | [33mcontext[0m: LHS (final): void;
+  | RHS (final): 1; (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:1126:17)
+  | AssignFailed {
+  |     span: Span {
+  |         lo: BytePos(
+  |             14,
+  |         ),
+  |         hi: BytePos(
+  |             15,
+  |         ),
+  |         ctxt: #1,
+  |     },
+  |     cause: [],
+  | }
+   ,-[$DIR/tests/errors/conformance/types/primitives/invalidAssignmentsToVoid.ts:1:1]
+ 1 | var x: void;
+ 2 | x = 1;
+   : ^
+ 3 | x = true;
+   `----
+TS2322
+
+  x [33mcontext[0m:
+  | lhs = void;
+  | rhs = true;
+  | lhs (normalized) = void;
+  | rhs (normalized) = true; (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:565:73)
+  | [33mcontext[0m: LHS (final): void;
+  | RHS (final): true; (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:1126:17)
+  | AssignFailed {
+  |     span: Span {
+  |         lo: BytePos(
+  |             21,
+  |         ),
+  |         hi: BytePos(
+  |             22,
+  |         ),
+  |         ctxt: #1,
+  |     },
+  |     cause: [],
+  | }
+   ,-[$DIR/tests/errors/conformance/types/primitives/invalidAssignmentsToVoid.ts:2:1]
+ 2 | x = 1;
+ 3 | x = true;
+   : ^
+ 4 | x = '';
+   `----
+TS2322
+
+  x [33mcontext[0m:
+  | lhs = void;
+  | rhs = '';
+  | lhs (normalized) = void;
+  | rhs (normalized) = ''; (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:565:73)
+  | [33mcontext[0m: LHS (final): void;
+  | RHS (final): ''; (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:1126:17)
+  | AssignFailed {
+  |     span: Span {
+  |         lo: BytePos(
+  |             31,
+  |         ),
+  |         hi: BytePos(
+  |             32,
+  |         ),
+  |         ctxt: #1,
+  |     },
+  |     cause: [],
+  | }
+   ,-[$DIR/tests/errors/conformance/types/primitives/invalidAssignmentsToVoid.ts:3:1]
+ 3 | x = true;
+ 4 | x = '';
+   : ^
+ 5 | x = {}
+   `----
+TS2322
+
+  x [33mcontext[0m:
+  | lhs = void;
+  | rhs = {
+  | };
+  | lhs (normalized) = void;
+  | rhs (normalized) = {
+  | }; (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:565:73)
+  | [33mcontext[0m: LHS (final): void;
+  | RHS (final): {
+  | }; (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:1126:17)
+  | AssignFailed {
+  |     span: Span {
+  |         lo: BytePos(
+  |             39,
+  |         ),
+  |         hi: BytePos(
+  |             40,
+  |         ),
+  |         ctxt: #1,
+  |     },
+  |     cause: [],
+  | }
+   ,-[$DIR/tests/errors/conformance/types/primitives/invalidAssignmentsToVoid.ts:4:1]
+ 4 | x = '';
+ 5 | x = {}
+   : ^
+   `----
+TS2322
+
+  x [33mcontext[0m:
+  | lhs = void;
+  | rhs = typeof C#1;
+  | 
+  | ClassDef(arc: ClassDef { span: Span { lo: BytePos(86), hi: BytePos(87), ctxt: #1 }, is_abstract: false, name: Some(C#1), super_class: None, body: [Property(ClassProperty { span:
+  | Span { lo: BytePos(57), hi: BytePos(69), ctxt: #0 }, key: foo, value: Some(Keyword(string)), is_static: false, accessibility: None, is_abstract: false, is_optional: false, readonly:
+  | false, definite: false, accessor: Accessor { getter: false, setter: false } })], type_params: None, implements: [], metadata: ClassDefMetadata { common: CommonTypeMetadata { implicit:
+  | false, infected_by_this_in_object_literal: false, prevent_converting_to_children: false, contains_infer_type: false, prevent_complex_simplification: false, resolved_from_var: true,
+  | prevent_generalization: false, destructure_key: DestructureId(0) } }, tracker: Tracker { _priv: () } })
+  | lhs (normalized) = void;
+  | rhs (normalized) = typeof C#1;
+  | 
+  | ClassDef(arc: ClassDef { span: Span { lo: BytePos(86), hi: BytePos(87), ctxt: #1 }, is_abstract: false, name: Some(C#1), super_class: None, body: [Property(ClassProperty { span:
+  | Span { lo: BytePos(57), hi: BytePos(69), ctxt: #0 }, key: foo, value: Some(Keyword(string)), is_static: false, accessibility: None, is_abstract: false, is_optional: false, readonly:
+  | false, definite: false, accessor: Accessor { getter: false, setter: false } })], type_params: None, implements: [], metadata: ClassDefMetadata { common: CommonTypeMetadata { implicit:
+  | false, infected_by_this_in_object_literal: false, prevent_converting_to_children: false, contains_infer_type: false, prevent_complex_simplification: false, resolved_from_var: true,
+  | prevent_generalization: false, destructure_key: DestructureId(0) } }, tracker: Tracker { _priv: () } }) (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:565:73)
+  | [33mcontext[0m: LHS (final): void;
+  | RHS (final): typeof C#1;
+  | 
+  | ClassDef(arc: ClassDef { span: Span { lo: BytePos(86), hi: BytePos(87), ctxt: #1 }, is_abstract: false, name: Some(C#1), super_class: None, body: [Property(ClassProperty { span:
+  | Span { lo: BytePos(57), hi: BytePos(69), ctxt: #0 }, key: foo, value: Some(Keyword(string)), is_static: false, accessibility: None, is_abstract: false, is_optional: false, readonly:
+  | false, definite: false, accessor: Accessor { getter: false, setter: false } })], type_params: None, implements: [], metadata: ClassDefMetadata { common: CommonTypeMetadata { implicit:
+  | false, infected_by_this_in_object_literal: false, prevent_converting_to_children: false, contains_infer_type: false, prevent_complex_simplification: false, resolved_from_var: true,
+  | prevent_generalization: false, destructure_key: DestructureId(0) } }, tracker: Tracker { _priv: () } }) (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:1126:17)
+  | AssignFailed {
+  |     span: Span {
+  |         lo: BytePos(
+  |             82,
+  |         ),
+  |         hi: BytePos(
+  |             83,
+  |         ),
+  |         ctxt: #1,
+  |     },
+  |     cause: [],
+  | }
+    ,-[$DIR/tests/errors/conformance/types/primitives/invalidAssignmentsToVoid.ts:8:1]
+  8 | var c: C;
+  9 | x = C;
+    : ^
+ 10 | x = c;
+    `----
+TS2322
+
+  x [33mcontext[0m:
+  | lhs = void;
+  | rhs = C#1;
+  | 
+  | Class(Class { span: Span { lo: BytePos(93), hi: BytePos(94), ctxt: #1 }, def: arc: ClassDef { span: Span { lo: BytePos(47), hi: BytePos(71), ctxt: #0 }, is_abstract: false, name: Some(C#1),
+  | super_class: None, body: [Property(ClassProperty { span: Span { lo: BytePos(57), hi: BytePos(69), ctxt: #0 }, key: foo, value: Some(Keyword(string)), is_static: false, accessibility: None,
+  | is_abstract: false, is_optional: false, readonly: false, definite: false, accessor: Accessor { getter: false, setter: false } })], type_params: None, implements: [], metadata: ClassDefMetadata
+  | { common: CommonTypeMetadata { implicit: false, infected_by_this_in_object_literal: false, prevent_converting_to_children: false, contains_infer_type: false, prevent_complex_simplification:
+  | false, resolved_from_var: false, prevent_generalization: false, destructure_key: DestructureId(0) } }, tracker: Tracker { _priv: () } }, metadata: ClassMetadata { common: CommonTypeMetadata
+  | { implicit: false, infected_by_this_in_object_literal: false, prevent_converting_to_children: false, contains_infer_type: false, prevent_complex_simplification: false, resolved_from_var: true,
+  | prevent_generalization: false, destructure_key: DestructureId(0) } }, tracker: Tracker { _priv: () } })
+  | lhs (normalized) = void;
+  | rhs (normalized) = C#1;
+  | 
+  | Class(Class { span: Span { lo: BytePos(93), hi: BytePos(94), ctxt: #1 }, def: arc: ClassDef { span: Span { lo: BytePos(47), hi: BytePos(71), ctxt: #0 }, is_abstract: false, name: Some(C#1),
+  | super_class: None, body: [Property(ClassProperty { span: Span { lo: BytePos(57), hi: BytePos(69), ctxt: #0 }, key: foo, value: Some(Keyword(string)), is_static: false, accessibility: None,
+  | is_abstract: false, is_optional: false, readonly: false, definite: false, accessor: Accessor { getter: false, setter: false } })], type_params: None, implements: [], metadata: ClassDefMetadata
+  | { common: CommonTypeMetadata { implicit: false, infected_by_this_in_object_literal: false, prevent_converting_to_children: false, contains_infer_type: false, prevent_complex_simplification:
+  | false, resolved_from_var: false, prevent_generalization: false, destructure_key: DestructureId(0) } }, tracker: Tracker { _priv: () } }, metadata: ClassMetadata { common: CommonTypeMetadata
+  | { implicit: false, infected_by_this_in_object_literal: false, prevent_converting_to_children: false, contains_infer_type: false, prevent_complex_simplification: false, resolved_from_var: true,
+  | prevent_generalization: false, destructure_key: DestructureId(0) } }, tracker: Tracker { _priv: () } }) (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:565:73)
+  | [33mcontext[0m: LHS (final): void;
+  | RHS (final): C#1;
+  | 
+  | Class(Class { span: Span { lo: BytePos(93), hi: BytePos(94), ctxt: #1 }, def: arc: ClassDef { span: Span { lo: BytePos(47), hi: BytePos(71), ctxt: #0 }, is_abstract: false, name: Some(C#1),
+  | super_class: None, body: [Property(ClassProperty { span: Span { lo: BytePos(57), hi: BytePos(69), ctxt: #0 }, key: foo, value: Some(Keyword(string)), is_static: false, accessibility: None,
+  | is_abstract: false, is_optional: false, readonly: false, definite: false, accessor: Accessor { getter: false, setter: false } })], type_params: None, implements: [], metadata: ClassDefMetadata
+  | { common: CommonTypeMetadata { implicit: false, infected_by_this_in_object_literal: false, prevent_converting_to_children: false, contains_infer_type: false, prevent_complex_simplification:
+  | false, resolved_from_var: false, prevent_generalization: false, destructure_key: DestructureId(0) } }, tracker: Tracker { _priv: () } }, metadata: ClassMetadata { common: CommonTypeMetadata
+  | { implicit: false, infected_by_this_in_object_literal: false, prevent_converting_to_children: false, contains_infer_type: false, prevent_complex_simplification: false, resolved_from_var: true,
+  | prevent_generalization: false, destructure_key: DestructureId(0) } }, tracker: Tracker { _priv: () } }) (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:1126:17)
+  | AssignFailed {
+  |     span: Span {
+  |         lo: BytePos(
+  |             89,
+  |         ),
+  |         hi: BytePos(
+  |             90,
+  |         ),
+  |         ctxt: #1,
+  |     },
+  |     cause: [],
+  | }
+    ,-[$DIR/tests/errors/conformance/types/primitives/invalidAssignmentsToVoid.ts:9:1]
+  9 | x = C;
+ 10 | x = c;
+    : ^
+    `----
+TS2322
+
+  x [33mcontext[0m:
+  | lhs = void;
+  | rhs = I#1;
+  | Member as {
+  |     foo: string;
+  | };
+  | lhs (normalized) = void;
+  | rhs (normalized) = I#1;
+  | Member as {
+  |     foo: string;
+  | }; (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:565:73)
+  | [33mcontext[0m: LHS (final): void;
+  | RHS (final): I#1;
+  | Member as {
+  |     foo: string;
+  | }; (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:1126:17)
+  | AssignFailed {
+  |     span: Span {
+  |         lo: BytePos(
+  |             136,
+  |         ),
+  |         hi: BytePos(
+  |             137,
+  |         ),
+  |         ctxt: #1,
+  |     },
+  |     cause: [],
+  | }
+    ,-[$DIR/tests/errors/conformance/types/primitives/invalidAssignmentsToVoid.ts:13:1]
+ 13 | var i: I;
+ 14 | x = i;
+    : ^
+    `----
+TS2322
+
+  x [33mcontext[0m:
+  | lhs = void;
+  | rhs = Module(module {
+  |   types:
+  |   vars:
+  |     x
+  | })
+  | lhs (normalized) = void;
+  | rhs (normalized) = Module(module {
+  |   types:
+  |   vars:
+  |     x
+  | }) (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:565:73)
+  | [33mcontext[0m: LHS (final): void;
+  | RHS (final): Module(module {
+  |   types:
+  |   vars:
+  |     x
+  | }) (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:1126:17)
+  | AssignFailed {
+  |     span: Span {
+  |         lo: BytePos(
+  |             175,
+  |         ),
+  |         hi: BytePos(
+  |             176,
+  |         ),
+  |         ctxt: #1,
+  |     },
+  |     cause: [],
+  | }
+    ,-[$DIR/tests/errors/conformance/types/primitives/invalidAssignmentsToVoid.ts:16:1]
+ 16 | module M { export var x = 1; }
+ 17 | x = M;
+    : ^
+    `----
+TS2322
+
+  x [33mcontext[0m:
+  | lhs = void;
+  | rhs = T#3#0;
+  | lhs (normalized) = void;
+  | rhs (normalized) = T#3#0; (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:565:73)
+  | [33mcontext[0m: LHS (final): void;
+  | RHS (final): T#3#0; (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:1126:17)
+  | AssignFailed {
+  |     span: Span {
+  |         lo: BytePos(
+  |             209,
+  |         ),
+  |         hi: BytePos(
+  |             210,
+  |         ),
+  |         ctxt: #1,
+  |     },
+  |     cause: [],
+  | }
+    ,-[$DIR/tests/errors/conformance/types/primitives/invalidAssignmentsToVoid.ts:19:1]
+ 19 | function f<T>(a: T) {
+ 20 |     x = a;
+    :     ^
+ 21 | }
+    `----
+TS2322
+
+  x [33mcontext[0m:
+  | lhs = void;
+  | rhs = <T#3#0>(a: T#3) => void;
+  | lhs (normalized) = void;
+  | rhs (normalized) = <T#3#0>(a: T#3) => void; (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:565:73)
+  | [33mcontext[0m: LHS (final): void;
+  | RHS (final): <T#3#0>(a: T#3) => void; (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:1126:17)
+  | AssignFailed {
+  |     span: Span {
+  |         lo: BytePos(
+  |             218,
+  |         ),
+  |         hi: BytePos(
+  |             219,
+  |         ),
+  |         ctxt: #1,
+  |     },
+  |     cause: [],
+  | }
+    ,-[$DIR/tests/errors/conformance/types/primitives/invalidAssignmentsToVoid.ts:21:1]
+ 21 | }
+ 22 | x = f;
+    : ^
+    `----

--- a/crates/stc_ts_file_analyzer/tests/errors/conformance/types/primitives/invalidVoidAssignments.swc-stderr
+++ b/crates/stc_ts_file_analyzer/tests/errors/conformance/types/primitives/invalidVoidAssignments.swc-stderr
@@ -1,0 +1,421 @@
+TS2322
+
+  x [33mcontext[0m: tried to assign from var decl (at crates/stc_ts_file_analyzer/src/analyzer/stmt/var_decl.rs:345:34)
+  | [33mcontext[0m:
+  | lhs = boolean;
+  | rhs = void;
+  | lhs (normalized) = boolean;
+  | rhs (normalized) = void; (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:565:73)
+  | [33mcontext[0m: LHS (final): boolean;
+  | RHS (final): void; (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:1995:25)
+  | AssignFailed {
+  |     span: Span {
+  |         lo: BytePos(
+  |             19,
+  |         ),
+  |         hi: BytePos(
+  |             33,
+  |         ),
+  |         ctxt: #0,
+  |     },
+  |     cause: [],
+  | }
+   ,-[$DIR/tests/errors/conformance/types/primitives/invalidVoidAssignments.ts:2:1]
+ 2 | 
+ 3 | var a: boolean = x;
+   :     ^^^^^^^^^^^^^^
+ 4 | var b: string = x;
+   `----
+TS2322
+
+  x [33mcontext[0m: tried to assign from var decl (at crates/stc_ts_file_analyzer/src/analyzer/stmt/var_decl.rs:345:34)
+  | [33mcontext[0m:
+  | lhs = string;
+  | rhs = void;
+  | lhs (normalized) = string;
+  | rhs (normalized) = void; (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:565:73)
+  | [33mcontext[0m: LHS (final): string;
+  | RHS (final): void; (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:1995:25)
+  | AssignFailed {
+  |     span: Span {
+  |         lo: BytePos(
+  |             39,
+  |         ),
+  |         hi: BytePos(
+  |             52,
+  |         ),
+  |         ctxt: #0,
+  |     },
+  |     cause: [],
+  | }
+   ,-[$DIR/tests/errors/conformance/types/primitives/invalidVoidAssignments.ts:3:1]
+ 3 | var a: boolean = x;
+ 4 | var b: string = x;
+   :     ^^^^^^^^^^^^^
+ 5 | var c: number = x;
+   `----
+TS2322
+
+  x [33mcontext[0m: tried to assign from var decl (at crates/stc_ts_file_analyzer/src/analyzer/stmt/var_decl.rs:345:34)
+  | [33mcontext[0m:
+  | lhs = number;
+  | rhs = void;
+  | lhs (normalized) = number;
+  | rhs (normalized) = void; (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:565:73)
+  | [33mcontext[0m: LHS (final): number;
+  | RHS (final): void; (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:1995:25)
+  | AssignFailed {
+  |     span: Span {
+  |         lo: BytePos(
+  |             58,
+  |         ),
+  |         hi: BytePos(
+  |             71,
+  |         ),
+  |         ctxt: #0,
+  |     },
+  |     cause: [],
+  | }
+   ,-[$DIR/tests/errors/conformance/types/primitives/invalidVoidAssignments.ts:4:1]
+ 4 | var b: string = x;
+ 5 | var c: number = x;
+   :     ^^^^^^^^^^^^^
+ 6 | var d: typeof undefined = x;
+   `----
+TS2322
+
+  x [33mcontext[0m: tried to assign from var decl (at crates/stc_ts_file_analyzer/src/analyzer/stmt/var_decl.rs:345:34)
+  | [33mcontext[0m:
+  | lhs = instanceof  C;
+  | rhs = void;
+  | lhs (normalized) = C#1;
+  | 
+  | Class(Class { span: Span { lo: BytePos(135), hi: BytePos(136), ctxt: #0 }, def: arc: ClassDef { span: Span { lo: BytePos(103), hi: BytePos(127), ctxt: #0 }, is_abstract: false, name: Some(C#1),
+  | super_class: None, body: [Property(ClassProperty { span: Span { lo: BytePos(113), hi: BytePos(125), ctxt: #0 }, key: foo, value: Some(Keyword(string)), is_static: false, accessibility: None,
+  | is_abstract: false, is_optional: false, readonly: false, definite: false, accessor: Accessor { getter: false, setter: false } })], type_params: None, implements: [], metadata: ClassDefMetadata
+  | { common: CommonTypeMetadata { implicit: false, infected_by_this_in_object_literal: false, prevent_converting_to_children: false, contains_infer_type: false, prevent_complex_simplification:
+  | false, resolved_from_var: false, prevent_generalization: false, destructure_key: DestructureId(0) } }, tracker: Tracker { _priv: () } }, metadata: ClassMetadata { common: CommonTypeMetadata
+  | { implicit: false, infected_by_this_in_object_literal: false, prevent_converting_to_children: false, contains_infer_type: false, prevent_complex_simplification: false, resolved_from_var: false,
+  | prevent_generalization: false, destructure_key: DestructureId(0) } }, tracker: Tracker { _priv: () } })
+  | rhs (normalized) = void; (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:565:73)
+  | [33mcontext[0m: tried to assign a type to an instance of a class (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:1403:26)
+  | [33mcontext[0m: cannot assign literal or keyword to a class (at crates/stc_ts_file_analyzer/src/analyzer/assign/class.rs:268:14)
+  | AssignFailed {
+  |     span: Span {
+  |         lo: BytePos(
+  |             132,
+  |         ),
+  |         hi: BytePos(
+  |             140,
+  |         ),
+  |         ctxt: #0,
+  |     },
+  |     cause: [
+  |         SimpleAssignFailed {
+  |             span: Span {
+  |                 lo: BytePos(
+  |                     132,
+  |                 ),
+  |                 hi: BytePos(
+  |                     140,
+  |                 ),
+  |                 ctxt: #0,
+  |             },
+  |             cause: None,
+  |         },
+  |     ],
+  | }
+   ,-[$DIR/tests/errors/conformance/types/primitives/invalidVoidAssignments.ts:8:1]
+ 8 | class C { foo: string; }
+ 9 | var e: C = x;
+   :     ^^^^^^^^
+   `----
+TS2322
+
+  x [33mcontext[0m: tried to assign from var decl (at crates/stc_ts_file_analyzer/src/analyzer/stmt/var_decl.rs:345:34)
+  | [33mcontext[0m:
+  | lhs = instanceof  I;
+  | rhs = void;
+  | lhs (normalized) = I#1;
+  | Member as {
+  |     bar: string;
+  | };
+  | rhs (normalized) = void; (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:565:73)
+  | [33mcontext[0m: tried to assign a type to an interface (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:2232:18)
+  | AssignFailed {
+  |     span: Span {
+  |         lo: BytePos(
+  |             176,
+  |         ),
+  |         hi: BytePos(
+  |             184,
+  |         ),
+  |         ctxt: #0,
+  |     },
+  |     cause: [
+  |         SimpleAssignFailed {
+  |             span: Span {
+  |                 lo: BytePos(
+  |                     176,
+  |                 ),
+  |                 hi: BytePos(
+  |                     184,
+  |                 ),
+  |                 ctxt: #0,
+  |             },
+  |             cause: None,
+  |         },
+  |     ],
+  | }
+    ,-[$DIR/tests/errors/conformance/types/primitives/invalidVoidAssignments.ts:11:1]
+ 11 | interface I { bar: string; }
+ 12 | var f: I = x;
+    :     ^^^^^^^^
+    `----
+TS2322
+
+  x [33mcontext[0m: tried to assign from var decl (at crates/stc_ts_file_analyzer/src/analyzer/stmt/var_decl.rs:345:34)
+  | [33mcontext[0m:
+  | lhs = instanceof  {
+  |     baz: string;
+  | };
+  | rhs = 1;
+  | lhs (normalized) = {
+  |     baz: string;
+  | };
+  | rhs (normalized) = 1; (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:565:73)
+  | [33mcontext[0m: tried to assign a type to type elements (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:2351:22)
+  | [33mcontext[0m: tried to assign a literal as keyword to type elements (at crates/stc_ts_file_analyzer/src/analyzer/assign/type_el.rs:664:26)
+  | [33mcontext[0m: tried to assign a keyword as builtin to type elements
+  | RHS =  (at crates/stc_ts_file_analyzer/src/analyzer/assign/type_el.rs:613:26)
+  | SimpleAssignFailed {
+  |     span: Span {
+  |         lo: BytePos(
+  |             191,
+  |         ),
+  |         hi: BytePos(
+  |             213,
+  |         ),
+  |         ctxt: #0,
+  |     },
+  |     cause: Some(
+  |         MissingFields {
+  |             span: Span {
+  |                 lo: BytePos(
+  |                     191,
+  |                 ),
+  |                 hi: BytePos(
+  |                     213,
+  |                 ),
+  |                 ctxt: #0,
+  |             },
+  |             fields: [
+  |                 baz: Keyword(string),
+  |             ],
+  |         },
+  |     ),
+  | }
+    ,-[$DIR/tests/errors/conformance/types/primitives/invalidVoidAssignments.ts:13:1]
+ 13 | 
+ 14 | var g: { baz: string } = 1;
+    :     ^^^^^^^^^^^^^^^^^^^^^^
+ 15 | var g2: { 0: number } = 1;
+    `----
+TS2322
+
+  x [33mcontext[0m: tried to assign from var decl (at crates/stc_ts_file_analyzer/src/analyzer/stmt/var_decl.rs:345:34)
+  | [33mcontext[0m:
+  | lhs = instanceof  {
+  |     0: number;
+  | };
+  | rhs = 1;
+  | lhs (normalized) = {
+  |     0: number;
+  | };
+  | rhs (normalized) = 1; (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:565:73)
+  | [33mcontext[0m: tried to assign a type to type elements (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:2351:22)
+  | [33mcontext[0m: tried to assign a literal as keyword to type elements (at crates/stc_ts_file_analyzer/src/analyzer/assign/type_el.rs:664:26)
+  | [33mcontext[0m: tried to assign a keyword as builtin to type elements
+  | RHS =  (at crates/stc_ts_file_analyzer/src/analyzer/assign/type_el.rs:613:26)
+  | SimpleAssignFailed {
+  |     span: Span {
+  |         lo: BytePos(
+  |             219,
+  |         ),
+  |         hi: BytePos(
+  |             240,
+  |         ),
+  |         ctxt: #0,
+  |     },
+  |     cause: Some(
+  |         MissingFields {
+  |             span: Span {
+  |                 lo: BytePos(
+  |                     219,
+  |                 ),
+  |                 hi: BytePos(
+  |                     240,
+  |                 ),
+  |                 ctxt: #0,
+  |             },
+  |             fields: [
+  |                 0: Keyword(number),
+  |             ],
+  |         },
+  |     ),
+  | }
+    ,-[$DIR/tests/errors/conformance/types/primitives/invalidVoidAssignments.ts:14:1]
+ 14 | var g: { baz: string } = 1;
+ 15 | var g2: { 0: number } = 1;
+    :     ^^^^^^^^^^^^^^^^^^^^^
+    `----
+TS2631
+
+  x [33mcontext[0m: tried to get type of lhs of an assignment (at crates/stc_ts_file_analyzer/src/analyzer/expr/mod.rs:398:26)
+  | CannotAssignToNamespace {
+  |     span: Span {
+  |         lo: BytePos(
+  |             274,
+  |         ),
+  |         hi: BytePos(
+  |             279,
+  |         ),
+  |         ctxt: #0,
+  |     },
+  | }
+    ,-[$DIR/tests/errors/conformance/types/primitives/invalidVoidAssignments.ts:17:1]
+ 17 | module M { export var x = 1; }
+ 18 | M = x;
+    : ^^^^^
+    `----
+TS2322
+
+  x [33mcontext[0m:
+  | lhs = T#3#0;
+  | rhs = void;
+  | lhs (normalized) = T#3#0;
+  | rhs (normalized) = void; (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:565:73)
+  | [33mcontext[0m: LHS (final): T#3#0;
+  | RHS (final): void; (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:1736:30)
+  | AssignFailed {
+  |     span: Span {
+  |         lo: BytePos(
+  |             308,
+  |         ),
+  |         hi: BytePos(
+  |             309,
+  |         ),
+  |         ctxt: #3,
+  |     },
+  |     cause: [],
+  | }
+    ,-[$DIR/tests/errors/conformance/types/primitives/invalidVoidAssignments.ts:20:1]
+ 20 | function i<T>(a: T) {
+ 21 |     a = x;
+    :     ^
+ 22 | }
+    `----
+TS2630
+
+  x [33mcontext[0m: tried to get type of lhs of an assignment (at crates/stc_ts_file_analyzer/src/analyzer/expr/mod.rs:398:26)
+  | CannotAssignToFunction {
+  |     span: Span {
+  |         lo: BytePos(
+  |             317,
+  |         ),
+  |         hi: BytePos(
+  |             318,
+  |         ),
+  |         ctxt: #0,
+  |     },
+  | }
+    ,-[$DIR/tests/errors/conformance/types/primitives/invalidVoidAssignments.ts:22:1]
+ 22 | }
+ 23 | i = x;
+    : ^
+    `----
+TS2322
+
+  x [33mcontext[0m:
+  | lhs = void;
+  | rhs = E#1;
+  | lhs (normalized) = void;
+  | rhs (normalized) = E#1; (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:565:73)
+  | [33mcontext[0m: LHS (final): void;
+  | RHS (final): E#1; (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:1126:17)
+  | AssignFailed {
+  |     span: Span {
+  |         lo: BytePos(
+  |             338,
+  |         ),
+  |         hi: BytePos(
+  |             339,
+  |         ),
+  |         ctxt: #1,
+  |     },
+  |     cause: [],
+  | }
+    ,-[$DIR/tests/errors/conformance/types/primitives/invalidVoidAssignments.ts:25:1]
+ 25 | enum E { A }
+ 26 | x = E;
+    : ^
+ 27 | x = E.A;
+    `----
+TS2322
+
+  x [33mcontext[0m:
+  | lhs = void;
+  | rhs = E#1.A;
+  | lhs (normalized) = void;
+  | rhs (normalized) = E#1.A; (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:565:73)
+  | [33mcontext[0m: LHS (final): void;
+  | RHS (final): E#1.A; (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:1126:17)
+  | AssignFailed {
+  |     span: Span {
+  |         lo: BytePos(
+  |             345,
+  |         ),
+  |         hi: BytePos(
+  |             346,
+  |         ),
+  |         ctxt: #1,
+  |     },
+  |     cause: [],
+  | }
+    ,-[$DIR/tests/errors/conformance/types/primitives/invalidVoidAssignments.ts:26:1]
+ 26 | x = E;
+ 27 | x = E.A;
+    : ^
+    `----
+TS2322
+
+  x [33mcontext[0m:
+  | lhs = void;
+  | rhs = {
+  |     f(): void;
+  | };
+  | lhs (normalized) = void;
+  | rhs (normalized) = {
+  |     f(): void;
+  | }; (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:565:73)
+  | [33mcontext[0m: LHS (final): void;
+  | RHS (final): {
+  |     f(): void;
+  | }; (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:1126:17)
+  | AssignFailed {
+  |     span: Span {
+  |         lo: BytePos(
+  |             355,
+  |         ),
+  |         hi: BytePos(
+  |             356,
+  |         ),
+  |         ctxt: #1,
+  |     },
+  |     cause: [],
+  | }
+    ,-[$DIR/tests/errors/conformance/types/primitives/invalidVoidAssignments.ts:28:1]
+ 28 | 
+ 29 | x = { f() { } }
+    : ^
+    `----

--- a/crates/stc_ts_file_analyzer/tests/errors/conformance/types/primitives/invalidVoidValues.swc-stderr
+++ b/crates/stc_ts_file_analyzer/tests/errors/conformance/types/primitives/invalidVoidValues.swc-stderr
@@ -1,0 +1,341 @@
+TS2322
+
+  x [33mcontext[0m:
+  | lhs = void;
+  | rhs = 1;
+  | lhs (normalized) = void;
+  | rhs (normalized) = 1; (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:565:73)
+  | [33mcontext[0m: LHS (final): void;
+  | RHS (final): 1; (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:1126:17)
+  | AssignFailed {
+  |     span: Span {
+  |         lo: BytePos(
+  |             14,
+  |         ),
+  |         hi: BytePos(
+  |             15,
+  |         ),
+  |         ctxt: #1,
+  |     },
+  |     cause: [],
+  | }
+   ,-[$DIR/tests/errors/conformance/types/primitives/invalidVoidValues.ts:1:1]
+ 1 | var x: void;
+ 2 | x = 1;
+   : ^
+ 3 | x = "";
+   `----
+TS2322
+
+  x [33mcontext[0m:
+  | lhs = void;
+  | rhs = "";
+  | lhs (normalized) = void;
+  | rhs (normalized) = ""; (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:565:73)
+  | [33mcontext[0m: LHS (final): void;
+  | RHS (final): ""; (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:1126:17)
+  | AssignFailed {
+  |     span: Span {
+  |         lo: BytePos(
+  |             21,
+  |         ),
+  |         hi: BytePos(
+  |             22,
+  |         ),
+  |         ctxt: #1,
+  |     },
+  |     cause: [],
+  | }
+   ,-[$DIR/tests/errors/conformance/types/primitives/invalidVoidValues.ts:2:1]
+ 2 | x = 1;
+ 3 | x = "";
+   : ^
+ 4 | x = true;
+   `----
+TS2322
+
+  x [33mcontext[0m:
+  | lhs = void;
+  | rhs = true;
+  | lhs (normalized) = void;
+  | rhs (normalized) = true; (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:565:73)
+  | [33mcontext[0m: LHS (final): void;
+  | RHS (final): true; (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:1126:17)
+  | AssignFailed {
+  |     span: Span {
+  |         lo: BytePos(
+  |             29,
+  |         ),
+  |         hi: BytePos(
+  |             30,
+  |         ),
+  |         ctxt: #1,
+  |     },
+  |     cause: [],
+  | }
+   ,-[$DIR/tests/errors/conformance/types/primitives/invalidVoidValues.ts:3:1]
+ 3 | x = "";
+ 4 | x = true;
+   : ^
+   `----
+TS2322
+
+  x [33mcontext[0m:
+  | lhs = void;
+  | rhs = E#1;
+  | lhs (normalized) = void;
+  | rhs (normalized) = E#1; (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:565:73)
+  | [33mcontext[0m: LHS (final): void;
+  | RHS (final): E#1; (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:1126:17)
+  | AssignFailed {
+  |     span: Span {
+  |         lo: BytePos(
+  |             56,
+  |         ),
+  |         hi: BytePos(
+  |             57,
+  |         ),
+  |         ctxt: #1,
+  |     },
+  |     cause: [],
+  | }
+    ,-[$DIR/tests/errors/conformance/types/primitives/invalidVoidValues.ts:8:1]
+  8 | }
+  9 | x = E;
+    : ^
+ 10 | x = E.A;
+    `----
+TS2322
+
+  x [33mcontext[0m:
+  | lhs = void;
+  | rhs = E#1.A;
+  | lhs (normalized) = void;
+  | rhs (normalized) = E#1.A; (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:565:73)
+  | [33mcontext[0m: LHS (final): void;
+  | RHS (final): E#1.A; (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:1126:17)
+  | AssignFailed {
+  |     span: Span {
+  |         lo: BytePos(
+  |             63,
+  |         ),
+  |         hi: BytePos(
+  |             64,
+  |         ),
+  |         ctxt: #1,
+  |     },
+  |     cause: [],
+  | }
+    ,-[$DIR/tests/errors/conformance/types/primitives/invalidVoidValues.ts:9:1]
+  9 | x = E;
+ 10 | x = E.A;
+    : ^
+    `----
+TS2322
+
+  x [33mcontext[0m:
+  | lhs = void;
+  | rhs = C#1;
+  | 
+  | Class(Class { span: Span { lo: BytePos(114), hi: BytePos(115), ctxt: #1 }, def: arc: ClassDef { span: Span { lo: BytePos(73), hi: BytePos(99), ctxt: #0 }, is_abstract: false, name: Some(C#1),
+  | super_class: None, body: [Property(ClassProperty { span: Span { lo: BytePos(85), hi: BytePos(97), ctxt: #0 }, key: foo, value: Some(Keyword(string)), is_static: false, accessibility: None,
+  | is_abstract: false, is_optional: false, readonly: false, definite: false, accessor: Accessor { getter: false, setter: false } })], type_params: None, implements: [], metadata: ClassDefMetadata
+  | { common: CommonTypeMetadata { implicit: false, infected_by_this_in_object_literal: false, prevent_converting_to_children: false, contains_infer_type: false, prevent_complex_simplification:
+  | false, resolved_from_var: false, prevent_generalization: false, destructure_key: DestructureId(0) } }, tracker: Tracker { _priv: () } }, metadata: ClassMetadata { common: CommonTypeMetadata
+  | { implicit: false, infected_by_this_in_object_literal: false, prevent_converting_to_children: false, contains_infer_type: false, prevent_complex_simplification: false, resolved_from_var: true,
+  | prevent_generalization: false, destructure_key: DestructureId(0) } }, tracker: Tracker { _priv: () } })
+  | lhs (normalized) = void;
+  | rhs (normalized) = C#1;
+  | 
+  | Class(Class { span: Span { lo: BytePos(114), hi: BytePos(115), ctxt: #1 }, def: arc: ClassDef { span: Span { lo: BytePos(73), hi: BytePos(99), ctxt: #0 }, is_abstract: false, name: Some(C#1),
+  | super_class: None, body: [Property(ClassProperty { span: Span { lo: BytePos(85), hi: BytePos(97), ctxt: #0 }, key: foo, value: Some(Keyword(string)), is_static: false, accessibility: None,
+  | is_abstract: false, is_optional: false, readonly: false, definite: false, accessor: Accessor { getter: false, setter: false } })], type_params: None, implements: [], metadata: ClassDefMetadata
+  | { common: CommonTypeMetadata { implicit: false, infected_by_this_in_object_literal: false, prevent_converting_to_children: false, contains_infer_type: false, prevent_complex_simplification:
+  | false, resolved_from_var: false, prevent_generalization: false, destructure_key: DestructureId(0) } }, tracker: Tracker { _priv: () } }, metadata: ClassMetadata { common: CommonTypeMetadata
+  | { implicit: false, infected_by_this_in_object_literal: false, prevent_converting_to_children: false, contains_infer_type: false, prevent_complex_simplification: false, resolved_from_var: true,
+  | prevent_generalization: false, destructure_key: DestructureId(0) } }, tracker: Tracker { _priv: () } }) (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:565:73)
+  | [33mcontext[0m: LHS (final): void;
+  | RHS (final): C#1;
+  | 
+  | Class(Class { span: Span { lo: BytePos(114), hi: BytePos(115), ctxt: #1 }, def: arc: ClassDef { span: Span { lo: BytePos(73), hi: BytePos(99), ctxt: #0 }, is_abstract: false, name: Some(C#1),
+  | super_class: None, body: [Property(ClassProperty { span: Span { lo: BytePos(85), hi: BytePos(97), ctxt: #0 }, key: foo, value: Some(Keyword(string)), is_static: false, accessibility: None,
+  | is_abstract: false, is_optional: false, readonly: false, definite: false, accessor: Accessor { getter: false, setter: false } })], type_params: None, implements: [], metadata: ClassDefMetadata
+  | { common: CommonTypeMetadata { implicit: false, infected_by_this_in_object_literal: false, prevent_converting_to_children: false, contains_infer_type: false, prevent_complex_simplification:
+  | false, resolved_from_var: false, prevent_generalization: false, destructure_key: DestructureId(0) } }, tracker: Tracker { _priv: () } }, metadata: ClassMetadata { common: CommonTypeMetadata
+  | { implicit: false, infected_by_this_in_object_literal: false, prevent_converting_to_children: false, contains_infer_type: false, prevent_complex_simplification: false, resolved_from_var: true,
+  | prevent_generalization: false, destructure_key: DestructureId(0) } }, tracker: Tracker { _priv: () } }) (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:1126:17)
+  | AssignFailed {
+  |     span: Span {
+  |         lo: BytePos(
+  |             110,
+  |         ),
+  |         hi: BytePos(
+  |             111,
+  |         ),
+  |         ctxt: #1,
+  |     },
+  |     cause: [],
+  | }
+    ,-[$DIR/tests/errors/conformance/types/primitives/invalidVoidValues.ts:15:1]
+ 15 | var a: C;
+ 16 | x = a;
+    : ^
+    `----
+TS2322
+
+  x [33mcontext[0m:
+  | lhs = void;
+  | rhs = I#1;
+  | Member as {
+  |     foo: string;
+  | };
+  | lhs (normalized) = void;
+  | rhs (normalized) = I#1;
+  | Member as {
+  |     foo: string;
+  | }; (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:565:73)
+  | [33mcontext[0m: LHS (final): void;
+  | RHS (final): I#1;
+  | Member as {
+  |     foo: string;
+  | }; (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:1126:17)
+  | AssignFailed {
+  |     span: Span {
+  |         lo: BytePos(
+  |             159,
+  |         ),
+  |         hi: BytePos(
+  |             160,
+  |         ),
+  |         ctxt: #1,
+  |     },
+  |     cause: [],
+  | }
+    ,-[$DIR/tests/errors/conformance/types/primitives/invalidVoidValues.ts:21:1]
+ 21 | var b: I;
+ 22 | x = b;
+    : ^
+    `----
+TS2322
+
+  x [33mcontext[0m:
+  | lhs = void;
+  | rhs = {
+  |     f(): void;
+  | };
+  | lhs (normalized) = void;
+  | rhs (normalized) = {
+  |     f(): void;
+  | }; (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:565:73)
+  | [33mcontext[0m: LHS (final): void;
+  | RHS (final): {
+  |     f(): void;
+  | }; (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:1126:17)
+  | AssignFailed {
+  |     span: Span {
+  |         lo: BytePos(
+  |             167,
+  |         ),
+  |         hi: BytePos(
+  |             168,
+  |         ),
+  |         ctxt: #1,
+  |     },
+  |     cause: [],
+  | }
+    ,-[$DIR/tests/errors/conformance/types/primitives/invalidVoidValues.ts:23:1]
+ 23 | 
+ 24 | x = { f() {} };
+    : ^
+    `----
+TS2322
+
+  x [33mcontext[0m:
+  | lhs = void;
+  | rhs = Module(module {
+  |   types:
+  |   vars:
+  |     x
+  | })
+  | lhs (normalized) = void;
+  | rhs (normalized) = Module(module {
+  |   types:
+  |   vars:
+  |     x
+  | }) (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:565:73)
+  | [33mcontext[0m: LHS (final): void;
+  | RHS (final): Module(module {
+  |   types:
+  |   vars:
+  |     x
+  | }) (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:1126:17)
+  | AssignFailed {
+  |     span: Span {
+  |         lo: BytePos(
+  |             217,
+  |         ),
+  |         hi: BytePos(
+  |             218,
+  |         ),
+  |         ctxt: #1,
+  |     },
+  |     cause: [],
+  | }
+    ,-[$DIR/tests/errors/conformance/types/primitives/invalidVoidValues.ts:28:1]
+ 28 | }
+ 29 | x = M;
+    : ^
+    `----
+TS2322
+
+  x [33mcontext[0m:
+  | lhs = void;
+  | rhs = T#4#0;
+  | lhs (normalized) = void;
+  | rhs (normalized) = T#4#0; (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:565:73)
+  | [33mcontext[0m: LHS (final): void;
+  | RHS (final): T#4#0; (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:1126:17)
+  | AssignFailed {
+  |     span: Span {
+  |         lo: BytePos(
+  |             249,
+  |         ),
+  |         hi: BytePos(
+  |             250,
+  |         ),
+  |         ctxt: #1,
+  |     },
+  |     cause: [],
+  | }
+    ,-[$DIR/tests/errors/conformance/types/primitives/invalidVoidValues.ts:31:1]
+ 31 | function f<T>(a: T) {
+ 32 |   x = a;
+    :   ^
+ 33 | }
+    `----
+TS2322
+
+  x [33mcontext[0m:
+  | lhs = void;
+  | rhs = <T#4#0>(a: T#4) => void;
+  | lhs (normalized) = void;
+  | rhs (normalized) = <T#4#0>(a: T#4) => void; (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:565:73)
+  | [33mcontext[0m: LHS (final): void;
+  | RHS (final): <T#4#0>(a: T#4) => void; (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:1126:17)
+  | AssignFailed {
+  |     span: Span {
+  |         lo: BytePos(
+  |             258,
+  |         ),
+  |         hi: BytePos(
+  |             259,
+  |         ),
+  |         ctxt: #1,
+  |     },
+  |     cause: [],
+  | }
+    ,-[$DIR/tests/errors/conformance/types/primitives/invalidVoidValues.ts:33:1]
+ 33 | }
+ 34 | x = f;
+    : ^
+    `----

--- a/crates/stc_ts_file_analyzer/tests/errors/conformance/types/primitives/void1.swc-stderr
+++ b/crates/stc_ts_file_analyzer/tests/errors/conformance/types/primitives/void1.swc-stderr
@@ -1,0 +1,53 @@
+TS2322
+
+  x [33mcontext[0m:
+  | lhs = void;
+  | rhs = E#1;
+  | lhs (normalized) = void;
+  | rhs (normalized) = E#1; (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:565:73)
+  | [33mcontext[0m: LHS (final): void;
+  | RHS (final): E#1; (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:1126:17)
+  | AssignFailed {
+  |     span: Span {
+  |         lo: BytePos(
+  |             80,
+  |         ),
+  |         hi: BytePos(
+  |             81,
+  |         ),
+  |         ctxt: #1,
+  |     },
+  |     cause: [],
+  | }
+   ,-[$DIR/tests/errors/conformance/types/primitives/void1.ts:4:1]
+ 4 | enum E { A }
+ 5 | x = E;
+   : ^
+ 6 | x = E.A;
+   `----
+TS2322
+
+  x [33mcontext[0m:
+  | lhs = void;
+  | rhs = E#1.A;
+  | lhs (normalized) = void;
+  | rhs (normalized) = E#1.A; (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:565:73)
+  | [33mcontext[0m: LHS (final): void;
+  | RHS (final): E#1.A; (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:1126:17)
+  | AssignFailed {
+  |     span: Span {
+  |         lo: BytePos(
+  |             87,
+  |         ),
+  |         hi: BytePos(
+  |             88,
+  |         ),
+  |         ctxt: #1,
+  |     },
+  |     cause: [],
+  | }
+   ,-[$DIR/tests/errors/conformance/types/primitives/void1.ts:5:1]
+ 5 | x = E;
+ 6 | x = E.A;
+   : ^
+   `----

--- a/crates/stc_ts_file_analyzer/tests/errors/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithCallSignatures5/1.swc-stderr
+++ b/crates/stc_ts_file_analyzer/tests/errors/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithCallSignatures5/1.swc-stderr
@@ -1,0 +1,36 @@
+TS2322
+
+  x [33mcontext[0m:
+  | lhs = instanceof  <T#3#0>(x: T#3) => T;
+  | rhs = <T#2#0>(x: T#2) => void;
+  | lhs (normalized) = <T#3#0>(x: T#3) => T;
+  | rhs (normalized) = <T#2#0>(x: T#2) => void; (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:565:73)
+  | [33mcontext[0m: tried to assign to a function type:  (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:2378:77)
+  | [33mcontext[0m: tried to assign a function to another one (at crates/stc_ts_file_analyzer/src/analyzer/assign/function.rs:438:18)
+  | [33mcontext[0m: tried to assign to a mapped (wrong) function (at crates/stc_ts_file_analyzer/src/analyzer/assign/function.rs:212:26)
+  | [33mcontext[0m: tried to assign the return type of a function to the return type of another function (at crates/stc_ts_file_analyzer/src/analyzer/assign/function.rs:394:22)
+  | [33mcontext[0m:
+  | lhs = T#3#0;
+  | rhs = void;
+  | lhs (normalized) = T#3#0;
+  | rhs (normalized) = void; (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:565:73)
+  | [33mcontext[0m: LHS (final): T#3#0;
+  | RHS (final): void; (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:1736:30)
+  | AssignFailed {
+  |     span: Span {
+  |         lo: BytePos(
+  |             127,
+  |         ),
+  |         hi: BytePos(
+  |             129,
+  |         ),
+  |         ctxt: #1,
+  |     },
+  |     cause: [],
+  | }
+   ,-[$DIR/tests/errors/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithCallSignatures5/1.ts:5:1]
+ 5 | var b3: <T>(x: T) => T;
+ 6 | b3 = a3; // ok
+   : ^^
+ 7 | export { }
+   `----

--- a/crates/stc_ts_file_analyzer/tests/errors/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithCallSignatures5/2.swc-stderr
+++ b/crates/stc_ts_file_analyzer/tests/errors/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithCallSignatures5/2.swc-stderr
@@ -1,0 +1,128 @@
+TS2322
+
+  x [33mcontext[0m:
+  | lhs = instanceof  <T#3#0, U#3#0>(x: {
+  |     foo: T#3;
+  | }, y: {
+  |     foo: U#3;
+  |     bar: U;
+  | }) => Base;
+  | rhs = <T#2#0>(x: {
+  |     foo: T#2;
+  | }, y: {
+  |     foo: T;
+  |     bar: T;
+  | }) => Base;
+  | lhs (normalized) = <T#3#0, U#3#0>(x: {
+  |     foo: T#3;
+  | }, y: {
+  |     foo: U#3;
+  |     bar: U;
+  | }) => Base;
+  | rhs (normalized) = <T#2#0>(x: {
+  |     foo: T#2;
+  | }, y: {
+  |     foo: T;
+  |     bar: T;
+  | }) => Base; (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:565:73)
+  | [33mcontext[0m: tried to assign to a function type:  (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:2378:77)
+  | [33mcontext[0m: tried to assign a function to another one (at crates/stc_ts_file_analyzer/src/analyzer/assign/function.rs:438:18)
+  | [33mcontext[0m: tried to assign to an expanded callable
+  | Map:
+  | T#2:  (at crates/stc_ts_file_analyzer/src/analyzer/assign/function.rs:346:22)
+  | [33mcontext[0m: tried to assign parameters of a function to parameters of another function (at crates/stc_ts_file_analyzer/src/analyzer/assign/function.rs:377:14)
+  | [33mcontext[0m: tried to assign the type of a parameter to another (at crates/stc_ts_file_analyzer/src/analyzer/assign/function.rs:776:26)
+  | [33mcontext[0m:
+  | lhs = {
+  |     foo: T#3#0;
+  |     bar: T;
+  | };
+  | rhs = {
+  |     foo: U#3#0;
+  |     bar: U;
+  | };
+  | lhs (normalized) = {
+  |     foo: T#3#0;
+  |     bar: T;
+  | };
+  | rhs (normalized) = {
+  |     foo: U#3#0;
+  |     bar: U;
+  | }; (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:565:73)
+  | [33mcontext[0m: tried to assign a type to type elements (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:2351:22)
+  | ObjectAssignFailed {
+  |     span: Span {
+  |         lo: BytePos(
+  |             228,
+  |         ),
+  |         hi: BytePos(
+  |             231,
+  |         ),
+  |         ctxt: #0,
+  |     },
+  |     errors: [
+  |         [33mcontext[0m: tried assignment of a type literal to a type literals
+  |         LHS={
+  |             foo: T#3#0;
+  |             bar: T;
+  |         };
+  |         RHS={
+  |             foo: U#3#0;
+  |             bar: U;
+  |         }; (at crates/stc_ts_file_analyzer/src/analyzer/assign/type_el.rs:199:22)
+  |         [33mcontext[0m: tried to assign to 0th element: Some(foo) (at crates/stc_ts_file_analyzer/src/analyzer/assign/type_el.rs:1049:18)
+  |         [33mcontext[0m:
+  |         lhs = T#3#0;
+  |         rhs = U#3#0;
+  |         lhs (normalized) = T#3#0;
+  |         rhs (normalized) = U#3#0; (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:565:73)
+  |         [33mcontext[0m: LHS (final): T#3#0;
+  |         RHS (final): U#3#0; (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:1657:29)
+  |         AssignFailed {
+  |             span: Span {
+  |                 lo: BytePos(
+  |                     228,
+  |                 ),
+  |                 hi: BytePos(
+  |                     231,
+  |                 ),
+  |                 ctxt: #1,
+  |             },
+  |             cause: [],
+  |         },
+  |         [33mcontext[0m: tried assignment of a type literal to a type literals
+  |         LHS={
+  |             foo: T#3#0;
+  |             bar: T;
+  |         };
+  |         RHS={
+  |             foo: U#3#0;
+  |             bar: U;
+  |         }; (at crates/stc_ts_file_analyzer/src/analyzer/assign/type_el.rs:199:22)
+  |         [33mcontext[0m: tried to assign to 1th element: Some(bar) (at crates/stc_ts_file_analyzer/src/analyzer/assign/type_el.rs:1049:18)
+  |         [33mcontext[0m:
+  |         lhs = T#3#0;
+  |         rhs = U#3#0;
+  |         lhs (normalized) = T#3#0;
+  |         rhs (normalized) = U#3#0; (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:565:73)
+  |         [33mcontext[0m: LHS (final): T#3#0;
+  |         RHS (final): U#3#0; (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:1657:29)
+  |         AssignFailed {
+  |             span: Span {
+  |                 lo: BytePos(
+  |                     228,
+  |                 ),
+  |                 hi: BytePos(
+  |                     231,
+  |                 ),
+  |                 ctxt: #1,
+  |             },
+  |             cause: [],
+  |         },
+  |     ],
+  | }
+   ,-[$DIR/tests/errors/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithCallSignatures5/2.ts:7:1]
+ 7 | var b11: <T, U>(x: { foo: T }, y: { foo: U; bar: U }) => Base;
+ 8 | b11 = a11; // ok
+   : ^^^
+   `----

--- a/crates/stc_ts_file_analyzer/tests/errors/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithCallSignatures5/3.swc-stderr
+++ b/crates/stc_ts_file_analyzer/tests/errors/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithCallSignatures5/3.swc-stderr
@@ -1,0 +1,91 @@
+TS2322
+
+  x [33mcontext[0m:
+  | lhs = instanceof  <U#3#0, V#3#0>(x: {
+  |     a: U#3;
+  |     b: V#3;
+  | }) => U[];
+  | rhs = <T#2#0>(x: {
+  |     a: T#2;
+  |     b: T;
+  | }) => T[];
+  | lhs (normalized) = <U#3#0, V#3#0>(x: {
+  |     a: U#3;
+  |     b: V#3;
+  | }) => U[];
+  | rhs (normalized) = <T#2#0>(x: {
+  |     a: T#2;
+  |     b: T;
+  | }) => T[]; (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:565:73)
+  | [33mcontext[0m: tried to assign to a function type:  (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:2378:77)
+  | [33mcontext[0m: tried to assign a function to another one (at crates/stc_ts_file_analyzer/src/analyzer/assign/function.rs:438:18)
+  | [33mcontext[0m: tried to assign to an expanded callable
+  | Map:
+  | T#2:  (at crates/stc_ts_file_analyzer/src/analyzer/assign/function.rs:346:22)
+  | [33mcontext[0m: tried to assign parameters of a function to parameters of another function (at crates/stc_ts_file_analyzer/src/analyzer/assign/function.rs:377:14)
+  | [33mcontext[0m: tried to assign the type of a parameter to another (at crates/stc_ts_file_analyzer/src/analyzer/assign/function.rs:776:26)
+  | [33mcontext[0m:
+  | lhs = {
+  |     a: U#3#0;
+  |     b: U;
+  | };
+  | rhs = {
+  |     a: U#3#0;
+  |     b: V#3#0;
+  | };
+  | lhs (normalized) = {
+  |     a: U#3#0;
+  |     b: U;
+  | };
+  | rhs (normalized) = {
+  |     a: U#3#0;
+  |     b: V#3#0;
+  | }; (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:565:73)
+  | [33mcontext[0m: tried to assign a type to type elements (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:2351:22)
+  | ObjectAssignFailed {
+  |     span: Span {
+  |         lo: BytePos(
+  |             190,
+  |         ),
+  |         hi: BytePos(
+  |             193,
+  |         ),
+  |         ctxt: #0,
+  |     },
+  |     errors: [
+  |         [33mcontext[0m: tried assignment of a type literal to a type literals
+  |         LHS={
+  |             a: U#3#0;
+  |             b: U;
+  |         };
+  |         RHS={
+  |             a: U#3#0;
+  |             b: V#3#0;
+  |         }; (at crates/stc_ts_file_analyzer/src/analyzer/assign/type_el.rs:199:22)
+  |         [33mcontext[0m: tried to assign to 1th element: Some(b) (at crates/stc_ts_file_analyzer/src/analyzer/assign/type_el.rs:1049:18)
+  |         [33mcontext[0m:
+  |         lhs = U#3#0;
+  |         rhs = V#3#0;
+  |         lhs (normalized) = U#3#0;
+  |         rhs (normalized) = V#3#0; (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:565:73)
+  |         [33mcontext[0m: LHS (final): U#3#0;
+  |         RHS (final): V#3#0; (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:1657:29)
+  |         AssignFailed {
+  |             span: Span {
+  |                 lo: BytePos(
+  |                     190,
+  |                 ),
+  |                 hi: BytePos(
+  |                     193,
+  |                 ),
+  |                 ctxt: #1,
+  |             },
+  |             cause: [],
+  |         },
+  |     ],
+  | }
+   ,-[$DIR/tests/errors/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithCallSignatures5/3.ts:8:1]
+ 8 | var b15: <U, V>(x: { a: U; b: V; }) => U[];
+ 9 | b15 = a15; // ok
+   : ^^^
+   `----

--- a/crates/stc_ts_file_analyzer/tests/errors/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithCallSignatures5/4.swc-stderr
+++ b/crates/stc_ts_file_analyzer/tests/errors/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithCallSignatures5/4.swc-stderr
@@ -1,0 +1,91 @@
+TS2322
+
+  x [33mcontext[0m:
+  | lhs = instanceof  <U#3#0, V#3#0>(x: {
+  |     a: U#3;
+  |     b: V#3;
+  | }) => U[];
+  | rhs = <T#2#0 extends Base>(x: {
+  |     a: T#2;
+  |     b: T;
+  | }) => T[];
+  | lhs (normalized) = <U#3#0, V#3#0>(x: {
+  |     a: U#3;
+  |     b: V#3;
+  | }) => U[];
+  | rhs (normalized) = <T#2#0 extends Base>(x: {
+  |     a: T#2;
+  |     b: T;
+  | }) => T[]; (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:565:73)
+  | [33mcontext[0m: tried to assign to a function type:  (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:2378:77)
+  | [33mcontext[0m: tried to assign a function to another one (at crates/stc_ts_file_analyzer/src/analyzer/assign/function.rs:438:18)
+  | [33mcontext[0m: tried to assign to an expanded callable
+  | Map:
+  | T#2:  (at crates/stc_ts_file_analyzer/src/analyzer/assign/function.rs:346:22)
+  | [33mcontext[0m: tried to assign parameters of a function to parameters of another function (at crates/stc_ts_file_analyzer/src/analyzer/assign/function.rs:377:14)
+  | [33mcontext[0m: tried to assign the type of a parameter to another (at crates/stc_ts_file_analyzer/src/analyzer/assign/function.rs:776:26)
+  | [33mcontext[0m:
+  | lhs = {
+  |     a: U#3#0;
+  |     b: U;
+  | };
+  | rhs = {
+  |     a: U#3#0;
+  |     b: V#3#0;
+  | };
+  | lhs (normalized) = {
+  |     a: U#3#0;
+  |     b: U;
+  | };
+  | rhs (normalized) = {
+  |     a: U#3#0;
+  |     b: V#3#0;
+  | }; (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:565:73)
+  | [33mcontext[0m: tried to assign a type to type elements (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:2351:22)
+  | ObjectAssignFailed {
+  |     span: Span {
+  |         lo: BytePos(
+  |             202,
+  |         ),
+  |         hi: BytePos(
+  |             205,
+  |         ),
+  |         ctxt: #0,
+  |     },
+  |     errors: [
+  |         [33mcontext[0m: tried assignment of a type literal to a type literals
+  |         LHS={
+  |             a: U#3#0;
+  |             b: U;
+  |         };
+  |         RHS={
+  |             a: U#3#0;
+  |             b: V#3#0;
+  |         }; (at crates/stc_ts_file_analyzer/src/analyzer/assign/type_el.rs:199:22)
+  |         [33mcontext[0m: tried to assign to 1th element: Some(b) (at crates/stc_ts_file_analyzer/src/analyzer/assign/type_el.rs:1049:18)
+  |         [33mcontext[0m:
+  |         lhs = U#3#0;
+  |         rhs = V#3#0;
+  |         lhs (normalized) = U#3#0;
+  |         rhs (normalized) = V#3#0; (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:565:73)
+  |         [33mcontext[0m: LHS (final): U#3#0;
+  |         RHS (final): V#3#0; (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:1657:29)
+  |         AssignFailed {
+  |             span: Span {
+  |                 lo: BytePos(
+  |                     202,
+  |                 ),
+  |                 hi: BytePos(
+  |                     205,
+  |                 ),
+  |                 ctxt: #1,
+  |             },
+  |             cause: [],
+  |         },
+  |     ],
+  | }
+   ,-[$DIR/tests/errors/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithCallSignatures5/4.ts:7:1]
+ 7 | 
+ 8 | b15 = a16; // ok
+   : ^^^
+   `----

--- a/crates/stc_ts_file_analyzer/tests/errors/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithCallSignatures6/1.swc-stderr
+++ b/crates/stc_ts_file_analyzer/tests/errors/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithCallSignatures6/1.swc-stderr
@@ -1,0 +1,35 @@
+TS2322
+
+  x [33mcontext[0m:
+  | lhs = instanceof  <T#3#0>(x: T#3) => T;
+  | rhs = <T#2#0>(x: T#2) => void;
+  | lhs (normalized) = <T#3#0>(x: T#3) => T;
+  | rhs (normalized) = <T#2#0>(x: T#2) => void; (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:565:73)
+  | [33mcontext[0m: tried to assign to a function type:  (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:2378:77)
+  | [33mcontext[0m: tried to assign a function to another one (at crates/stc_ts_file_analyzer/src/analyzer/assign/function.rs:438:18)
+  | [33mcontext[0m: tried to assign to a mapped (wrong) function (at crates/stc_ts_file_analyzer/src/analyzer/assign/function.rs:212:26)
+  | [33mcontext[0m: tried to assign the return type of a function to the return type of another function (at crates/stc_ts_file_analyzer/src/analyzer/assign/function.rs:394:22)
+  | [33mcontext[0m:
+  | lhs = T#3#0;
+  | rhs = void;
+  | lhs (normalized) = T#3#0;
+  | rhs (normalized) = void; (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:565:73)
+  | [33mcontext[0m: LHS (final): T#3#0;
+  | RHS (final): void; (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:1736:30)
+  | AssignFailed {
+  |     span: Span {
+  |         lo: BytePos(
+  |             158,
+  |         ),
+  |         hi: BytePos(
+  |             160,
+  |         ),
+  |         ctxt: #1,
+  |     },
+  |     cause: [],
+  | }
+    ,-[$DIR/tests/errors/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithCallSignatures6/1.ts:9:1]
+  9 | var b3: <T>(x: T) => T;
+ 10 | b3 = x.a3;
+    : ^^
+    `----

--- a/crates/stc_ts_file_analyzer/tests/errors/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithCallSignatures6/2.swc-stderr
+++ b/crates/stc_ts_file_analyzer/tests/errors/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithCallSignatures6/2.swc-stderr
@@ -1,0 +1,118 @@
+TS2322
+
+  x [33mcontext[0m:
+  | lhs = instanceof  <T#3#0>(x: {
+  |     a: T#3;
+  |     b: T;
+  | }) => T[];
+  | rhs = <T#2#0 extends Base>(x: {
+  |     a: T#2;
+  |     b: T;
+  | }) => T[];
+  | lhs (normalized) = <T#3#0>(x: {
+  |     a: T#3;
+  |     b: T;
+  | }) => T[];
+  | rhs (normalized) = <T#2#0 extends Base>(x: {
+  |     a: T#2;
+  |     b: T;
+  | }) => T[]; (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:565:73)
+  | [33mcontext[0m: tried to assign to a function type:  (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:2378:77)
+  | [33mcontext[0m: tried to assign a function to another one (at crates/stc_ts_file_analyzer/src/analyzer/assign/function.rs:438:18)
+  | [33mcontext[0m: tried to assign to a mapped (wrong) function (at crates/stc_ts_file_analyzer/src/analyzer/assign/function.rs:212:26)
+  | [33mcontext[0m: tried to assign parameters of a function to parameters of another function (at crates/stc_ts_file_analyzer/src/analyzer/assign/function.rs:377:14)
+  | [33mcontext[0m: tried to assign the type of a parameter to another (at crates/stc_ts_file_analyzer/src/analyzer/assign/function.rs:776:26)
+  | [33mcontext[0m:
+  | lhs = {
+  |     a: T#2#0;
+  |     b: T;
+  | };
+  | rhs = {
+  |     a: T#3#0;
+  |     b: T;
+  | };
+  | lhs (normalized) = {
+  |     a: T#2#0;
+  |     b: T;
+  | };
+  | rhs (normalized) = {
+  |     a: T#3#0;
+  |     b: T;
+  | }; (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:565:73)
+  | [33mcontext[0m: tried to assign a type to type elements (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:2351:22)
+  | ObjectAssignFailed {
+  |     span: Span {
+  |         lo: BytePos(
+  |             229,
+  |         ),
+  |         hi: BytePos(
+  |             232,
+  |         ),
+  |         ctxt: #0,
+  |     },
+  |     errors: [
+  |         [33mcontext[0m: tried assignment of a type literal to a type literals
+  |         LHS={
+  |             a: T#2#0;
+  |             b: T;
+  |         };
+  |         RHS={
+  |             a: T#3#0;
+  |             b: T;
+  |         }; (at crates/stc_ts_file_analyzer/src/analyzer/assign/type_el.rs:199:22)
+  |         [33mcontext[0m: tried to assign to 0th element: Some(a) (at crates/stc_ts_file_analyzer/src/analyzer/assign/type_el.rs:1049:18)
+  |         [33mcontext[0m:
+  |         lhs = T#2#0;
+  |         rhs = T#3#0;
+  |         lhs (normalized) = T#2#0;
+  |         rhs (normalized) = T#3#0; (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:565:73)
+  |         [33mcontext[0m: LHS (final): T#2#0;
+  |         RHS (final): T#3#0; (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:1657:29)
+  |         AssignFailed {
+  |             span: Span {
+  |                 lo: BytePos(
+  |                     229,
+  |                 ),
+  |                 hi: BytePos(
+  |                     232,
+  |                 ),
+  |                 ctxt: #1,
+  |             },
+  |             cause: [],
+  |         },
+  |         [33mcontext[0m: tried assignment of a type literal to a type literals
+  |         LHS={
+  |             a: T#2#0;
+  |             b: T;
+  |         };
+  |         RHS={
+  |             a: T#3#0;
+  |             b: T;
+  |         }; (at crates/stc_ts_file_analyzer/src/analyzer/assign/type_el.rs:199:22)
+  |         [33mcontext[0m: tried to assign to 1th element: Some(b) (at crates/stc_ts_file_analyzer/src/analyzer/assign/type_el.rs:1049:18)
+  |         [33mcontext[0m:
+  |         lhs = T#2#0;
+  |         rhs = T#3#0;
+  |         lhs (normalized) = T#2#0;
+  |         rhs (normalized) = T#3#0; (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:565:73)
+  |         [33mcontext[0m: LHS (final): T#2#0;
+  |         RHS (final): T#3#0; (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:1657:29)
+  |         AssignFailed {
+  |             span: Span {
+  |                 lo: BytePos(
+  |                     229,
+  |                 ),
+  |                 hi: BytePos(
+  |                     232,
+  |                 ),
+  |                 ctxt: #1,
+  |             },
+  |             cause: [],
+  |         },
+  |     ],
+  | }
+    ,-[$DIR/tests/errors/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithCallSignatures6/2.ts:11:1]
+ 11 | var b16: <T>(x: { a: T; b: T }) => T[];
+ 12 | b16 = x.a16;
+    : ^^^
+    `----

--- a/crates/stc_ts_file_analyzer/tests/errors/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithConstructSignatures4/1.swc-stderr
+++ b/crates/stc_ts_file_analyzer/tests/errors/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithConstructSignatures4/1.swc-stderr
@@ -1,0 +1,161 @@
+TS2322
+
+  x [33mcontext[0m:
+  | lhs = instanceof  new <T#2#0>(x: (a: T#2) => T) => T[];
+  | rhs = {
+  |     new(x: {
+  |         new(a: number): number;
+  |         new(a?: number): number;
+  |     }): number[];
+  |     new(x: {
+  |         new(a: boolean): boolean;
+  |         new(a?: boolean): boolean;
+  |     }): boolean[];
+  | };
+  | lhs (normalized) = new <T#2#0>(x: (a: T#2) => T) => T[];
+  | rhs (normalized) = {
+  |     new(x: {
+  |         new(a: number): number;
+  |         new(a?: number): number;
+  |     }): number[];
+  |     new(x: {
+  |         new(a: boolean): boolean;
+  |         new(a?: boolean): boolean;
+  |     }): boolean[];
+  | }; (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:565:73)
+  | [33mcontext[0m: tried to assign to a constructor type (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:2425:22)
+  | AssignFailed {
+  |     span: Span {
+  |         lo: BytePos(
+  |             377,
+  |         ),
+  |         hi: BytePos(
+  |             380,
+  |         ),
+  |         ctxt: #1,
+  |     },
+  |     cause: [
+  |         SimpleAssignFailedWithCause {
+  |             span: Span {
+  |                 lo: BytePos(
+  |                     377,
+  |                 ),
+  |                 hi: BytePos(
+  |                     380,
+  |                 ),
+  |                 ctxt: #1,
+  |             },
+  |             cause: [
+  |                 [33mcontext[0m: tried to assign a constructor to another constructor (0th element) (at crates/stc_ts_file_analyzer/src/analyzer/assign/function.rs:577:30)
+  |                 [33mcontext[0m: tried to assign parameters of a function to parameters of another function (at crates/stc_ts_file_analyzer/src/analyzer/assign/function.rs:377:14)
+  |                 [33mcontext[0m: tried to assign the type of a parameter to another (at crates/stc_ts_file_analyzer/src/analyzer/assign/function.rs:776:26)
+  |                 [33mcontext[0m:
+  |                 lhs = {
+  |                     new(a: number): number;
+  |                     new(a?: number): number;
+  |                 };
+  |                 rhs = (a: T#2#0) => T;
+  |                 lhs (normalized) = {
+  |                     new(a: number): number;
+  |                     new(a?: number): number;
+  |                 };
+  |                 rhs (normalized) = (a: T#2#0) => T; (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:565:73)
+  |                 [33mcontext[0m: tried to assign a type to type elements (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:2351:22)
+  |                 [33mcontext[0m: tried to assign the converted type to type elements:
+  |                 RHS= (at crates/stc_ts_file_analyzer/src/analyzer/assign/type_el.rs:543:26)
+  |                 ObjectAssignFailed {
+  |                     span: Span {
+  |                         lo: BytePos(
+  |                             377,
+  |                         ),
+  |                         hi: BytePos(
+  |                             380,
+  |                         ),
+  |                         ctxt: #0,
+  |                     },
+  |                     errors: [
+  |                         [33mcontext[0m: tried assignment of a type literal to a type literals
+  |                         LHS={
+  |                             new(a: number): number;
+  |                             new(a?: number): number;
+  |                         };
+  |                         RHS={
+  |                             (a: T#2#0) : T;
+  |                         }; (at crates/stc_ts_file_analyzer/src/analyzer/assign/type_el.rs:199:22)
+  |                         [33mcontext[0m: tried to assign to an element (not a key-based) (at crates/stc_ts_file_analyzer/src/analyzer/assign/type_el.rs:1087:18)
+  |                         [33mcontext[0m: failed to assign to a constructor (at crates/stc_ts_file_analyzer/src/analyzer/assign/type_el.rs:1565:92)
+  |                         SimpleAssignFailed {
+  |                             span: Span {
+  |                                 lo: BytePos(
+  |                                     377,
+  |                                 ),
+  |                                 hi: BytePos(
+  |                                     380,
+  |                                 ),
+  |                                 ctxt: #0,
+  |                             },
+  |                             cause: None,
+  |                         },
+  |                     ],
+  |                 },
+  |                 [33mcontext[0m: tried to assign a constructor to another constructor (1th element) (at crates/stc_ts_file_analyzer/src/analyzer/assign/function.rs:577:30)
+  |                 [33mcontext[0m: tried to assign parameters of a function to parameters of another function (at crates/stc_ts_file_analyzer/src/analyzer/assign/function.rs:377:14)
+  |                 [33mcontext[0m: tried to assign the type of a parameter to another (at crates/stc_ts_file_analyzer/src/analyzer/assign/function.rs:776:26)
+  |                 [33mcontext[0m:
+  |                 lhs = {
+  |                     new(a: boolean): boolean;
+  |                     new(a?: boolean): boolean;
+  |                 };
+  |                 rhs = (a: T#2#0) => T;
+  |                 lhs (normalized) = {
+  |                     new(a: boolean): boolean;
+  |                     new(a?: boolean): boolean;
+  |                 };
+  |                 rhs (normalized) = (a: T#2#0) => T; (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:565:73)
+  |                 [33mcontext[0m: tried to assign a type to type elements (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:2351:22)
+  |                 [33mcontext[0m: tried to assign the converted type to type elements:
+  |                 RHS= (at crates/stc_ts_file_analyzer/src/analyzer/assign/type_el.rs:543:26)
+  |                 ObjectAssignFailed {
+  |                     span: Span {
+  |                         lo: BytePos(
+  |                             377,
+  |                         ),
+  |                         hi: BytePos(
+  |                             380,
+  |                         ),
+  |                         ctxt: #0,
+  |                     },
+  |                     errors: [
+  |                         [33mcontext[0m: tried assignment of a type literal to a type literals
+  |                         LHS={
+  |                             new(a: boolean): boolean;
+  |                             new(a?: boolean): boolean;
+  |                         };
+  |                         RHS={
+  |                             (a: T#2#0) : T;
+  |                         }; (at crates/stc_ts_file_analyzer/src/analyzer/assign/type_el.rs:199:22)
+  |                         [33mcontext[0m: tried to assign to an element (not a key-based) (at crates/stc_ts_file_analyzer/src/analyzer/assign/type_el.rs:1087:18)
+  |                         [33mcontext[0m: failed to assign to a constructor (at crates/stc_ts_file_analyzer/src/analyzer/assign/type_el.rs:1565:92)
+  |                         SimpleAssignFailed {
+  |                             span: Span {
+  |                                 lo: BytePos(
+  |                                     377,
+  |                                 ),
+  |                                 hi: BytePos(
+  |                                     380,
+  |                                 ),
+  |                                 ctxt: #0,
+  |                             },
+  |                             cause: None,
+  |                         },
+  |                     ],
+  |                 },
+  |             ],
+  |         },
+  |     ],
+  | }
+    ,-[$DIR/tests/errors/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithConstructSignatures4/1.ts:18:1]
+ 18 | var b16: new <T>(x: (a: T) => T) => T[];
+ 19 | b16 = a16; // error
+    : ^^^
+    `----

--- a/crates/stc_ts_file_analyzer/tests/errors/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithConstructSignatures4/2.swc-stderr
+++ b/crates/stc_ts_file_analyzer/tests/errors/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithConstructSignatures4/2.swc-stderr
@@ -1,0 +1,161 @@
+TS2322
+
+  x [33mcontext[0m:
+  | lhs = instanceof  new <T#6#0>(x: (a: T#6) => T) => any[];
+  | rhs = {
+  |     new(x: {
+  |         new <T#2 extends Derived>(a: T#2#0): T;
+  |         new <T#3 extends Base>(a: T#3#0): T;
+  |     }): any[];
+  |     new(x: {
+  |         new <T#4 extends Derived2>(a: T#4#0): T;
+  |         new <T#5 extends Base>(a: T#5#0): T;
+  |     }): any[];
+  | };
+  | lhs (normalized) = new <T#6#0>(x: (a: T#6) => T) => any[];
+  | rhs (normalized) = {
+  |     new(x: {
+  |         new <T#2 extends Derived>(a: T#2#0): T;
+  |         new <T#3 extends Base>(a: T#3#0): T;
+  |     }): any[];
+  |     new(x: {
+  |         new <T#4 extends Derived2>(a: T#4#0): T;
+  |         new <T#5 extends Base>(a: T#5#0): T;
+  |     }): any[];
+  | }; (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:565:73)
+  | [33mcontext[0m: tried to assign to a constructor type (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:2425:22)
+  | AssignFailed {
+  |     span: Span {
+  |         lo: BytePos(
+  |             449,
+  |         ),
+  |         hi: BytePos(
+  |             452,
+  |         ),
+  |         ctxt: #1,
+  |     },
+  |     cause: [
+  |         SimpleAssignFailedWithCause {
+  |             span: Span {
+  |                 lo: BytePos(
+  |                     449,
+  |                 ),
+  |                 hi: BytePos(
+  |                     452,
+  |                 ),
+  |                 ctxt: #1,
+  |             },
+  |             cause: [
+  |                 [33mcontext[0m: tried to assign a constructor to another constructor (0th element) (at crates/stc_ts_file_analyzer/src/analyzer/assign/function.rs:577:30)
+  |                 [33mcontext[0m: tried to assign parameters of a function to parameters of another function (at crates/stc_ts_file_analyzer/src/analyzer/assign/function.rs:377:14)
+  |                 [33mcontext[0m: tried to assign the type of a parameter to another (at crates/stc_ts_file_analyzer/src/analyzer/assign/function.rs:776:26)
+  |                 [33mcontext[0m:
+  |                 lhs = {
+  |                     new <T#2 extends Derived>(a: T#2#0): T;
+  |                     new <T#3 extends Base>(a: T#3#0): T;
+  |                 };
+  |                 rhs = (a: T#6#0) => T;
+  |                 lhs (normalized) = {
+  |                     new <T#2 extends Derived>(a: T#2#0): T;
+  |                     new <T#3 extends Base>(a: T#3#0): T;
+  |                 };
+  |                 rhs (normalized) = (a: T#6#0) => T; (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:565:73)
+  |                 [33mcontext[0m: tried to assign a type to type elements (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:2351:22)
+  |                 [33mcontext[0m: tried to assign the converted type to type elements:
+  |                 RHS= (at crates/stc_ts_file_analyzer/src/analyzer/assign/type_el.rs:543:26)
+  |                 ObjectAssignFailed {
+  |                     span: Span {
+  |                         lo: BytePos(
+  |                             449,
+  |                         ),
+  |                         hi: BytePos(
+  |                             452,
+  |                         ),
+  |                         ctxt: #0,
+  |                     },
+  |                     errors: [
+  |                         [33mcontext[0m: tried assignment of a type literal to a type literals
+  |                         LHS={
+  |                             new <T#2 extends Derived>(a: T#2#0): T;
+  |                             new <T#3 extends Base>(a: T#3#0): T;
+  |                         };
+  |                         RHS={
+  |                             (a: T#6#0) : T;
+  |                         }; (at crates/stc_ts_file_analyzer/src/analyzer/assign/type_el.rs:199:22)
+  |                         [33mcontext[0m: tried to assign to an element (not a key-based) (at crates/stc_ts_file_analyzer/src/analyzer/assign/type_el.rs:1087:18)
+  |                         [33mcontext[0m: failed to assign to a constructor (at crates/stc_ts_file_analyzer/src/analyzer/assign/type_el.rs:1565:92)
+  |                         SimpleAssignFailed {
+  |                             span: Span {
+  |                                 lo: BytePos(
+  |                                     449,
+  |                                 ),
+  |                                 hi: BytePos(
+  |                                     452,
+  |                                 ),
+  |                                 ctxt: #0,
+  |                             },
+  |                             cause: None,
+  |                         },
+  |                     ],
+  |                 },
+  |                 [33mcontext[0m: tried to assign a constructor to another constructor (1th element) (at crates/stc_ts_file_analyzer/src/analyzer/assign/function.rs:577:30)
+  |                 [33mcontext[0m: tried to assign parameters of a function to parameters of another function (at crates/stc_ts_file_analyzer/src/analyzer/assign/function.rs:377:14)
+  |                 [33mcontext[0m: tried to assign the type of a parameter to another (at crates/stc_ts_file_analyzer/src/analyzer/assign/function.rs:776:26)
+  |                 [33mcontext[0m:
+  |                 lhs = {
+  |                     new <T#4 extends Derived2>(a: T#4#0): T;
+  |                     new <T#5 extends Base>(a: T#5#0): T;
+  |                 };
+  |                 rhs = (a: T#6#0) => T;
+  |                 lhs (normalized) = {
+  |                     new <T#4 extends Derived2>(a: T#4#0): T;
+  |                     new <T#5 extends Base>(a: T#5#0): T;
+  |                 };
+  |                 rhs (normalized) = (a: T#6#0) => T; (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:565:73)
+  |                 [33mcontext[0m: tried to assign a type to type elements (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:2351:22)
+  |                 [33mcontext[0m: tried to assign the converted type to type elements:
+  |                 RHS= (at crates/stc_ts_file_analyzer/src/analyzer/assign/type_el.rs:543:26)
+  |                 ObjectAssignFailed {
+  |                     span: Span {
+  |                         lo: BytePos(
+  |                             449,
+  |                         ),
+  |                         hi: BytePos(
+  |                             452,
+  |                         ),
+  |                         ctxt: #0,
+  |                     },
+  |                     errors: [
+  |                         [33mcontext[0m: tried assignment of a type literal to a type literals
+  |                         LHS={
+  |                             new <T#4 extends Derived2>(a: T#4#0): T;
+  |                             new <T#5 extends Base>(a: T#5#0): T;
+  |                         };
+  |                         RHS={
+  |                             (a: T#6#0) : T;
+  |                         }; (at crates/stc_ts_file_analyzer/src/analyzer/assign/type_el.rs:199:22)
+  |                         [33mcontext[0m: tried to assign to an element (not a key-based) (at crates/stc_ts_file_analyzer/src/analyzer/assign/type_el.rs:1087:18)
+  |                         [33mcontext[0m: failed to assign to a constructor (at crates/stc_ts_file_analyzer/src/analyzer/assign/type_el.rs:1565:92)
+  |                         SimpleAssignFailed {
+  |                             span: Span {
+  |                                 lo: BytePos(
+  |                                     449,
+  |                                 ),
+  |                                 hi: BytePos(
+  |                                     452,
+  |                                 ),
+  |                                 ctxt: #0,
+  |                             },
+  |                             cause: None,
+  |                         },
+  |                     ],
+  |                 },
+  |             ],
+  |         },
+  |     ],
+  | }
+    ,-[$DIR/tests/errors/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithConstructSignatures4/2.ts:19:1]
+ 19 | var b17: new <T>(x: (a: T) => T) => any[];
+ 20 | b17 = a17; // error
+    : ^^^
+    `----

--- a/crates/stc_ts_file_analyzer/tests/errors/conformance/types/typeRelationships/typeInference/genericCallWithGenericSignatureArguments/1.swc-stderr
+++ b/crates/stc_ts_file_analyzer/tests/errors/conformance/types/typeRelationships/typeInference/genericCallWithGenericSignatureArguments/1.swc-stderr
@@ -1,0 +1,132 @@
+TS2304
+
+  x NoSuchVar {
+  |     span: Span {
+  |         lo: BytePos(
+  |             117,
+  |         ),
+  |         hi: BytePos(
+  |             118,
+  |         ),
+  |         ctxt: #0,
+  |     },
+  |     name: x#1,
+  | }
+   ,-[$DIR/tests/errors/conformance/types/typeRelationships/typeInference/genericCallWithGenericSignatureArguments/1.ts:5:1]
+ 5 | 
+ 6 | var r11 = foo2(x, (a1: (y: string) => string) => (n: Object) => 1, (a2: (z: string) => string) => 2); // error
+   :                ^
+ 7 | var r12 = foo2(x, (a1: (y: string) => boolean) => (n: Object) => 1, (a2: (z: string) => boolean) => 2); // error
+   `----
+TS2345
+
+  x [33mcontext[0m: tried to validate an argument (at crates/stc_ts_file_analyzer/src/analyzer/expr/call_new.rs:3335:25)
+  | [33mcontext[0m:
+  | lhs = instanceof  (x: any) => (n: Object) => 1;
+  | rhs = (a2: (z: string) => string) => 2;
+  | lhs (normalized) = (x: any) => (n: Object) => 1;
+  | rhs (normalized) = (a2: (z: string) => string) => 2; (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:565:73)
+  | [33mcontext[0m: tried to assign to a function type:  (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:2378:77)
+  | [33mcontext[0m: tried to assign a function to another one (at crates/stc_ts_file_analyzer/src/analyzer/assign/function.rs:438:18)
+  | [33mcontext[0m: tried to assign the return type of a function to the return type of another function (at crates/stc_ts_file_analyzer/src/analyzer/assign/function.rs:394:22)
+  | [33mcontext[0m:
+  | lhs = (n: Object) => 1;
+  | rhs = 2;
+  | lhs (normalized) = (n: Object) => 1;
+  | rhs (normalized) = 2; (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:565:73)
+  | [33mcontext[0m: LHS (final): (n: Object) => 1;
+  | RHS (final): 2; (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:2539:17)
+  | WrongArgType {
+  |     span: Span {
+  |         lo: BytePos(
+  |             169,
+  |         ),
+  |         hi: BytePos(
+  |             201,
+  |         ),
+  |         ctxt: #0,
+  |     },
+  |     inner: AssignFailed {
+  |         span: Span {
+  |             lo: BytePos(
+  |                 169,
+  |             ),
+  |             hi: BytePos(
+  |                 201,
+  |             ),
+  |             ctxt: #0,
+  |         },
+  |         cause: [],
+  |     },
+  | }
+   ,-[$DIR/tests/errors/conformance/types/typeRelationships/typeInference/genericCallWithGenericSignatureArguments/1.ts:5:1]
+ 5 | 
+ 6 | var r11 = foo2(x, (a1: (y: string) => string) => (n: Object) => 1, (a2: (z: string) => string) => 2); // error
+   :                                                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+ 7 | var r12 = foo2(x, (a1: (y: string) => boolean) => (n: Object) => 1, (a2: (z: string) => boolean) => 2); // error
+   `----
+TS2304
+
+  x NoSuchVar {
+  |     span: Span {
+  |         lo: BytePos(
+  |             228,
+  |         ),
+  |         hi: BytePos(
+  |             229,
+  |         ),
+  |         ctxt: #0,
+  |     },
+  |     name: x#1,
+  | }
+   ,-[$DIR/tests/errors/conformance/types/typeRelationships/typeInference/genericCallWithGenericSignatureArguments/1.ts:6:1]
+ 6 | var r11 = foo2(x, (a1: (y: string) => string) => (n: Object) => 1, (a2: (z: string) => string) => 2); // error
+ 7 | var r12 = foo2(x, (a1: (y: string) => boolean) => (n: Object) => 1, (a2: (z: string) => boolean) => 2); // error
+   :                ^
+   `----
+TS2345
+
+  x [33mcontext[0m: tried to validate an argument (at crates/stc_ts_file_analyzer/src/analyzer/expr/call_new.rs:3335:25)
+  | [33mcontext[0m:
+  | lhs = instanceof  (x: any) => (n: Object) => 1;
+  | rhs = (a2: (z: string) => boolean) => 2;
+  | lhs (normalized) = (x: any) => (n: Object) => 1;
+  | rhs (normalized) = (a2: (z: string) => boolean) => 2; (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:565:73)
+  | [33mcontext[0m: tried to assign to a function type:  (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:2378:77)
+  | [33mcontext[0m: tried to assign a function to another one (at crates/stc_ts_file_analyzer/src/analyzer/assign/function.rs:438:18)
+  | [33mcontext[0m: tried to assign the return type of a function to the return type of another function (at crates/stc_ts_file_analyzer/src/analyzer/assign/function.rs:394:22)
+  | [33mcontext[0m:
+  | lhs = (n: Object) => 1;
+  | rhs = 2;
+  | lhs (normalized) = (n: Object) => 1;
+  | rhs (normalized) = 2; (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:565:73)
+  | [33mcontext[0m: LHS (final): (n: Object) => 1;
+  | RHS (final): 2; (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:2539:17)
+  | WrongArgType {
+  |     span: Span {
+  |         lo: BytePos(
+  |             281,
+  |         ),
+  |         hi: BytePos(
+  |             314,
+  |         ),
+  |         ctxt: #0,
+  |     },
+  |     inner: AssignFailed {
+  |         span: Span {
+  |             lo: BytePos(
+  |                 281,
+  |             ),
+  |             hi: BytePos(
+  |                 314,
+  |             ),
+  |             ctxt: #0,
+  |         },
+  |         cause: [],
+  |     },
+  | }
+   ,-[$DIR/tests/errors/conformance/types/typeRelationships/typeInference/genericCallWithGenericSignatureArguments/1.ts:6:1]
+ 6 | var r11 = foo2(x, (a1: (y: string) => string) => (n: Object) => 1, (a2: (z: string) => string) => 2); // error
+ 7 | var r12 = foo2(x, (a1: (y: string) => boolean) => (n: Object) => 1, (a2: (z: string) => boolean) => 2); // error
+   :                                                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   `----

--- a/crates/stc_ts_file_analyzer/tests/errors/conformance/types/union/withIndexSignature/1.swc-stderr
+++ b/crates/stc_ts_file_analyzer/tests/errors/conformance/types/union/withIndexSignature/1.swc-stderr
@@ -1,0 +1,25 @@
+TS2540
+
+  x [33mcontext[0m: tried to access property of an object to calculate type of a member expression (at crates/stc_ts_file_analyzer/src/analyzer/expr/mod.rs:4280:14)
+  | [33mcontext[0m: tried to access property of an object (({
+  |     foo: number;
+  | } | {
+  |     readonly [s: string]: string;
+  | });, id_ctx = Var)
+  | Prop=foo (at crates/stc_ts_file_analyzer/src/analyzer/expr/mod.rs:1347:23)
+  | ReadOnly {
+  |     span: Span {
+  |         lo: BytePos(
+  |             100,
+  |         ),
+  |         hi: BytePos(
+  |             106,
+  |         ),
+  |         ctxt: #0,
+  |     },
+  | }
+   ,-[$DIR/tests/errors/conformance/types/union/withIndexSignature/1.ts:4:1]
+ 4 | declare var ro: RO;
+ 5 | ro.foo = "not allowed";
+   : ^^^^^^
+   `----

--- a/crates/stc_ts_file_analyzer/tests/errors/conformance/types/union/withIndexSignature/2.swc-stderr
+++ b/crates/stc_ts_file_analyzer/tests/errors/conformance/types/union/withIndexSignature/2.swc-stderr
@@ -1,0 +1,20 @@
+TS2304
+
+  x NoSuchVar {
+  |     span: Span {
+  |         lo: BytePos(
+  |             61,
+  |         ),
+  |         hi: BytePos(
+  |             64,
+  |         ),
+  |         ctxt: #0,
+  |     },
+  |     name: sym#1,
+  | }
+   ,-[$DIR/tests/errors/conformance/types/union/withIndexSignature/2.ts:3:1]
+ 3 | type Both =
+ 4 |   | { s: number; "0": number; [sym]: boolean }
+   :                                ^^^
+ 5 |   | { [n: number]: number; [s: string]: string | number };
+   `----

--- a/crates/stc_ts_file_analyzer/tests/errors/conformance/types/union/withIndexSignature/3.swc-stderr
+++ b/crates/stc_ts_file_analyzer/tests/errors/conformance/types/union/withIndexSignature/3.swc-stderr
@@ -1,0 +1,20 @@
+TS2304
+
+  x NoSuchVar {
+  |     span: Span {
+  |         lo: BytePos(
+  |             44,
+  |         ),
+  |         hi: BytePos(
+  |             47,
+  |         ),
+  |         ctxt: #0,
+  |     },
+  |     name: sym#1,
+  | }
+   ,-[$DIR/tests/errors/conformance/types/union/withIndexSignature/3.ts:1:1]
+ 1 | type Both =
+ 2 |   | { s: number; "0": number; [sym]: boolean }
+   :                                ^^^
+ 3 |   | { [n: number]: number; [s: string]: string | number };
+   `----

--- a/crates/stc_ts_file_analyzer/tests/errors/issues/0xxx/415/1.swc-stderr
+++ b/crates/stc_ts_file_analyzer/tests/errors/issues/0xxx/415/1.swc-stderr
@@ -1,0 +1,290 @@
+TS2322
+
+  x [33mcontext[0m:
+  | lhs = instanceof  ((A | B) & (C | D));
+  | rhs = (A#1 & B#1);
+  | lhs (normalized) = ((A#1 | B#1) & (C#1 | D#1));
+  | rhs (normalized) = (A#1 & B#1); (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:565:73)
+  | [33mcontext[0m: tried to assign to an element of an intersection type (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:1353:26)
+  | [33mcontext[0m:
+  | lhs = (C#1 | D#1);
+  | rhs = (A#1 & B#1);
+  | lhs (normalized) = (C#1 | D#1);
+  | rhs (normalized) = (A#1 & B#1); (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:565:73)
+  | [33mcontext[0m: tried to assign a normalized intersection type to another type (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:1526:30)
+  | [33mcontext[0m:
+  | lhs = (C#1 | D#1);
+  | rhs = (A#1 & B#1);
+  | lhs (normalized) = (C#1 | D#1);
+  | rhs (normalized) = (A#1 & B#1); (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:565:73)
+  | SimpleAssignFailed {
+  |     span: Span {
+  |         lo: BytePos(
+  |             188,
+  |         ),
+  |         hi: BytePos(
+  |             189,
+  |         ),
+  |         ctxt: #1,
+  |     },
+  |     cause: Some(
+  |         AssignFailed {
+  |             span: Span {
+  |                 lo: BytePos(
+  |                     188,
+  |                 ),
+  |                 hi: BytePos(
+  |                     189,
+  |                 ),
+  |                 ctxt: #1,
+  |             },
+  |             cause: [
+  |                 [33mcontext[0m: tried to assign an element of an intersection type to another type (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:1547:26)
+  |                 [33mcontext[0m:
+  |                 lhs = (C#1 | D#1);
+  |                 rhs = A#1;
+  |                 Member as {
+  |                     a: string;
+  |                 };
+  |                 lhs (normalized) = (C#1 | D#1);
+  |                 rhs (normalized) = A#1;
+  |                 Member as {
+  |                     a: string;
+  |                 }; (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:565:73)
+  |                 [33mcontext[0m: tried to assign a type to a union type (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:1962:67)
+  |                 Errors {
+  |                     span: Span {
+  |                         lo: BytePos(
+  |                             188,
+  |                         ),
+  |                         hi: BytePos(
+  |                             189,
+  |                         ),
+  |                         ctxt: #1,
+  |                     },
+  |                     errors: [
+  |                         [33mcontext[0m: tried to assign a type to a union (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:1925:26)
+  |                         [33mcontext[0m:
+  |                         lhs = C#1;
+  |                         Member as {
+  |                             c: string;
+  |                         };
+  |                         rhs = A#1;
+  |                         Member as {
+  |                             a: string;
+  |                         };
+  |                         lhs (normalized) = C#1;
+  |                         Member as {
+  |                             c: string;
+  |                         };
+  |                         rhs (normalized) = A#1;
+  |                         Member as {
+  |                             a: string;
+  |                         }; (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:565:73)
+  |                         [33mcontext[0m: tried to assign a type to an interface (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:2232:18)
+  |                         [33mcontext[0m: tried to assign to type elements by converting rhs to a type literal (at crates/stc_ts_file_analyzer/src/analyzer/assign/type_el.rs:255:30)
+  |                         Errors {
+  |                             span: Span {
+  |                                 lo: BytePos(
+  |                                     188,
+  |                                 ),
+  |                                 hi: BytePos(
+  |                                     189,
+  |                                 ),
+  |                                 ctxt: #0,
+  |                             },
+  |                             errors: [
+  |                                 MissingFields {
+  |                                     span: Span {
+  |                                         lo: BytePos(
+  |                                             188,
+  |                                         ),
+  |                                         hi: BytePos(
+  |                                             189,
+  |                                         ),
+  |                                         ctxt: #0,
+  |                                     },
+  |                                     fields: [
+  |                                         c: Keyword(string),
+  |                                     ],
+  |                                 },
+  |                             ],
+  |                         },
+  |                         [33mcontext[0m: tried to assign a type to a union (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:1925:26)
+  |                         [33mcontext[0m:
+  |                         lhs = D#1;
+  |                         Member as {
+  |                             d: string;
+  |                         };
+  |                         rhs = A#1;
+  |                         Member as {
+  |                             a: string;
+  |                         };
+  |                         lhs (normalized) = D#1;
+  |                         Member as {
+  |                             d: string;
+  |                         };
+  |                         rhs (normalized) = A#1;
+  |                         Member as {
+  |                             a: string;
+  |                         }; (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:565:73)
+  |                         [33mcontext[0m: tried to assign a type to an interface (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:2232:18)
+  |                         [33mcontext[0m: tried to assign to type elements by converting rhs to a type literal (at crates/stc_ts_file_analyzer/src/analyzer/assign/type_el.rs:255:30)
+  |                         Errors {
+  |                             span: Span {
+  |                                 lo: BytePos(
+  |                                     188,
+  |                                 ),
+  |                                 hi: BytePos(
+  |                                     189,
+  |                                 ),
+  |                                 ctxt: #0,
+  |                             },
+  |                             errors: [
+  |                                 MissingFields {
+  |                                     span: Span {
+  |                                         lo: BytePos(
+  |                                             188,
+  |                                         ),
+  |                                         hi: BytePos(
+  |                                             189,
+  |                                         ),
+  |                                         ctxt: #0,
+  |                                     },
+  |                                     fields: [
+  |                                         d: Keyword(string),
+  |                                     ],
+  |                                 },
+  |                             ],
+  |                         },
+  |                     ],
+  |                 },
+  |                 [33mcontext[0m: tried to assign an element of an intersection type to another type (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:1547:26)
+  |                 [33mcontext[0m:
+  |                 lhs = (C#1 | D#1);
+  |                 rhs = B#1;
+  |                 Member as {
+  |                     b: string;
+  |                 };
+  |                 lhs (normalized) = (C#1 | D#1);
+  |                 rhs (normalized) = B#1;
+  |                 Member as {
+  |                     b: string;
+  |                 }; (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:565:73)
+  |                 [33mcontext[0m: tried to assign a type to a union type (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:1962:67)
+  |                 Errors {
+  |                     span: Span {
+  |                         lo: BytePos(
+  |                             188,
+  |                         ),
+  |                         hi: BytePos(
+  |                             189,
+  |                         ),
+  |                         ctxt: #1,
+  |                     },
+  |                     errors: [
+  |                         [33mcontext[0m: tried to assign a type to a union (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:1925:26)
+  |                         [33mcontext[0m:
+  |                         lhs = C#1;
+  |                         Member as {
+  |                             c: string;
+  |                         };
+  |                         rhs = B#1;
+  |                         Member as {
+  |                             b: string;
+  |                         };
+  |                         lhs (normalized) = C#1;
+  |                         Member as {
+  |                             c: string;
+  |                         };
+  |                         rhs (normalized) = B#1;
+  |                         Member as {
+  |                             b: string;
+  |                         }; (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:565:73)
+  |                         [33mcontext[0m: tried to assign a type to an interface (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:2232:18)
+  |                         [33mcontext[0m: tried to assign to type elements by converting rhs to a type literal (at crates/stc_ts_file_analyzer/src/analyzer/assign/type_el.rs:255:30)
+  |                         Errors {
+  |                             span: Span {
+  |                                 lo: BytePos(
+  |                                     188,
+  |                                 ),
+  |                                 hi: BytePos(
+  |                                     189,
+  |                                 ),
+  |                                 ctxt: #0,
+  |                             },
+  |                             errors: [
+  |                                 MissingFields {
+  |                                     span: Span {
+  |                                         lo: BytePos(
+  |                                             188,
+  |                                         ),
+  |                                         hi: BytePos(
+  |                                             189,
+  |                                         ),
+  |                                         ctxt: #0,
+  |                                     },
+  |                                     fields: [
+  |                                         c: Keyword(string),
+  |                                     ],
+  |                                 },
+  |                             ],
+  |                         },
+  |                         [33mcontext[0m: tried to assign a type to a union (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:1925:26)
+  |                         [33mcontext[0m:
+  |                         lhs = D#1;
+  |                         Member as {
+  |                             d: string;
+  |                         };
+  |                         rhs = B#1;
+  |                         Member as {
+  |                             b: string;
+  |                         };
+  |                         lhs (normalized) = D#1;
+  |                         Member as {
+  |                             d: string;
+  |                         };
+  |                         rhs (normalized) = B#1;
+  |                         Member as {
+  |                             b: string;
+  |                         }; (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:565:73)
+  |                         [33mcontext[0m: tried to assign a type to an interface (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:2232:18)
+  |                         [33mcontext[0m: tried to assign to type elements by converting rhs to a type literal (at crates/stc_ts_file_analyzer/src/analyzer/assign/type_el.rs:255:30)
+  |                         Errors {
+  |                             span: Span {
+  |                                 lo: BytePos(
+  |                                     188,
+  |                                 ),
+  |                                 hi: BytePos(
+  |                                     189,
+  |                                 ),
+  |                                 ctxt: #0,
+  |                             },
+  |                             errors: [
+  |                                 MissingFields {
+  |                                     span: Span {
+  |                                         lo: BytePos(
+  |                                             188,
+  |                                         ),
+  |                                         hi: BytePos(
+  |                                             189,
+  |                                         ),
+  |                                         ctxt: #0,
+  |                                     },
+  |                                     fields: [
+  |                                         d: Keyword(string),
+  |                                     ],
+  |                                 },
+  |                             ],
+  |                         },
+  |                     ],
+  |                 },
+  |             ],
+  |         },
+  |     ),
+  | }
+    ,-[$DIR/tests/errors/issues/0xxx/415/1.ts:18:1]
+ 18 | 
+ 19 | y = anb;
+    : ^
+    `----

--- a/crates/stc_ts_file_analyzer/tests/errors/issues/0xxx/415/2.swc-stderr
+++ b/crates/stc_ts_file_analyzer/tests/errors/issues/0xxx/415/2.swc-stderr
@@ -1,0 +1,290 @@
+TS2322
+
+  x [33mcontext[0m:
+  | lhs = instanceof  ((A | B) & (C | D));
+  | rhs = (C#1 & D#1);
+  | lhs (normalized) = ((A#1 | B#1) & (C#1 | D#1));
+  | rhs (normalized) = (C#1 & D#1); (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:565:73)
+  | [33mcontext[0m: tried to assign to an element of an intersection type (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:1353:26)
+  | [33mcontext[0m:
+  | lhs = (A#1 | B#1);
+  | rhs = (C#1 & D#1);
+  | lhs (normalized) = (A#1 | B#1);
+  | rhs (normalized) = (C#1 & D#1); (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:565:73)
+  | [33mcontext[0m: tried to assign a normalized intersection type to another type (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:1526:30)
+  | [33mcontext[0m:
+  | lhs = (A#1 | B#1);
+  | rhs = (C#1 & D#1);
+  | lhs (normalized) = (A#1 | B#1);
+  | rhs (normalized) = (C#1 & D#1); (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:565:73)
+  | SimpleAssignFailed {
+  |     span: Span {
+  |         lo: BytePos(
+  |             188,
+  |         ),
+  |         hi: BytePos(
+  |             189,
+  |         ),
+  |         ctxt: #1,
+  |     },
+  |     cause: Some(
+  |         AssignFailed {
+  |             span: Span {
+  |                 lo: BytePos(
+  |                     188,
+  |                 ),
+  |                 hi: BytePos(
+  |                     189,
+  |                 ),
+  |                 ctxt: #1,
+  |             },
+  |             cause: [
+  |                 [33mcontext[0m: tried to assign an element of an intersection type to another type (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:1547:26)
+  |                 [33mcontext[0m:
+  |                 lhs = (A#1 | B#1);
+  |                 rhs = C#1;
+  |                 Member as {
+  |                     c: string;
+  |                 };
+  |                 lhs (normalized) = (A#1 | B#1);
+  |                 rhs (normalized) = C#1;
+  |                 Member as {
+  |                     c: string;
+  |                 }; (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:565:73)
+  |                 [33mcontext[0m: tried to assign a type to a union type (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:1962:67)
+  |                 Errors {
+  |                     span: Span {
+  |                         lo: BytePos(
+  |                             188,
+  |                         ),
+  |                         hi: BytePos(
+  |                             189,
+  |                         ),
+  |                         ctxt: #1,
+  |                     },
+  |                     errors: [
+  |                         [33mcontext[0m: tried to assign a type to a union (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:1925:26)
+  |                         [33mcontext[0m:
+  |                         lhs = A#1;
+  |                         Member as {
+  |                             a: string;
+  |                         };
+  |                         rhs = C#1;
+  |                         Member as {
+  |                             c: string;
+  |                         };
+  |                         lhs (normalized) = A#1;
+  |                         Member as {
+  |                             a: string;
+  |                         };
+  |                         rhs (normalized) = C#1;
+  |                         Member as {
+  |                             c: string;
+  |                         }; (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:565:73)
+  |                         [33mcontext[0m: tried to assign a type to an interface (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:2232:18)
+  |                         [33mcontext[0m: tried to assign to type elements by converting rhs to a type literal (at crates/stc_ts_file_analyzer/src/analyzer/assign/type_el.rs:255:30)
+  |                         Errors {
+  |                             span: Span {
+  |                                 lo: BytePos(
+  |                                     188,
+  |                                 ),
+  |                                 hi: BytePos(
+  |                                     189,
+  |                                 ),
+  |                                 ctxt: #0,
+  |                             },
+  |                             errors: [
+  |                                 MissingFields {
+  |                                     span: Span {
+  |                                         lo: BytePos(
+  |                                             188,
+  |                                         ),
+  |                                         hi: BytePos(
+  |                                             189,
+  |                                         ),
+  |                                         ctxt: #0,
+  |                                     },
+  |                                     fields: [
+  |                                         a: Keyword(string),
+  |                                     ],
+  |                                 },
+  |                             ],
+  |                         },
+  |                         [33mcontext[0m: tried to assign a type to a union (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:1925:26)
+  |                         [33mcontext[0m:
+  |                         lhs = B#1;
+  |                         Member as {
+  |                             b: string;
+  |                         };
+  |                         rhs = C#1;
+  |                         Member as {
+  |                             c: string;
+  |                         };
+  |                         lhs (normalized) = B#1;
+  |                         Member as {
+  |                             b: string;
+  |                         };
+  |                         rhs (normalized) = C#1;
+  |                         Member as {
+  |                             c: string;
+  |                         }; (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:565:73)
+  |                         [33mcontext[0m: tried to assign a type to an interface (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:2232:18)
+  |                         [33mcontext[0m: tried to assign to type elements by converting rhs to a type literal (at crates/stc_ts_file_analyzer/src/analyzer/assign/type_el.rs:255:30)
+  |                         Errors {
+  |                             span: Span {
+  |                                 lo: BytePos(
+  |                                     188,
+  |                                 ),
+  |                                 hi: BytePos(
+  |                                     189,
+  |                                 ),
+  |                                 ctxt: #0,
+  |                             },
+  |                             errors: [
+  |                                 MissingFields {
+  |                                     span: Span {
+  |                                         lo: BytePos(
+  |                                             188,
+  |                                         ),
+  |                                         hi: BytePos(
+  |                                             189,
+  |                                         ),
+  |                                         ctxt: #0,
+  |                                     },
+  |                                     fields: [
+  |                                         b: Keyword(string),
+  |                                     ],
+  |                                 },
+  |                             ],
+  |                         },
+  |                     ],
+  |                 },
+  |                 [33mcontext[0m: tried to assign an element of an intersection type to another type (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:1547:26)
+  |                 [33mcontext[0m:
+  |                 lhs = (A#1 | B#1);
+  |                 rhs = D#1;
+  |                 Member as {
+  |                     d: string;
+  |                 };
+  |                 lhs (normalized) = (A#1 | B#1);
+  |                 rhs (normalized) = D#1;
+  |                 Member as {
+  |                     d: string;
+  |                 }; (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:565:73)
+  |                 [33mcontext[0m: tried to assign a type to a union type (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:1962:67)
+  |                 Errors {
+  |                     span: Span {
+  |                         lo: BytePos(
+  |                             188,
+  |                         ),
+  |                         hi: BytePos(
+  |                             189,
+  |                         ),
+  |                         ctxt: #1,
+  |                     },
+  |                     errors: [
+  |                         [33mcontext[0m: tried to assign a type to a union (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:1925:26)
+  |                         [33mcontext[0m:
+  |                         lhs = A#1;
+  |                         Member as {
+  |                             a: string;
+  |                         };
+  |                         rhs = D#1;
+  |                         Member as {
+  |                             d: string;
+  |                         };
+  |                         lhs (normalized) = A#1;
+  |                         Member as {
+  |                             a: string;
+  |                         };
+  |                         rhs (normalized) = D#1;
+  |                         Member as {
+  |                             d: string;
+  |                         }; (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:565:73)
+  |                         [33mcontext[0m: tried to assign a type to an interface (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:2232:18)
+  |                         [33mcontext[0m: tried to assign to type elements by converting rhs to a type literal (at crates/stc_ts_file_analyzer/src/analyzer/assign/type_el.rs:255:30)
+  |                         Errors {
+  |                             span: Span {
+  |                                 lo: BytePos(
+  |                                     188,
+  |                                 ),
+  |                                 hi: BytePos(
+  |                                     189,
+  |                                 ),
+  |                                 ctxt: #0,
+  |                             },
+  |                             errors: [
+  |                                 MissingFields {
+  |                                     span: Span {
+  |                                         lo: BytePos(
+  |                                             188,
+  |                                         ),
+  |                                         hi: BytePos(
+  |                                             189,
+  |                                         ),
+  |                                         ctxt: #0,
+  |                                     },
+  |                                     fields: [
+  |                                         a: Keyword(string),
+  |                                     ],
+  |                                 },
+  |                             ],
+  |                         },
+  |                         [33mcontext[0m: tried to assign a type to a union (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:1925:26)
+  |                         [33mcontext[0m:
+  |                         lhs = B#1;
+  |                         Member as {
+  |                             b: string;
+  |                         };
+  |                         rhs = D#1;
+  |                         Member as {
+  |                             d: string;
+  |                         };
+  |                         lhs (normalized) = B#1;
+  |                         Member as {
+  |                             b: string;
+  |                         };
+  |                         rhs (normalized) = D#1;
+  |                         Member as {
+  |                             d: string;
+  |                         }; (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:565:73)
+  |                         [33mcontext[0m: tried to assign a type to an interface (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:2232:18)
+  |                         [33mcontext[0m: tried to assign to type elements by converting rhs to a type literal (at crates/stc_ts_file_analyzer/src/analyzer/assign/type_el.rs:255:30)
+  |                         Errors {
+  |                             span: Span {
+  |                                 lo: BytePos(
+  |                                     188,
+  |                                 ),
+  |                                 hi: BytePos(
+  |                                     189,
+  |                                 ),
+  |                                 ctxt: #0,
+  |                             },
+  |                             errors: [
+  |                                 MissingFields {
+  |                                     span: Span {
+  |                                         lo: BytePos(
+  |                                             188,
+  |                                         ),
+  |                                         hi: BytePos(
+  |                                             189,
+  |                                         ),
+  |                                         ctxt: #0,
+  |                                     },
+  |                                     fields: [
+  |                                         b: Keyword(string),
+  |                                     ],
+  |                                 },
+  |                             ],
+  |                         },
+  |                     ],
+  |                 },
+  |             ],
+  |         },
+  |     ),
+  | }
+    ,-[$DIR/tests/errors/issues/0xxx/415/2.ts:18:1]
+ 18 | 
+ 19 | y = cnd;
+    : ^
+    `----

--- a/crates/stc_ts_file_analyzer/tests/errors/issues/0xxx/415/3.swc-stderr
+++ b/crates/stc_ts_file_analyzer/tests/errors/issues/0xxx/415/3.swc-stderr
@@ -1,0 +1,329 @@
+TS2322
+
+  x [33mcontext[0m:
+  | lhs = instanceof  (C | D);
+  | rhs = ((A#1 & B#1) | (C#1 & D#1));
+  | lhs (normalized) = (C#1 | D#1);
+  | rhs (normalized) = ((A#1 & B#1) | (C#1 & D#1)); (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:565:73)
+  | [33mcontext[0m: tried to assign an union type to another one (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:1613:26)
+  | [33mcontext[0m:
+  | lhs = (C#1 | D#1);
+  | rhs = (A#1 & B#1);
+  | lhs (normalized) = (C#1 | D#1);
+  | rhs (normalized) = (A#1 & B#1); (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:565:73)
+  | [33mcontext[0m: tried to assign a normalized intersection type to another type (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:1526:30)
+  | [33mcontext[0m:
+  | lhs = (C#1 | D#1);
+  | rhs = (A#1 & B#1);
+  | lhs (normalized) = (C#1 | D#1);
+  | rhs (normalized) = (A#1 & B#1); (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:565:73)
+  | AssignFailed {
+  |     span: Span {
+  |         lo: BytePos(
+  |             188,
+  |         ),
+  |         hi: BytePos(
+  |             191,
+  |         ),
+  |         ctxt: #1,
+  |     },
+  |     cause: [
+  |         [33mcontext[0m: tried to assign an element of an intersection type to another type (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:1547:26)
+  |         [33mcontext[0m:
+  |         lhs = (C#1 | D#1);
+  |         rhs = A#1;
+  |         Member as {
+  |             a: string;
+  |         };
+  |         lhs (normalized) = (C#1 | D#1);
+  |         rhs (normalized) = A#1;
+  |         Member as {
+  |             a: string;
+  |         }; (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:565:73)
+  |         [33mcontext[0m: tried to assign a type to a union type (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:1962:67)
+  |         Errors {
+  |             span: Span {
+  |                 lo: BytePos(
+  |                     188,
+  |                 ),
+  |                 hi: BytePos(
+  |                     191,
+  |                 ),
+  |                 ctxt: #1,
+  |             },
+  |             errors: [
+  |                 [33mcontext[0m: tried to assign a type to a union (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:1925:26)
+  |                 [33mcontext[0m:
+  |                 lhs = C#1;
+  |                 Member as {
+  |                     c: string;
+  |                 };
+  |                 rhs = A#1;
+  |                 Member as {
+  |                     a: string;
+  |                 };
+  |                 lhs (normalized) = C#1;
+  |                 Member as {
+  |                     c: string;
+  |                 };
+  |                 rhs (normalized) = A#1;
+  |                 Member as {
+  |                     a: string;
+  |                 }; (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:565:73)
+  |                 [33mcontext[0m: tried to assign a type to an interface (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:2232:18)
+  |                 [33mcontext[0m: tried to assign to type elements by converting rhs to a type literal (at crates/stc_ts_file_analyzer/src/analyzer/assign/type_el.rs:255:30)
+  |                 Errors {
+  |                     span: Span {
+  |                         lo: BytePos(
+  |                             188,
+  |                         ),
+  |                         hi: BytePos(
+  |                             191,
+  |                         ),
+  |                         ctxt: #0,
+  |                     },
+  |                     errors: [
+  |                         ObjectAssignFailed {
+  |                             span: Span {
+  |                                 lo: BytePos(
+  |                                     188,
+  |                                 ),
+  |                                 hi: BytePos(
+  |                                     191,
+  |                                 ),
+  |                                 ctxt: #0,
+  |                             },
+  |                             errors: [
+  |                                 MissingFields {
+  |                                     span: Span {
+  |                                         lo: BytePos(
+  |                                             188,
+  |                                         ),
+  |                                         hi: BytePos(
+  |                                             191,
+  |                                         ),
+  |                                         ctxt: #0,
+  |                                     },
+  |                                     fields: [
+  |                                         c: Keyword(string),
+  |                                     ],
+  |                                 },
+  |                             ],
+  |                         },
+  |                     ],
+  |                 },
+  |                 [33mcontext[0m: tried to assign a type to a union (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:1925:26)
+  |                 [33mcontext[0m:
+  |                 lhs = D#1;
+  |                 Member as {
+  |                     d: string;
+  |                 };
+  |                 rhs = A#1;
+  |                 Member as {
+  |                     a: string;
+  |                 };
+  |                 lhs (normalized) = D#1;
+  |                 Member as {
+  |                     d: string;
+  |                 };
+  |                 rhs (normalized) = A#1;
+  |                 Member as {
+  |                     a: string;
+  |                 }; (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:565:73)
+  |                 [33mcontext[0m: tried to assign a type to an interface (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:2232:18)
+  |                 [33mcontext[0m: tried to assign to type elements by converting rhs to a type literal (at crates/stc_ts_file_analyzer/src/analyzer/assign/type_el.rs:255:30)
+  |                 Errors {
+  |                     span: Span {
+  |                         lo: BytePos(
+  |                             188,
+  |                         ),
+  |                         hi: BytePos(
+  |                             191,
+  |                         ),
+  |                         ctxt: #0,
+  |                     },
+  |                     errors: [
+  |                         ObjectAssignFailed {
+  |                             span: Span {
+  |                                 lo: BytePos(
+  |                                     188,
+  |                                 ),
+  |                                 hi: BytePos(
+  |                                     191,
+  |                                 ),
+  |                                 ctxt: #0,
+  |                             },
+  |                             errors: [
+  |                                 MissingFields {
+  |                                     span: Span {
+  |                                         lo: BytePos(
+  |                                             188,
+  |                                         ),
+  |                                         hi: BytePos(
+  |                                             191,
+  |                                         ),
+  |                                         ctxt: #0,
+  |                                     },
+  |                                     fields: [
+  |                                         d: Keyword(string),
+  |                                     ],
+  |                                 },
+  |                             ],
+  |                         },
+  |                     ],
+  |                 },
+  |             ],
+  |         },
+  |         [33mcontext[0m: tried to assign an element of an intersection type to another type (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:1547:26)
+  |         [33mcontext[0m:
+  |         lhs = (C#1 | D#1);
+  |         rhs = B#1;
+  |         Member as {
+  |             b: string;
+  |         };
+  |         lhs (normalized) = (C#1 | D#1);
+  |         rhs (normalized) = B#1;
+  |         Member as {
+  |             b: string;
+  |         }; (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:565:73)
+  |         [33mcontext[0m: tried to assign a type to a union type (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:1962:67)
+  |         Errors {
+  |             span: Span {
+  |                 lo: BytePos(
+  |                     188,
+  |                 ),
+  |                 hi: BytePos(
+  |                     191,
+  |                 ),
+  |                 ctxt: #1,
+  |             },
+  |             errors: [
+  |                 [33mcontext[0m: tried to assign a type to a union (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:1925:26)
+  |                 [33mcontext[0m:
+  |                 lhs = C#1;
+  |                 Member as {
+  |                     c: string;
+  |                 };
+  |                 rhs = B#1;
+  |                 Member as {
+  |                     b: string;
+  |                 };
+  |                 lhs (normalized) = C#1;
+  |                 Member as {
+  |                     c: string;
+  |                 };
+  |                 rhs (normalized) = B#1;
+  |                 Member as {
+  |                     b: string;
+  |                 }; (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:565:73)
+  |                 [33mcontext[0m: tried to assign a type to an interface (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:2232:18)
+  |                 [33mcontext[0m: tried to assign to type elements by converting rhs to a type literal (at crates/stc_ts_file_analyzer/src/analyzer/assign/type_el.rs:255:30)
+  |                 Errors {
+  |                     span: Span {
+  |                         lo: BytePos(
+  |                             188,
+  |                         ),
+  |                         hi: BytePos(
+  |                             191,
+  |                         ),
+  |                         ctxt: #0,
+  |                     },
+  |                     errors: [
+  |                         ObjectAssignFailed {
+  |                             span: Span {
+  |                                 lo: BytePos(
+  |                                     188,
+  |                                 ),
+  |                                 hi: BytePos(
+  |                                     191,
+  |                                 ),
+  |                                 ctxt: #0,
+  |                             },
+  |                             errors: [
+  |                                 MissingFields {
+  |                                     span: Span {
+  |                                         lo: BytePos(
+  |                                             188,
+  |                                         ),
+  |                                         hi: BytePos(
+  |                                             191,
+  |                                         ),
+  |                                         ctxt: #0,
+  |                                     },
+  |                                     fields: [
+  |                                         c: Keyword(string),
+  |                                     ],
+  |                                 },
+  |                             ],
+  |                         },
+  |                     ],
+  |                 },
+  |                 [33mcontext[0m: tried to assign a type to a union (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:1925:26)
+  |                 [33mcontext[0m:
+  |                 lhs = D#1;
+  |                 Member as {
+  |                     d: string;
+  |                 };
+  |                 rhs = B#1;
+  |                 Member as {
+  |                     b: string;
+  |                 };
+  |                 lhs (normalized) = D#1;
+  |                 Member as {
+  |                     d: string;
+  |                 };
+  |                 rhs (normalized) = B#1;
+  |                 Member as {
+  |                     b: string;
+  |                 }; (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:565:73)
+  |                 [33mcontext[0m: tried to assign a type to an interface (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:2232:18)
+  |                 [33mcontext[0m: tried to assign to type elements by converting rhs to a type literal (at crates/stc_ts_file_analyzer/src/analyzer/assign/type_el.rs:255:30)
+  |                 Errors {
+  |                     span: Span {
+  |                         lo: BytePos(
+  |                             188,
+  |                         ),
+  |                         hi: BytePos(
+  |                             191,
+  |                         ),
+  |                         ctxt: #0,
+  |                     },
+  |                     errors: [
+  |                         ObjectAssignFailed {
+  |                             span: Span {
+  |                                 lo: BytePos(
+  |                                     188,
+  |                                 ),
+  |                                 hi: BytePos(
+  |                                     191,
+  |                                 ),
+  |                                 ctxt: #0,
+  |                             },
+  |                             errors: [
+  |                                 MissingFields {
+  |                                     span: Span {
+  |                                         lo: BytePos(
+  |                                             188,
+  |                                         ),
+  |                                         hi: BytePos(
+  |                                             191,
+  |                                         ),
+  |                                         ctxt: #0,
+  |                                     },
+  |                                     fields: [
+  |                                         d: Keyword(string),
+  |                                     ],
+  |                                 },
+  |                             ],
+  |                         },
+  |                     ],
+  |                 },
+  |             ],
+  |         },
+  |     ],
+  | }
+    ,-[$DIR/tests/errors/issues/0xxx/415/3.ts:18:1]
+ 18 | 
+ 19 | cod = x;
+    : ^^^
+    `----

--- a/crates/stc_ts_file_analyzer/tests/errors/issues/0xxx/415/4.swc-stderr
+++ b/crates/stc_ts_file_analyzer/tests/errors/issues/0xxx/415/4.swc-stderr
@@ -1,0 +1,329 @@
+TS2322
+
+  x [33mcontext[0m:
+  | lhs = instanceof  (A | B);
+  | rhs = ((A#1 & B#1) | (C#1 & D#1));
+  | lhs (normalized) = (A#1 | B#1);
+  | rhs (normalized) = ((A#1 & B#1) | (C#1 & D#1)); (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:565:73)
+  | [33mcontext[0m: tried to assign an union type to another one (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:1613:26)
+  | [33mcontext[0m:
+  | lhs = (A#1 | B#1);
+  | rhs = (C#1 & D#1);
+  | lhs (normalized) = (A#1 | B#1);
+  | rhs (normalized) = (C#1 & D#1); (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:565:73)
+  | [33mcontext[0m: tried to assign a normalized intersection type to another type (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:1526:30)
+  | [33mcontext[0m:
+  | lhs = (A#1 | B#1);
+  | rhs = (C#1 & D#1);
+  | lhs (normalized) = (A#1 | B#1);
+  | rhs (normalized) = (C#1 & D#1); (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:565:73)
+  | AssignFailed {
+  |     span: Span {
+  |         lo: BytePos(
+  |             188,
+  |         ),
+  |         hi: BytePos(
+  |             191,
+  |         ),
+  |         ctxt: #1,
+  |     },
+  |     cause: [
+  |         [33mcontext[0m: tried to assign an element of an intersection type to another type (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:1547:26)
+  |         [33mcontext[0m:
+  |         lhs = (A#1 | B#1);
+  |         rhs = C#1;
+  |         Member as {
+  |             c: string;
+  |         };
+  |         lhs (normalized) = (A#1 | B#1);
+  |         rhs (normalized) = C#1;
+  |         Member as {
+  |             c: string;
+  |         }; (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:565:73)
+  |         [33mcontext[0m: tried to assign a type to a union type (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:1962:67)
+  |         Errors {
+  |             span: Span {
+  |                 lo: BytePos(
+  |                     188,
+  |                 ),
+  |                 hi: BytePos(
+  |                     191,
+  |                 ),
+  |                 ctxt: #1,
+  |             },
+  |             errors: [
+  |                 [33mcontext[0m: tried to assign a type to a union (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:1925:26)
+  |                 [33mcontext[0m:
+  |                 lhs = A#1;
+  |                 Member as {
+  |                     a: string;
+  |                 };
+  |                 rhs = C#1;
+  |                 Member as {
+  |                     c: string;
+  |                 };
+  |                 lhs (normalized) = A#1;
+  |                 Member as {
+  |                     a: string;
+  |                 };
+  |                 rhs (normalized) = C#1;
+  |                 Member as {
+  |                     c: string;
+  |                 }; (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:565:73)
+  |                 [33mcontext[0m: tried to assign a type to an interface (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:2232:18)
+  |                 [33mcontext[0m: tried to assign to type elements by converting rhs to a type literal (at crates/stc_ts_file_analyzer/src/analyzer/assign/type_el.rs:255:30)
+  |                 Errors {
+  |                     span: Span {
+  |                         lo: BytePos(
+  |                             188,
+  |                         ),
+  |                         hi: BytePos(
+  |                             191,
+  |                         ),
+  |                         ctxt: #0,
+  |                     },
+  |                     errors: [
+  |                         ObjectAssignFailed {
+  |                             span: Span {
+  |                                 lo: BytePos(
+  |                                     188,
+  |                                 ),
+  |                                 hi: BytePos(
+  |                                     191,
+  |                                 ),
+  |                                 ctxt: #0,
+  |                             },
+  |                             errors: [
+  |                                 MissingFields {
+  |                                     span: Span {
+  |                                         lo: BytePos(
+  |                                             188,
+  |                                         ),
+  |                                         hi: BytePos(
+  |                                             191,
+  |                                         ),
+  |                                         ctxt: #0,
+  |                                     },
+  |                                     fields: [
+  |                                         a: Keyword(string),
+  |                                     ],
+  |                                 },
+  |                             ],
+  |                         },
+  |                     ],
+  |                 },
+  |                 [33mcontext[0m: tried to assign a type to a union (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:1925:26)
+  |                 [33mcontext[0m:
+  |                 lhs = B#1;
+  |                 Member as {
+  |                     b: string;
+  |                 };
+  |                 rhs = C#1;
+  |                 Member as {
+  |                     c: string;
+  |                 };
+  |                 lhs (normalized) = B#1;
+  |                 Member as {
+  |                     b: string;
+  |                 };
+  |                 rhs (normalized) = C#1;
+  |                 Member as {
+  |                     c: string;
+  |                 }; (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:565:73)
+  |                 [33mcontext[0m: tried to assign a type to an interface (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:2232:18)
+  |                 [33mcontext[0m: tried to assign to type elements by converting rhs to a type literal (at crates/stc_ts_file_analyzer/src/analyzer/assign/type_el.rs:255:30)
+  |                 Errors {
+  |                     span: Span {
+  |                         lo: BytePos(
+  |                             188,
+  |                         ),
+  |                         hi: BytePos(
+  |                             191,
+  |                         ),
+  |                         ctxt: #0,
+  |                     },
+  |                     errors: [
+  |                         ObjectAssignFailed {
+  |                             span: Span {
+  |                                 lo: BytePos(
+  |                                     188,
+  |                                 ),
+  |                                 hi: BytePos(
+  |                                     191,
+  |                                 ),
+  |                                 ctxt: #0,
+  |                             },
+  |                             errors: [
+  |                                 MissingFields {
+  |                                     span: Span {
+  |                                         lo: BytePos(
+  |                                             188,
+  |                                         ),
+  |                                         hi: BytePos(
+  |                                             191,
+  |                                         ),
+  |                                         ctxt: #0,
+  |                                     },
+  |                                     fields: [
+  |                                         b: Keyword(string),
+  |                                     ],
+  |                                 },
+  |                             ],
+  |                         },
+  |                     ],
+  |                 },
+  |             ],
+  |         },
+  |         [33mcontext[0m: tried to assign an element of an intersection type to another type (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:1547:26)
+  |         [33mcontext[0m:
+  |         lhs = (A#1 | B#1);
+  |         rhs = D#1;
+  |         Member as {
+  |             d: string;
+  |         };
+  |         lhs (normalized) = (A#1 | B#1);
+  |         rhs (normalized) = D#1;
+  |         Member as {
+  |             d: string;
+  |         }; (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:565:73)
+  |         [33mcontext[0m: tried to assign a type to a union type (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:1962:67)
+  |         Errors {
+  |             span: Span {
+  |                 lo: BytePos(
+  |                     188,
+  |                 ),
+  |                 hi: BytePos(
+  |                     191,
+  |                 ),
+  |                 ctxt: #1,
+  |             },
+  |             errors: [
+  |                 [33mcontext[0m: tried to assign a type to a union (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:1925:26)
+  |                 [33mcontext[0m:
+  |                 lhs = A#1;
+  |                 Member as {
+  |                     a: string;
+  |                 };
+  |                 rhs = D#1;
+  |                 Member as {
+  |                     d: string;
+  |                 };
+  |                 lhs (normalized) = A#1;
+  |                 Member as {
+  |                     a: string;
+  |                 };
+  |                 rhs (normalized) = D#1;
+  |                 Member as {
+  |                     d: string;
+  |                 }; (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:565:73)
+  |                 [33mcontext[0m: tried to assign a type to an interface (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:2232:18)
+  |                 [33mcontext[0m: tried to assign to type elements by converting rhs to a type literal (at crates/stc_ts_file_analyzer/src/analyzer/assign/type_el.rs:255:30)
+  |                 Errors {
+  |                     span: Span {
+  |                         lo: BytePos(
+  |                             188,
+  |                         ),
+  |                         hi: BytePos(
+  |                             191,
+  |                         ),
+  |                         ctxt: #0,
+  |                     },
+  |                     errors: [
+  |                         ObjectAssignFailed {
+  |                             span: Span {
+  |                                 lo: BytePos(
+  |                                     188,
+  |                                 ),
+  |                                 hi: BytePos(
+  |                                     191,
+  |                                 ),
+  |                                 ctxt: #0,
+  |                             },
+  |                             errors: [
+  |                                 MissingFields {
+  |                                     span: Span {
+  |                                         lo: BytePos(
+  |                                             188,
+  |                                         ),
+  |                                         hi: BytePos(
+  |                                             191,
+  |                                         ),
+  |                                         ctxt: #0,
+  |                                     },
+  |                                     fields: [
+  |                                         a: Keyword(string),
+  |                                     ],
+  |                                 },
+  |                             ],
+  |                         },
+  |                     ],
+  |                 },
+  |                 [33mcontext[0m: tried to assign a type to a union (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:1925:26)
+  |                 [33mcontext[0m:
+  |                 lhs = B#1;
+  |                 Member as {
+  |                     b: string;
+  |                 };
+  |                 rhs = D#1;
+  |                 Member as {
+  |                     d: string;
+  |                 };
+  |                 lhs (normalized) = B#1;
+  |                 Member as {
+  |                     b: string;
+  |                 };
+  |                 rhs (normalized) = D#1;
+  |                 Member as {
+  |                     d: string;
+  |                 }; (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:565:73)
+  |                 [33mcontext[0m: tried to assign a type to an interface (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:2232:18)
+  |                 [33mcontext[0m: tried to assign to type elements by converting rhs to a type literal (at crates/stc_ts_file_analyzer/src/analyzer/assign/type_el.rs:255:30)
+  |                 Errors {
+  |                     span: Span {
+  |                         lo: BytePos(
+  |                             188,
+  |                         ),
+  |                         hi: BytePos(
+  |                             191,
+  |                         ),
+  |                         ctxt: #0,
+  |                     },
+  |                     errors: [
+  |                         ObjectAssignFailed {
+  |                             span: Span {
+  |                                 lo: BytePos(
+  |                                     188,
+  |                                 ),
+  |                                 hi: BytePos(
+  |                                     191,
+  |                                 ),
+  |                                 ctxt: #0,
+  |                             },
+  |                             errors: [
+  |                                 MissingFields {
+  |                                     span: Span {
+  |                                         lo: BytePos(
+  |                                             188,
+  |                                         ),
+  |                                         hi: BytePos(
+  |                                             191,
+  |                                         ),
+  |                                         ctxt: #0,
+  |                                     },
+  |                                     fields: [
+  |                                         b: Keyword(string),
+  |                                     ],
+  |                                 },
+  |                             ],
+  |                         },
+  |                     ],
+  |                 },
+  |             ],
+  |         },
+  |     ],
+  | }
+    ,-[$DIR/tests/errors/issues/0xxx/415/4.ts:18:1]
+ 18 | 
+ 19 | aob = x;
+    : ^^^
+    `----

--- a/crates/stc_ts_file_analyzer/tests/errors/issues/0xxx/754/1.swc-stderr
+++ b/crates/stc_ts_file_analyzer/tests/errors/issues/0xxx/754/1.swc-stderr
@@ -1,0 +1,336 @@
+TS2322
+
+  x [33mcontext[0m: tried to assign from var decl (at crates/stc_ts_file_analyzer/src/analyzer/stmt/var_decl.rs:345:34)
+  | [33mcontext[0m:
+  | lhs = instanceof  ABC;
+  | rhs = IntesrectionABC<T#3#0>;
+  | lhs (normalized) = {
+  |     a: string;
+  |     d: number;
+  | };
+  | rhs (normalized) = IntesrectionABC<T#3#0>; (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:565:73)
+  | [33mcontext[0m: tried to assign a type expanded from a reference to another type (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:1486:22)
+  | [33mcontext[0m:
+  | lhs = {
+  |     a: string;
+  |     d: number;
+  | };
+  | rhs = (T#3#0 & A & B & C);
+  | lhs (normalized) = {
+  |     a: string;
+  |     d: number;
+  | };
+  | rhs (normalized) = (T#3#0 & A & B & C); (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:565:73)
+  | [33mcontext[0m: tried to assign a normalized intersection type to another type (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:1526:30)
+  | [33mcontext[0m:
+  | lhs = {
+  |     a: string;
+  |     d: number;
+  | };
+  | rhs = (T#3#0 & {
+  |     a: string;
+  | } & {
+  |     b: number;
+  | } & {
+  |     c: boolean;
+  | });
+  | lhs (normalized) = {
+  |     a: string;
+  |     d: number;
+  | };
+  | rhs (normalized) = (T#3#0 & {
+  |     a: string;
+  | } & {
+  |     b: number;
+  | } & {
+  |     c: boolean;
+  | }); (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:565:73)
+  | [33mcontext[0m: tried to assign an element of an intersection type to another type (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:1547:26)
+  | [33mcontext[0m:
+  | lhs = {
+  |     a: string;
+  |     d: number;
+  | };
+  | rhs = T#3#0;
+  | lhs (normalized) = {
+  |     a: string;
+  |     d: number;
+  | };
+  | rhs (normalized) = T#3#0; (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:565:73)
+  | [33mcontext[0m: LHS (final): {
+  |     a: string;
+  |     d: number;
+  | };
+  | RHS (final): T#3#0; (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:2640:29)
+  | AssignFailed {
+  |     span: Span {
+  |         lo: BytePos(
+  |             181,
+  |         ),
+  |         hi: BytePos(
+  |             216,
+  |         ),
+  |         ctxt: #0,
+  |     },
+  |     cause: [],
+  | }
+   ,-[$DIR/tests/errors/issues/0xxx/754/1.ts:6:1]
+ 6 | function some<T>() {
+ 7 |     let foo: ABC = {} as IntesrectionABC<T>;
+   :         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+ 8 | }
+   `----
+TS2322
+
+  x [33mcontext[0m: tried to assign from var decl (at crates/stc_ts_file_analyzer/src/analyzer/stmt/var_decl.rs:345:34)
+  | [33mcontext[0m:
+  | lhs = instanceof  ABC;
+  | rhs = IntesrectionABC<T#3#0>;
+  | lhs (normalized) = {
+  |     a: string;
+  |     d: number;
+  | };
+  | rhs (normalized) = IntesrectionABC<T#3#0>; (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:565:73)
+  | [33mcontext[0m: tried to assign a type expanded from a reference to another type (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:1486:22)
+  | [33mcontext[0m:
+  | lhs = {
+  |     a: string;
+  |     d: number;
+  | };
+  | rhs = (T#3#0 & A & B & C);
+  | lhs (normalized) = {
+  |     a: string;
+  |     d: number;
+  | };
+  | rhs (normalized) = (T#3#0 & A & B & C); (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:565:73)
+  | [33mcontext[0m: tried to assign a normalized intersection type to another type (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:1526:30)
+  | [33mcontext[0m:
+  | lhs = {
+  |     a: string;
+  |     d: number;
+  | };
+  | rhs = (T#3#0 & {
+  |     a: string;
+  | } & {
+  |     b: number;
+  | } & {
+  |     c: boolean;
+  | });
+  | lhs (normalized) = {
+  |     a: string;
+  |     d: number;
+  | };
+  | rhs (normalized) = (T#3#0 & {
+  |     a: string;
+  | } & {
+  |     b: number;
+  | } & {
+  |     c: boolean;
+  | }); (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:565:73)
+  | [33mcontext[0m: tried to assign an element of an intersection type to another type (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:1547:26)
+  | [33mcontext[0m:
+  | lhs = {
+  |     a: string;
+  |     d: number;
+  | };
+  | rhs = {
+  |     a: string;
+  | };
+  | lhs (normalized) = {
+  |     a: string;
+  |     d: number;
+  | };
+  | rhs (normalized) = {
+  |     a: string;
+  | }; (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:565:73)
+  | [33mcontext[0m: tried to assign a type to type elements (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:2351:22)
+  | MissingFields {
+  |     span: Span {
+  |         lo: BytePos(
+  |             181,
+  |         ),
+  |         hi: BytePos(
+  |             216,
+  |         ),
+  |         ctxt: #0,
+  |     },
+  |     fields: [
+  |         d: Keyword(number),
+  |     ],
+  | }
+   ,-[$DIR/tests/errors/issues/0xxx/754/1.ts:6:1]
+ 6 | function some<T>() {
+ 7 |     let foo: ABC = {} as IntesrectionABC<T>;
+   :         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+ 8 | }
+   `----
+TS2322
+
+  x [33mcontext[0m: tried to assign from var decl (at crates/stc_ts_file_analyzer/src/analyzer/stmt/var_decl.rs:345:34)
+  | [33mcontext[0m:
+  | lhs = instanceof  ABC;
+  | rhs = IntesrectionABC<T#3#0>;
+  | lhs (normalized) = {
+  |     a: string;
+  |     d: number;
+  | };
+  | rhs (normalized) = IntesrectionABC<T#3#0>; (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:565:73)
+  | [33mcontext[0m: tried to assign a type expanded from a reference to another type (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:1486:22)
+  | [33mcontext[0m:
+  | lhs = {
+  |     a: string;
+  |     d: number;
+  | };
+  | rhs = (T#3#0 & A & B & C);
+  | lhs (normalized) = {
+  |     a: string;
+  |     d: number;
+  | };
+  | rhs (normalized) = (T#3#0 & A & B & C); (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:565:73)
+  | [33mcontext[0m: tried to assign a normalized intersection type to another type (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:1526:30)
+  | [33mcontext[0m:
+  | lhs = {
+  |     a: string;
+  |     d: number;
+  | };
+  | rhs = (T#3#0 & {
+  |     a: string;
+  | } & {
+  |     b: number;
+  | } & {
+  |     c: boolean;
+  | });
+  | lhs (normalized) = {
+  |     a: string;
+  |     d: number;
+  | };
+  | rhs (normalized) = (T#3#0 & {
+  |     a: string;
+  | } & {
+  |     b: number;
+  | } & {
+  |     c: boolean;
+  | }); (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:565:73)
+  | [33mcontext[0m: tried to assign an element of an intersection type to another type (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:1547:26)
+  | [33mcontext[0m:
+  | lhs = {
+  |     a: string;
+  |     d: number;
+  | };
+  | rhs = {
+  |     b: number;
+  | };
+  | lhs (normalized) = {
+  |     a: string;
+  |     d: number;
+  | };
+  | rhs (normalized) = {
+  |     b: number;
+  | }; (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:565:73)
+  | [33mcontext[0m: tried to assign a type to type elements (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:2351:22)
+  | MissingFields {
+  |     span: Span {
+  |         lo: BytePos(
+  |             181,
+  |         ),
+  |         hi: BytePos(
+  |             216,
+  |         ),
+  |         ctxt: #0,
+  |     },
+  |     fields: [
+  |         a: Keyword(string),
+  |         d: Keyword(number),
+  |     ],
+  | }
+   ,-[$DIR/tests/errors/issues/0xxx/754/1.ts:6:1]
+ 6 | function some<T>() {
+ 7 |     let foo: ABC = {} as IntesrectionABC<T>;
+   :         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+ 8 | }
+   `----
+TS2322
+
+  x [33mcontext[0m: tried to assign from var decl (at crates/stc_ts_file_analyzer/src/analyzer/stmt/var_decl.rs:345:34)
+  | [33mcontext[0m:
+  | lhs = instanceof  ABC;
+  | rhs = IntesrectionABC<T#3#0>;
+  | lhs (normalized) = {
+  |     a: string;
+  |     d: number;
+  | };
+  | rhs (normalized) = IntesrectionABC<T#3#0>; (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:565:73)
+  | [33mcontext[0m: tried to assign a type expanded from a reference to another type (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:1486:22)
+  | [33mcontext[0m:
+  | lhs = {
+  |     a: string;
+  |     d: number;
+  | };
+  | rhs = (T#3#0 & A & B & C);
+  | lhs (normalized) = {
+  |     a: string;
+  |     d: number;
+  | };
+  | rhs (normalized) = (T#3#0 & A & B & C); (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:565:73)
+  | [33mcontext[0m: tried to assign a normalized intersection type to another type (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:1526:30)
+  | [33mcontext[0m:
+  | lhs = {
+  |     a: string;
+  |     d: number;
+  | };
+  | rhs = (T#3#0 & {
+  |     a: string;
+  | } & {
+  |     b: number;
+  | } & {
+  |     c: boolean;
+  | });
+  | lhs (normalized) = {
+  |     a: string;
+  |     d: number;
+  | };
+  | rhs (normalized) = (T#3#0 & {
+  |     a: string;
+  | } & {
+  |     b: number;
+  | } & {
+  |     c: boolean;
+  | }); (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:565:73)
+  | [33mcontext[0m: tried to assign an element of an intersection type to another type (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:1547:26)
+  | [33mcontext[0m:
+  | lhs = {
+  |     a: string;
+  |     d: number;
+  | };
+  | rhs = {
+  |     c: boolean;
+  | };
+  | lhs (normalized) = {
+  |     a: string;
+  |     d: number;
+  | };
+  | rhs (normalized) = {
+  |     c: boolean;
+  | }; (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:565:73)
+  | [33mcontext[0m: tried to assign a type to type elements (at crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs:2351:22)
+  | MissingFields {
+  |     span: Span {
+  |         lo: BytePos(
+  |             181,
+  |         ),
+  |         hi: BytePos(
+  |             216,
+  |         ),
+  |         ctxt: #0,
+  |     },
+  |     fields: [
+  |         a: Keyword(string),
+  |         d: Keyword(number),
+  |     ],
+  | }
+   ,-[$DIR/tests/errors/issues/0xxx/754/1.ts:6:1]
+ 6 | function some<T>() {
+ 7 |     let foo: ABC = {} as IntesrectionABC<T>;
+   :         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+ 8 | }
+   `----


### PR DESCRIPTION
**Description:**

Note that, currently, the rendered errors contain ANSI code.