### PR TITLE
fix: Fix `keyof` of tuple types

### DIFF
--- a/crates/stc_ts_file_analyzer/src/analyzer/types/keyof.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/types/keyof.rs
@@ -1,7 +1,7 @@
 use std::borrow::Cow;
 
 use itertools::Itertools;
-use stc_ts_ast_rnode::{RIdent, RNumber, RTsEntityName, RTsLit};
+use stc_ts_ast_rnode::{RIdent, RNumber, RStr, RTsEntityName, RTsLit};
 use stc_ts_errors::{debug::force_dump_type_as_string, DebugExt, ErrorKind};
 use stc_ts_type_ops::{is_str_lit_or_union, Fix};
 use stc_ts_types::{
@@ -264,7 +264,17 @@ impl Analyzer<'_, '_> {
                                 }),
                                 metadata: Default::default(),
                                 tracker: Default::default(),
-                            }))
+                            }));
+                            types.push(Type::Lit(LitType {
+                                span,
+                                lit: RTsLit::Str(RStr {
+                                    span,
+                                    value: idx.to_string().into(),
+                                    raw: None,
+                                }),
+                                metadata: Default::default(),
+                                tracker: Default::default(),
+                            }));
                         }
                     }
 


### PR DESCRIPTION
**Description:**


**Related issue (if exists):**
