### PR TITLE
refactor: Rename options of `access_property`

### DIFF
--- a/crates/stc_ts_file_analyzer/src/analyzer/assign/array.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/assign/array.rs
@@ -112,7 +112,7 @@ impl Analyzer<'_, '_> {
                         AccessPropertyOpts {
                             do_not_validate_type_of_computed_prop: true,
                             disallow_indexing_array_with_string: true,
-                            disallow_creating_indexed_type_from_ty_els: true,
+                            disallow_creating_indexed_type: true,
                             disallow_indexing_class_with_computed: true,
                             use_undefined_for_tuple_index_error: true,
                             ..Default::default()
@@ -132,7 +132,7 @@ impl Analyzer<'_, '_> {
                         AccessPropertyOpts {
                             do_not_validate_type_of_computed_prop: true,
                             disallow_indexing_array_with_string: true,
-                            disallow_creating_indexed_type_from_ty_els: true,
+                            disallow_creating_indexed_type: true,
                             disallow_indexing_class_with_computed: true,
                             use_undefined_for_tuple_index_error: true,
                             ..Default::default()

--- a/crates/stc_ts_file_analyzer/src/analyzer/assign/function.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/assign/function.rs
@@ -954,7 +954,7 @@ impl Analyzer<'_, '_> {
                                     IdCtx::Var,
                                     AccessPropertyOpts {
                                         disallow_indexing_array_with_string: true,
-                                        disallow_creating_indexed_type_from_ty_els: true,
+                                        disallow_creating_indexed_type: true,
                                         disallow_indexing_class_with_computed: true,
                                         disallow_inexact: true,
                                         ..Default::default()
@@ -973,7 +973,7 @@ impl Analyzer<'_, '_> {
                                     IdCtx::Var,
                                     AccessPropertyOpts {
                                         disallow_indexing_array_with_string: true,
-                                        disallow_creating_indexed_type_from_ty_els: true,
+                                        disallow_creating_indexed_type: true,
                                         disallow_indexing_class_with_computed: true,
                                         disallow_inexact: true,
                                         use_last_element_for_tuple_on_out_of_bound: true,

--- a/crates/stc_ts_file_analyzer/src/analyzer/class/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/class/mod.rs
@@ -168,7 +168,7 @@ impl Analyzer<'_, '_> {
                     TypeOfMode::RValue,
                     IdCtx::Var,
                     AccessPropertyOpts {
-                        disallow_creating_indexed_type_from_ty_els: true,
+                        disallow_creating_indexed_type: true,
                         ..Default::default()
                     },
                 ) {
@@ -242,7 +242,7 @@ impl Analyzer<'_, '_> {
                     TypeOfMode::RValue,
                     IdCtx::Var,
                     AccessPropertyOpts {
-                        disallow_creating_indexed_type_from_ty_els: true,
+                        disallow_creating_indexed_type: true,
                         ..Default::default()
                     },
                 ) {
@@ -693,7 +693,7 @@ impl Analyzer<'_, '_> {
                 TypeOfMode::RValue,
                 IdCtx::Var,
                 AccessPropertyOpts {
-                    disallow_creating_indexed_type_from_ty_els: true,
+                    disallow_creating_indexed_type: true,
                     ..Default::default()
                 },
             ) {

--- a/crates/stc_ts_file_analyzer/src/analyzer/control_flow.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/control_flow.rs
@@ -1286,7 +1286,7 @@ impl Analyzer<'_, '_> {
                 TypeOfMode::RValue,
                 IdCtx::Var,
                 AccessPropertyOpts {
-                    disallow_creating_indexed_type_from_ty_els: true,
+                    disallow_creating_indexed_type: true,
                     ..Default::default()
                 },
             )

--- a/crates/stc_ts_file_analyzer/src/analyzer/expr/array.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/expr/array.rs
@@ -513,7 +513,7 @@ impl Analyzer<'_, '_> {
                     IdCtx::Var,
                     AccessPropertyOpts {
                         disallow_indexing_array_with_string: true,
-                        disallow_creating_indexed_type_from_ty_els: true,
+                        disallow_creating_indexed_type: true,
                         ..Default::default()
                     },
                 );
@@ -541,7 +541,7 @@ impl Analyzer<'_, '_> {
                 IdCtx::Var,
                 AccessPropertyOpts {
                     disallow_indexing_array_with_string: true,
-                    disallow_creating_indexed_type_from_ty_els: true,
+                    disallow_creating_indexed_type: true,
                     ..Default::default()
                 },
             )

--- a/crates/stc_ts_file_analyzer/src/analyzer/expr/jsx.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/expr/jsx.rs
@@ -55,7 +55,7 @@ impl Analyzer<'_, '_> {
                 TypeOfMode::RValue,
                 IdCtx::Var,
                 AccessPropertyOpts {
-                    disallow_creating_indexed_type_from_ty_els: true,
+                    disallow_creating_indexed_type: true,
                     ..Default::default()
                 },
             )
@@ -85,7 +85,7 @@ impl Analyzer<'_, '_> {
                 TypeOfMode::RValue,
                 IdCtx::Var,
                 AccessPropertyOpts {
-                    disallow_creating_indexed_type_from_ty_els: true,
+                    disallow_creating_indexed_type: true,
                     ..Default::default()
                 },
             )
@@ -127,7 +127,7 @@ impl Analyzer<'_, '_> {
                 TypeOfMode::RValue,
                 IdCtx::Var,
                 AccessPropertyOpts {
-                    disallow_creating_indexed_type_from_ty_els: true,
+                    disallow_creating_indexed_type: true,
                     ..Default::default()
                 },
             )
@@ -435,7 +435,7 @@ impl Analyzer<'_, '_> {
             TypeOfMode::RValue,
             IdCtx::Var,
             AccessPropertyOpts {
-                disallow_creating_indexed_type_from_ty_els: true,
+                disallow_creating_indexed_type: true,
                 ..Default::default()
             },
         )

--- a/crates/stc_ts_file_analyzer/src/analyzer/expr/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/expr/mod.rs
@@ -655,7 +655,7 @@ pub(crate) struct AccessPropertyOpts {
     ///
     ///  obj11.foo; // Error TS2339
     /// ```
-    pub disallow_creating_indexed_type_from_ty_els: bool,
+    pub disallow_creating_indexed_type: bool,
 
     pub disallow_indexing_class_with_computed: bool,
 
@@ -1165,7 +1165,7 @@ impl Analyzer<'_, '_> {
             }
         }
 
-        if has_index_signature && !opts.disallow_creating_indexed_type_from_ty_els {
+        if has_index_signature && !opts.disallow_creating_indexed_type {
             // This check exists to prefer a specific property over generic index signature.
             if prop.is_computed() || matching_elements.is_empty() {
                 warn!("Creating a indexed access type from a type literal");
@@ -1278,7 +1278,7 @@ impl Analyzer<'_, '_> {
                             id_ctx,
                             AccessPropertyOpts {
                                 disallow_indexing_array_with_string: true,
-                                disallow_creating_indexed_type_from_ty_els: true,
+                                disallow_creating_indexed_type: true,
                                 is_key_computed: true,
                                 ..opts
                             },
@@ -2187,7 +2187,7 @@ impl Analyzer<'_, '_> {
                     }
                 }
 
-                if opts.disallow_creating_indexed_type_from_ty_els {
+                if opts.disallow_creating_indexed_type {
                     return Err(ErrorKind::NoSuchProperty {
                         span,
                         obj: Some(Box::new(obj.clone())),
@@ -2407,8 +2407,7 @@ impl Analyzer<'_, '_> {
                         type_mode,
                         id_ctx,
                         AccessPropertyOpts {
-                            disallow_creating_indexed_type_from_ty_els: opts.disallow_creating_indexed_type_from_ty_els
-                                || has_better_default,
+                            disallow_creating_indexed_type: opts.disallow_creating_indexed_type || has_better_default,
                             ..opts
                         },
                     )
@@ -2600,7 +2599,7 @@ impl Analyzer<'_, '_> {
                         id_ctx,
                         AccessPropertyOpts {
                             use_undefined_for_tuple_index_error,
-                            disallow_creating_indexed_type_from_ty_els: true,
+                            disallow_creating_indexed_type: true,
                             is_in_union: true,
                             ..opts
                         },

--- a/crates/stc_ts_file_analyzer/src/analyzer/expr/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/expr/mod.rs
@@ -2187,6 +2187,15 @@ impl Analyzer<'_, '_> {
                     }
                 }
 
+                if opts.disallow_creating_indexed_type_from_ty_els {
+                    return Err(ErrorKind::NoSuchProperty {
+                        span,
+                        obj: Some(Box::new(obj.clone())),
+                        prop: Some(Box::new(prop.clone())),
+                    }
+                    .context("type parameter"));
+                }
+
                 let mut prop_ty = match prop {
                     Key::Computed(key) => key.ty.clone(),
                     Key::Normal { span, sym } => Box::new(Type::Lit(LitType {
@@ -2756,6 +2765,9 @@ impl Analyzer<'_, '_> {
                                 }));
                             }
                             if opts.use_last_element_for_tuple_on_out_of_bound {
+                                if elems.is_empty() {
+                                    return Ok(Type::any(span, Default::default()));
+                                }
                                 return Ok(*elems.last().unwrap().ty.clone());
                             }
 
@@ -2777,7 +2789,7 @@ impl Analyzer<'_, '_> {
                             }
 
                             return Err(ErrorKind::TupleIndexError {
-                                span: n.span(),
+                                span,
                                 index: v,
                                 len: elems.len() as u64,
                             }

--- a/crates/stc_ts_file_analyzer/src/analyzer/generic/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/generic/mod.rs
@@ -2244,7 +2244,7 @@ impl Analyzer<'_, '_> {
                 AccessPropertyOpts {
                     do_not_validate_type_of_computed_prop: true,
                     disallow_indexing_array_with_string: true,
-                    disallow_creating_indexed_type_from_ty_els: true,
+                    disallow_creating_indexed_type: true,
                     disallow_indexing_class_with_computed: true,
                     use_undefined_for_tuple_index_error: true,
                     return_rest_tuple_element_as_is: true,
@@ -2265,7 +2265,7 @@ impl Analyzer<'_, '_> {
                 AccessPropertyOpts {
                     do_not_validate_type_of_computed_prop: true,
                     disallow_indexing_array_with_string: true,
-                    disallow_creating_indexed_type_from_ty_els: true,
+                    disallow_creating_indexed_type: true,
                     disallow_indexing_class_with_computed: true,
                     use_undefined_for_tuple_index_error: true,
                     return_rest_tuple_element_as_is: true,

--- a/crates/stc_ts_file_analyzer/src/analyzer/scope/vars.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/scope/vars.rs
@@ -654,7 +654,7 @@ impl Analyzer<'_, '_> {
                                         IdCtx::Var,
                                         AccessPropertyOpts {
                                             disallow_indexing_array_with_string: true,
-                                            disallow_creating_indexed_type_from_ty_els: true,
+                                            disallow_creating_indexed_type: true,
                                             disallow_inexact: true,
                                             ..Default::default()
                                         },
@@ -675,7 +675,7 @@ impl Analyzer<'_, '_> {
                                             IdCtx::Var,
                                             AccessPropertyOpts {
                                                 disallow_indexing_array_with_string: true,
-                                                disallow_creating_indexed_type_from_ty_els: true,
+                                                disallow_creating_indexed_type: true,
                                                 disallow_inexact: true,
                                                 ..Default::default()
                                             },
@@ -750,7 +750,7 @@ impl Analyzer<'_, '_> {
                                         IdCtx::Var,
                                         AccessPropertyOpts {
                                             disallow_indexing_array_with_string: true,
-                                            disallow_creating_indexed_type_from_ty_els: true,
+                                            disallow_creating_indexed_type: true,
                                             disallow_inexact: true,
                                             ..Default::default()
                                         },
@@ -771,7 +771,7 @@ impl Analyzer<'_, '_> {
                                             IdCtx::Var,
                                             AccessPropertyOpts {
                                                 disallow_indexing_array_with_string: true,
-                                                disallow_creating_indexed_type_from_ty_els: true,
+                                                disallow_creating_indexed_type: true,
                                                 disallow_inexact: true,
                                                 ..Default::default()
                                             },

--- a/crates/stc_ts_file_analyzer/src/analyzer/types/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/types/mod.rs
@@ -566,7 +566,7 @@ impl Analyzer<'_, '_> {
                             TypeOfMode::RValue,
                             IdCtx::Type,
                             AccessPropertyOpts {
-                                disallow_creating_indexed_type_from_ty_els: true,
+                                disallow_creating_indexed_type: true,
                                 disallow_inexact: true,
                                 do_not_use_any_for_object: true,
                                 ..Default::default()

--- a/crates/stc_ts_types/src/lib.rs
+++ b/crates/stc_ts_types/src/lib.rs
@@ -3288,3 +3288,28 @@ impl_freeze!(Key);
 impl_freeze!(Enum);
 impl_freeze!(ClassDef);
 impl_freeze!(Mapped);
+
+pub trait SpreadLike: 'static + Spanned + Clone {
+    fn is_spread(&self) -> bool;
+    fn ty(&self) -> &Type;
+}
+
+impl SpreadLike for FnParam {
+    fn is_spread(&self) -> bool {
+        matches!(&self.pat, RPat::Rest(..))
+    }
+
+    fn ty(&self) -> &Type {
+        &self.ty
+    }
+}
+
+impl SpreadLike for TypeOrSpread {
+    fn is_spread(&self) -> bool {
+        self.spread.is_some()
+    }
+
+    fn ty(&self) -> &Type {
+        &self.ty
+    }
+}

--- a/cspell.json
+++ b/cspell.json
@@ -57,6 +57,7 @@
     "osascript",
     "overriden",
     "partialeq",
+    "Peekable",
     "petgraph",
     "pmutil",
     "Postprocess",


### PR DESCRIPTION
**Description:**

Extracted from https://github.com/dudykr/stc/pull/1042to make review easier.

**Related issue (if exists):**
