### PR TITLE
refactor: Use `&self` instead of `&mut` where possible

### DIFF
--- a/crates/stc_ts_file_analyzer/src/analyzer/assign/array.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/assign/array.rs
@@ -19,7 +19,7 @@ use crate::{
 impl Analyzer<'_, '_> {
     /// Returns `Ok(Some())` if the assignment is handled.
     pub(super) fn assign_to_tuple(
-        &mut self,
+        &self,
         data: &mut AssignData,
         l: &Tuple,
         l_type: &Type,

--- a/crates/stc_ts_file_analyzer/src/analyzer/assign/builtin.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/assign/builtin.rs
@@ -21,7 +21,7 @@ impl Analyzer<'_, '_> {
     /// - Handles assignment of `Function` types.
     /// - Handles assignment of various array types.
     /// - Handles assignment of promise types.
-    pub(super) fn assign_to_builtin(&mut self, data: &mut AssignData, l: &Type, r: &Type, opts: AssignOpts) -> Option<VResult<()>> {
+    pub(super) fn assign_to_builtin(&self, data: &mut AssignData, l: &Type, r: &Type, opts: AssignOpts) -> Option<VResult<()>> {
         let span = opts.span;
         let l = l.normalize();
         let r = r.normalize();

--- a/crates/stc_ts_file_analyzer/src/analyzer/assign/cast.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/assign/cast.rs
@@ -9,7 +9,7 @@ use crate::analyzer::{types::NormalizeTypeOpts, Analyzer};
 impl Analyzer<'_, '_> {
     /// Returns true if the type can be casted to number if it's in the rvalue
     /// position.
-    pub(crate) fn can_be_casted_to_number_in_rhs(&mut self, span: Span, ty: &Type) -> bool {
+    pub(crate) fn can_be_casted_to_number_in_rhs(&self, span: Span, ty: &Type) -> bool {
         let ty = match self.normalize(
             Some(span),
             Cow::Borrowed(ty),

--- a/crates/stc_ts_file_analyzer/src/analyzer/assign/class.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/assign/class.rs
@@ -15,7 +15,7 @@ use crate::{
 };
 
 impl Analyzer<'_, '_> {
-    pub(super) fn assign_to_class_def(&mut self, data: &mut AssignData, l: &ClassDef, r: &Type, opts: AssignOpts) -> VResult<()> {
+    pub(super) fn assign_to_class_def(&self, data: &mut AssignData, l: &ClassDef, r: &Type, opts: AssignOpts) -> VResult<()> {
         let r = self.normalize(Some(opts.span), Cow::Borrowed(r), Default::default())?;
 
         match r.normalize() {
@@ -127,7 +127,7 @@ impl Analyzer<'_, '_> {
         .into())
     }
 
-    pub(super) fn assign_to_class(&mut self, data: &mut AssignData, l: &Class, r: &Type, opts: AssignOpts) -> VResult<()> {
+    pub(super) fn assign_to_class(&self, data: &mut AssignData, l: &Class, r: &Type, opts: AssignOpts) -> VResult<()> {
         // debug_assert!(!span.is_dummy());
 
         let r = self.normalize(Some(opts.span), Cow::Borrowed(r), Default::default())?;
@@ -279,7 +279,7 @@ impl Analyzer<'_, '_> {
     }
 
     fn assign_class_members_to_class_member(
-        &mut self,
+        &self,
         data: &mut AssignData,
         l: &ClassMember,
         r: &[ClassMember],

--- a/crates/stc_ts_file_analyzer/src/analyzer/assign/function.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/assign/function.rs
@@ -28,7 +28,7 @@ use crate::{
 /// Methods to handle assignment to function types and constructor types.
 impl Analyzer<'_, '_> {
     pub(crate) fn assign_to_fn_like(
-        &mut self,
+        &self,
         data: &mut AssignData,
         is_call: bool,
         l_type_params: Option<&TypeParamDecl>,
@@ -668,7 +668,7 @@ impl Analyzer<'_, '_> {
     /// # Notes
     ///
     ///  - `string` is assignable to `...args: any[]`.
-    fn assign_param(&mut self, data: &mut AssignData, l: &FnParam, r: &FnParam, opts: AssignOpts) -> VResult<()> {
+    fn assign_param(&self, data: &mut AssignData, l: &FnParam, r: &FnParam, opts: AssignOpts) -> VResult<()> {
         let _tracing = dev_span!("assign_param");
 
         let span = opts.span;
@@ -832,7 +832,7 @@ impl Analyzer<'_, '_> {
     /// ```
     ///
     /// So, it's an error if `l.params.len() < r.params.len()`.
-    pub(crate) fn assign_params(&mut self, data: &mut AssignData, l: &[FnParam], r: &[FnParam], opts: AssignOpts) -> VResult<()> {
+    pub(crate) fn assign_params(&self, data: &mut AssignData, l: &[FnParam], r: &[FnParam], opts: AssignOpts) -> VResult<()> {
         let _tracing = dev_span!("assign_params");
 
         let span = opts.span;

--- a/crates/stc_ts_file_analyzer/src/analyzer/assign/function.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/assign/function.rs
@@ -423,7 +423,7 @@ impl Analyzer<'_, '_> {
     /// a = b;
     /// b = a; // error
     /// ```
-    pub(super) fn assign_to_function(&mut self, data: &mut AssignData, lt: &Type, l: &Function, r: &Type, opts: AssignOpts) -> VResult<()> {
+    pub(super) fn assign_to_function(&self, data: &mut AssignData, lt: &Type, l: &Function, r: &Type, opts: AssignOpts) -> VResult<()> {
         let _tracing = dev_span!("assign_to_function");
 
         let span = opts.span;

--- a/crates/stc_ts_file_analyzer/src/analyzer/assign/function.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/assign/function.rs
@@ -530,7 +530,7 @@ impl Analyzer<'_, '_> {
     /// b18 = a18; // ok
     /// ```
     pub(super) fn assign_to_constructor(
-        &mut self,
+        &self,
         data: &mut AssignData,
         lt: &Type,
         l: &Constructor,

--- a/crates/stc_ts_file_analyzer/src/analyzer/assign/function.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/assign/function.rs
@@ -692,7 +692,7 @@ impl Analyzer<'_, '_> {
     }
 
     /// Implementation of `assign_param`.
-    fn assign_param_type(&mut self, data: &mut AssignData, l: &Type, r: &Type, opts: AssignOpts) -> VResult<()> {
+    fn assign_param_type(&self, data: &mut AssignData, l: &Type, r: &Type, opts: AssignOpts) -> VResult<()> {
         let _tracing = dev_span!("assign_param_type");
 
         let span = opts.span;

--- a/crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs
@@ -499,7 +499,7 @@ impl Analyzer<'_, '_> {
         })
     }
 
-    fn normalize_for_assign<'a>(&mut self, span: Span, ty: &'a Type, opts: AssignOpts) -> VResult<Cow<'a, Type>> {
+    fn normalize_for_assign<'a>(&self, span: Span, ty: &'a Type, opts: AssignOpts) -> VResult<Cow<'a, Type>> {
         ty.assert_valid();
 
         let ty = ty.normalize();

--- a/crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs
@@ -3170,7 +3170,7 @@ impl Analyzer<'_, '_> {
     ///
     ///
     /// Currently only literals and unions are supported for `keys`.
-    fn assign_keys(&mut self, data: &mut AssignData, keys: &Type, rhs: &Type, opts: AssignOpts) -> VResult<()> {
+    fn assign_keys(&self, data: &mut AssignData, keys: &Type, rhs: &Type, opts: AssignOpts) -> VResult<()> {
         let keys = keys.normalize();
         let rhs = rhs.normalize();
 
@@ -3189,7 +3189,7 @@ impl Analyzer<'_, '_> {
         .context("tried to assign keys")
     }
 
-    fn assign_to_mapped(&mut self, data: &mut AssignData, l: &Mapped, r: &Type, opts: AssignOpts) -> VResult<()> {
+    fn assign_to_mapped(&self, data: &mut AssignData, l: &Mapped, r: &Type, opts: AssignOpts) -> VResult<()> {
         let span = opts.span;
         let mut r = self
             .normalize(Some(span), Cow::Borrowed(r), NormalizeTypeOpts { ..Default::default() })

--- a/crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs
@@ -3110,7 +3110,7 @@ impl Analyzer<'_, '_> {
         Ok(())
     }
 
-    fn extract_keys(&mut self, span: Span, ty: &Type) -> VResult<Type> {
+    fn extract_keys(&self, span: Span, ty: &Type) -> VResult<Type> {
         (|| -> VResult<_> {
             let ty = self.normalize(
                 Some(span),
@@ -3320,7 +3320,7 @@ impl Analyzer<'_, '_> {
     /// Returns true for `A | B | | C = A | B` and similar cases.
     ///
     /// Should be called iff lhs is a union type.
-    fn should_use_special_union_assignment(&mut self, span: Span, r: &Type) -> VResult<bool> {
+    fn should_use_special_union_assignment(&self, span: Span, r: &Type) -> VResult<bool> {
         match r.normalize() {
             Type::Union(..) => return Ok(true),
             Type::TypeLit(r) => {
@@ -3339,7 +3339,7 @@ impl Analyzer<'_, '_> {
     }
 
     /// TODO(kdy1): I'm not sure about this.
-    fn variance(&mut self, ty: &Conditional) -> VResult<Variance> {
+    fn variance(&self, ty: &Conditional) -> VResult<Variance> {
         let can_be_covariant = self.is_covariant(&ty.check_type, &ty.true_type)? || self.is_covariant(&ty.check_type, &ty.false_type)?;
 
         let can_be_contravariant =
@@ -3352,11 +3352,11 @@ impl Analyzer<'_, '_> {
         }
     }
 
-    fn is_covariant(&mut self, check_type: &Type, output_type: &Type) -> VResult<bool> {
+    fn is_covariant(&self, check_type: &Type, output_type: &Type) -> VResult<bool> {
         Ok(check_type.type_eq(output_type))
     }
 
-    fn is_contravariant(&mut self, check_type: &Type, output_type: &Type) -> VResult<bool> {
+    fn is_contravariant(&self, check_type: &Type, output_type: &Type) -> VResult<bool> {
         if let Type::Index(Index { ty, .. }) = output_type.normalize() {
             if output_type.type_eq(&**ty) {
                 return Ok(true);

--- a/crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs
@@ -204,7 +204,7 @@ pub struct AssignData {
 impl Analyzer<'_, '_> {
     /// Denies `null` and `undefined`. This method does not check for elements
     /// of union.
-    pub(crate) fn deny_null_or_undefined(&mut self, span: Span, ty: &Type) -> VResult<()> {
+    pub(crate) fn deny_null_or_undefined(&self, span: Span, ty: &Type) -> VResult<()> {
         if ty.is_kwd(TsKeywordTypeKind::TsUndefinedKeyword) {
             return Err(ErrorKind::ObjectIsPossiblyUndefined { span }.into());
         }
@@ -217,7 +217,7 @@ impl Analyzer<'_, '_> {
     }
 
     /// Used to validate assignments like `a += b`.
-    pub(crate) fn assign_with_operator(&mut self, span: Span, op: AssignOp, lhs: &Type, rhs: &Type) -> VResult<()> {
+    pub(crate) fn assign_with_operator(&self, span: Span, op: AssignOp, lhs: &Type, rhs: &Type) -> VResult<()> {
         debug_assert_ne!(op, op!("="));
 
         let l = self.normalize(

--- a/crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs
@@ -2703,7 +2703,7 @@ impl Analyzer<'_, '_> {
     }
 
     /// Should be called only if `to` is not expandable.
-    pub(super) fn assign_to_intrinsic(&mut self, data: &mut AssignData, to: &StringMapping, r: &Type, opts: AssignOpts) -> VResult<()> {
+    pub(super) fn assign_to_intrinsic(&self, data: &mut AssignData, to: &StringMapping, r: &Type, opts: AssignOpts) -> VResult<()> {
         match r.normalize() {
             Type::Keyword(KeywordType {
                 kind: TsKeywordTypeKind::TsAnyKeyword,

--- a/crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs
@@ -459,7 +459,7 @@ impl Analyzer<'_, '_> {
     }
 
     /// Assign `right` to `left`. You can just use default for [AssignData].
-    pub(crate) fn assign_with_opts(&mut self, data: &mut AssignData, left: &Type, right: &Type, opts: AssignOpts) -> VResult<()> {
+    pub(crate) fn assign_with_opts(&self, data: &mut AssignData, left: &Type, right: &Type, opts: AssignOpts) -> VResult<()> {
         if self.config.is_builtin {
             return Ok(());
         }
@@ -560,7 +560,7 @@ impl Analyzer<'_, '_> {
         Ok(Cow::Borrowed(ty))
     }
 
-    fn assign_inner(&mut self, data: &mut AssignData, left: &Type, right: &Type, opts: AssignOpts) -> VResult<()> {
+    fn assign_inner(&self, data: &mut AssignData, left: &Type, right: &Type, opts: AssignOpts) -> VResult<()> {
         left.assert_valid();
         right.assert_valid();
 
@@ -611,7 +611,7 @@ impl Analyzer<'_, '_> {
     }
 
     /// Assigns, but does not wrap error with [Error::AssignFailed].
-    fn assign_without_wrapping(&mut self, data: &mut AssignData, to: &Type, rhs: &Type, opts: AssignOpts) -> VResult<()> {
+    fn assign_without_wrapping(&self, data: &mut AssignData, to: &Type, rhs: &Type, opts: AssignOpts) -> VResult<()> {
         let span = opts.span;
 
         if !self.config.is_builtin && span.is_dummy() {

--- a/crates/stc_ts_file_analyzer/src/analyzer/assign/tpl.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/assign/tpl.rs
@@ -27,7 +27,7 @@ impl Analyzer<'_, '_> {
     /// orders.
     ///
     /// After splitting, we can check if each element is assignable.
-    pub(crate) fn assign_to_tpl(&mut self, data: &mut AssignData, l: &TplType, r_ty: &Type, opts: AssignOpts) -> VResult<()> {
+    pub(crate) fn assign_to_tpl(&self, data: &mut AssignData, l: &TplType, r_ty: &Type, opts: AssignOpts) -> VResult<()> {
         let span = opts.span;
         let r_ty = r_ty.normalize();
 
@@ -52,7 +52,7 @@ impl Analyzer<'_, '_> {
     }
 
     /// Ported from `isValidTypeForTemplateLiteralPlaceholder` of `tsc`
-    pub(crate) fn is_valid_type_for_tpl_lit_placeholder(&mut self, span: Span, source: &Type, target: &Type) -> VResult<bool> {
+    pub(crate) fn is_valid_type_for_tpl_lit_placeholder(&self, span: Span, source: &Type, target: &Type) -> VResult<bool> {
         let _tracing = dev_span!(
             "is_valid_type_for_tpl_lit_placeholder",
             source = tracing::field::display(&force_dump_type_as_string(source)),

--- a/crates/stc_ts_file_analyzer/src/analyzer/assign/type_el.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/assign/type_el.rs
@@ -37,7 +37,7 @@ impl Analyzer<'_, '_> {
     /// let b: { key: string } = foo;
     /// ```
     pub(crate) fn assign_to_type_elements(
-        &mut self,
+        &self,
         data: &mut AssignData,
         lhs_span: Span,
         lhs: &[TypeElement],
@@ -1004,7 +1004,7 @@ impl Analyzer<'_, '_> {
         true
     }
 
-    pub(super) fn try_assign_using_parent(&mut self, data: &mut AssignData, l: &Type, r: &Type, opts: AssignOpts) -> Option<VResult<()>> {
+    pub(super) fn try_assign_using_parent(&self, data: &mut AssignData, l: &Type, r: &Type, opts: AssignOpts) -> Option<VResult<()>> {
         let span = opts.span;
 
         match r.normalize() {

--- a/crates/stc_ts_file_analyzer/src/analyzer/assign/unions.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/assign/unions.rs
@@ -26,7 +26,7 @@ impl Analyzer<'_, '_> {
     ///
     ///  - lhs = `(["a", number] | ["b", number] | ["c", string]);`
     ///  - rhs = `[("b" | "a"), 1];`
-    pub(super) fn assign_to_union(&mut self, data: &mut AssignData, l: &Type, r: &Type, opts: AssignOpts) -> Option<VResult<()>> {
+    pub(super) fn assign_to_union(&self, data: &mut AssignData, l: &Type, r: &Type, opts: AssignOpts) -> Option<VResult<()>> {
         let r_res = self.flatten_unions_for_assignment(opts.span, Cow::Borrowed(r));
 
         match r_res {

--- a/crates/stc_ts_file_analyzer/src/analyzer/class/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/class/mod.rs
@@ -2407,7 +2407,7 @@ impl Analyzer<'_, '_> {
     }
 
     /// TODO(kdy1): Instantiate fully
-    pub(crate) fn instantiate_class(&mut self, span: Span, ty: &Type) -> VResult<Type> {
+    pub(crate) fn instantiate_class(&self, span: Span, ty: &Type) -> VResult<Type> {
         let span = span.with_ctxt(SyntaxContext::empty());
 
         Ok(match ty.normalize() {

--- a/crates/stc_ts_file_analyzer/src/analyzer/enums.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/enums.rs
@@ -383,7 +383,7 @@ impl Analyzer<'_, '_> {
     /// };
     /// var e: typeof E1;
     /// ```
-    pub(super) fn enum_to_type_lit(&mut self, e: &ArcCow<Enum>) -> VResult<TypeLit> {
+    pub(super) fn enum_to_type_lit(&self, e: &ArcCow<Enum>) -> VResult<TypeLit> {
         let mut members = vec![];
 
         for m in &e.members {

--- a/crates/stc_ts_file_analyzer/src/analyzer/expr/array.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/expr/array.rs
@@ -555,12 +555,7 @@ impl Analyzer<'_, '_> {
         Ok(elem_ty)
     }
 
-    pub(crate) fn get_rest_elements<'a>(
-        &mut self,
-        span: Option<Span>,
-        iterator: Cow<'a, Type>,
-        start_index: usize,
-    ) -> VResult<Cow<'a, Type>> {
+    pub(crate) fn get_rest_elements<'a>(&self, span: Option<Span>, iterator: Cow<'a, Type>, start_index: usize) -> VResult<Cow<'a, Type>> {
         let mut iterator = self.normalize(span, iterator, NormalizeTypeOpts { ..Default::default() })?;
 
         if iterator.is_tuple() {
@@ -592,7 +587,7 @@ impl Analyzer<'_, '_> {
         Ok(Cow::Owned(iterator.into_owned()))
     }
 
-    pub(crate) fn get_iterator<'a>(&mut self, span: Span, ty: Cow<'a, Type>, opts: GetIteratorOpts) -> VResult<Cow<'a, Type>> {
+    pub(crate) fn get_iterator<'a>(&self, span: Span, ty: Cow<'a, Type>, opts: GetIteratorOpts) -> VResult<Cow<'a, Type>> {
         let start = Instant::now();
         let iterator = self.get_iterator_inner(span, ty, opts).context("tried to get iterator");
 
@@ -623,7 +618,7 @@ impl Analyzer<'_, '_> {
         Ok(iterator)
     }
 
-    fn get_iterator_inner<'a>(&mut self, span: Span, ty: Cow<'a, Type>, opts: GetIteratorOpts) -> VResult<Cow<'a, Type>> {
+    fn get_iterator_inner<'a>(&self, span: Span, ty: Cow<'a, Type>, opts: GetIteratorOpts) -> VResult<Cow<'a, Type>> {
         let ty_str = force_dump_type_as_string(&ty);
         debug!("[exprs/array] get_iterator({})", ty_str);
         ty.assert_valid();
@@ -768,7 +763,7 @@ impl Analyzer<'_, '_> {
     ///
     /// If it's true, this method will try `ty.next().value`.
     pub(crate) fn get_iterator_element_type<'a>(
-        &mut self,
+        &self,
         span: Span,
         ty: Cow<'a, Type>,
         try_next_value: bool,

--- a/crates/stc_ts_file_analyzer/src/analyzer/expr/array.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/expr/array.rs
@@ -246,7 +246,7 @@ impl Analyzer<'_, '_> {
 
 impl Analyzer<'_, '_> {
     /// Get `n`th element from the `iterator`.
-    pub(crate) fn get_element_from_iterator<'a>(&mut self, span: Span, iterator: Cow<'a, Type>, n: usize) -> VResult<Cow<'a, Type>> {
+    pub(crate) fn get_element_from_iterator<'a>(&self, span: Span, iterator: Cow<'a, Type>, n: usize) -> VResult<Cow<'a, Type>> {
         debug!("Calculating element type of an iterator ({})", dump_type_as_string(&iterator));
 
         if iterator.is_any() {
@@ -382,7 +382,7 @@ impl Analyzer<'_, '_> {
         Ok(Cow::Owned(value_ty))
     }
 
-    fn try_next_method_of_iterator(&mut self, span: Span, iterator: &Type, awaited: bool) -> VResult<Type> {
+    fn try_next_method_of_iterator(&self, span: Span, iterator: &Type, awaited: bool) -> VResult<Type> {
         let _tracing = dev_span!("try_next_method_of_iterator");
 
         let mut item = self

--- a/crates/stc_ts_file_analyzer/src/analyzer/expr/await_expr.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/expr/await_expr.rs
@@ -76,7 +76,7 @@ impl Analyzer<'_, '_> {
 }
 
 impl Analyzer<'_, '_> {
-    pub(crate) fn get_awaited_type<'a>(&mut self, span: Span, ty: Cow<'a, Type>, error_on_missing_then: bool) -> VResult<Cow<'a, Type>> {
+    pub(crate) fn get_awaited_type<'a>(&self, span: Span, ty: Cow<'a, Type>, error_on_missing_then: bool) -> VResult<Cow<'a, Type>> {
         if let Some(arg) = unwrap_builtin_with_single_arg(&ty, "Promise").or_else(|| unwrap_builtin_with_single_arg(&ty, "PromiseLike")) {
             return self
                 .get_awaited_type(span, Cow::Borrowed(arg), false)

--- a/crates/stc_ts_file_analyzer/src/analyzer/expr/call_new.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/expr/call_new.rs
@@ -588,7 +588,7 @@ impl Analyzer<'_, '_> {
     ///  - `expr`: Can be default if argument does not include an arrow
     ///    expression nor a function expression.
     pub(super) fn call_property(
-        &mut self,
+        &self,
         span: Span,
         kind: ExtractKind,
         expr: ReEvalMode,

--- a/crates/stc_ts_file_analyzer/src/analyzer/expr/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/expr/mod.rs
@@ -1207,7 +1207,7 @@ impl Analyzer<'_, '_> {
     }
 
     pub(super) fn access_property(
-        &mut self,
+        &self,
         span: Span,
         obj: &Type,
         prop: &Key,
@@ -4019,13 +4019,13 @@ impl Analyzer<'_, '_> {
         }
     }
 
-    pub(crate) fn type_of_ts_entity_name(&mut self, span: Span, n: &RExpr, type_args: Option<&TypeParamInstantiation>) -> VResult<Type> {
+    pub(crate) fn type_of_ts_entity_name(&self, span: Span, n: &RExpr, type_args: Option<&TypeParamInstantiation>) -> VResult<Type> {
         let _tracing = dev_span!("type_of_ts_entity_name");
 
         self.type_of_ts_entity_name_inner(span, n, type_args)
     }
 
-    fn type_of_ts_entity_name_inner(&mut self, span: Span, n: &RExpr, type_args: Option<&TypeParamInstantiation>) -> VResult<Type> {
+    fn type_of_ts_entity_name_inner(&self, span: Span, n: &RExpr, type_args: Option<&TypeParamInstantiation>) -> VResult<Type> {
         let _tracing = dev_span!("type_of_ts_entity_name_inner");
 
         let span = span.with_ctxt(SyntaxContext::empty());

--- a/crates/stc_ts_file_analyzer/src/analyzer/expr/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/expr/mod.rs
@@ -823,7 +823,7 @@ impl Analyzer<'_, '_> {
     /// # Parameters
     ///
     /// - `declared`: Key of declared property.
-    pub(crate) fn key_matches(&mut self, span: Span, declared: &Key, cur: &Key, allow_union: bool) -> bool {
+    pub(crate) fn key_matches(&self, span: Span, declared: &Key, cur: &Key, allow_union: bool) -> bool {
         let _tracing = dev_span!("key_matches");
 
         match declared {

--- a/crates/stc_ts_file_analyzer/src/analyzer/expr/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/expr/mod.rs
@@ -3498,7 +3498,7 @@ impl Analyzer<'_, '_> {
     }
 
     /// Returned type reflects conditional type facts.
-    pub(super) fn type_of_var(&mut self, i: &RIdent, type_mode: TypeOfMode, type_args: Option<&TypeParamInstantiation>) -> VResult<Type> {
+    pub(super) fn type_of_var(&self, i: &RIdent, type_mode: TypeOfMode, type_args: Option<&TypeParamInstantiation>) -> VResult<Type> {
         let _tracing = dev_span!("type_of_var");
 
         let span = i.span();

--- a/crates/stc_ts_file_analyzer/src/analyzer/expr/object.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/expr/object.rs
@@ -57,7 +57,7 @@ impl Analyzer<'_, '_> {
     ///
     /// Type of `a` in the code above is `{ a: number, b?: undefined } | {
     /// a:number, b: string }`.
-    pub(super) fn normalize_union(&mut self, ty: &mut Type, preserve_specified: bool) {
+    pub(super) fn normalize_union(&self, ty: &mut Type, preserve_specified: bool) {
         let _tracing = dev_span!("normalize_union");
 
         let start = Instant::now();

--- a/crates/stc_ts_file_analyzer/src/analyzer/function/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/function/mod.rs
@@ -267,7 +267,7 @@ impl Analyzer<'_, '_> {
 }
 
 impl Analyzer<'_, '_> {
-    pub(crate) fn fn_to_type_element(&mut self, f: &Function) -> VResult<TypeElement> {
+    pub(crate) fn fn_to_type_element(&self, f: &Function) -> VResult<TypeElement> {
         Ok(TypeElement::Call(CallSignature {
             span: f.span.with_ctxt(SyntaxContext::empty()),
             params: f.params.clone(),

--- a/crates/stc_ts_file_analyzer/src/analyzer/generic/expander.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/generic/expander.rs
@@ -92,7 +92,7 @@ impl Analyzer<'_, '_> {
     ///z     T extends {
     ///          x: infer P extends number ? infer P : string;
     ///      } ? P : never
-    pub(in super::super) fn expand_type_params<T>(&mut self, params: &FxHashMap<Id, Type>, ty: T, opts: ExpandGenericOpts) -> VResult<T>
+    pub(in super::super) fn expand_type_params<T>(&self, params: &FxHashMap<Id, Type>, ty: T, opts: ExpandGenericOpts) -> VResult<T>
     where
         T: for<'aa> FoldWith<GenericExpander<'aa>> + Fix,
     {

--- a/crates/stc_ts_file_analyzer/src/analyzer/generic/inference.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/generic/inference.rs
@@ -978,7 +978,7 @@ impl Analyzer<'_, '_> {
     /// let e5 = f(data, data2); // Error
     /// ```
     pub(super) fn insert_inferred_raw(
-        &mut self,
+        &self,
         span: Span,
         inferred: &mut InferData,
         name: Id,
@@ -1024,14 +1024,7 @@ impl Analyzer<'_, '_> {
         self.upsert_inferred(span, inferred, name, &ty, opts)
     }
 
-    pub(super) fn upsert_inferred(
-        &mut self,
-        span: Span,
-        inferred: &mut InferData,
-        name: Id,
-        arg: &Type,
-        opts: InferTypeOpts,
-    ) -> VResult<()> {
+    pub(super) fn upsert_inferred(&self, span: Span, inferred: &mut InferData, name: Id, arg: &Type, opts: InferTypeOpts) -> VResult<()> {
         let arg = match arg.normalize() {
             Type::Union(arg) if opts.exclude_null_and_undefined => {
                 Cow::Owned(Type::new_union(arg.span, arg.types.iter().filter(|ty| !ty.is_null_or_undefined()).cloned()).freezed())
@@ -1224,7 +1217,7 @@ impl Analyzer<'_, '_> {
 
     /// Infer types, using `param` and `arg`.
     pub(crate) fn infer_type_with_types(
-        &mut self,
+        &self,
         span: Span,
         type_params: &[TypeParam],
         param: &Type,

--- a/crates/stc_ts_file_analyzer/src/analyzer/generic/inference.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/generic/inference.rs
@@ -777,7 +777,7 @@ impl Analyzer<'_, '_> {
     }
 
     /// Ported from `inferTypesFromTemplateLiteralType` of `tsc`.
-    pub(crate) fn infer_types_from_tpl_lit_type(&mut self, span: Span, source: &Type, target: &TplType) -> VResult<Option<Vec<Type>>> {
+    pub(crate) fn infer_types_from_tpl_lit_type(&self, span: Span, source: &Type, target: &TplType) -> VResult<Option<Vec<Type>>> {
         match source.normalize() {
             Type::Lit(LitType {
                 lit: RTsLit::Str(source), ..
@@ -837,7 +837,7 @@ impl Analyzer<'_, '_> {
     #[allow(unused_assignments)]
     #[allow(clippy::needless_range_loop)]
     fn infer_from_lit_parts_to_tpl_lit(
-        &mut self,
+        &self,
         span: Span,
         source_texts: &[Atom],
         source_types: &[Type],
@@ -944,7 +944,7 @@ impl Analyzer<'_, '_> {
     }
 
     pub(super) fn insert_inferred(
-        &mut self,
+        &self,
         span: Span,
         inferred: &mut InferData,
         tp: &TypeParam,
@@ -1246,7 +1246,7 @@ impl Analyzer<'_, '_> {
     /// Handle some special builtin types
 
     pub(super) fn infer_builtin(
-        &mut self,
+        &self,
         span: Span,
         inferred: &mut InferData,
         param: &Type,
@@ -1352,7 +1352,7 @@ impl Analyzer<'_, '_> {
     }
 
     fn infer_type_using_interface_and_interface(
-        &mut self,
+        &self,
         span: Span,
         inferred: &mut InferData,
         param: &Interface,
@@ -1366,7 +1366,7 @@ impl Analyzer<'_, '_> {
 
     /// Compare fields.
     pub(super) fn infer_type_using_type_lit_and_type_lit(
-        &mut self,
+        &self,
         span: Span,
         inferred: &mut InferData,
         param: &TypeLit,
@@ -1378,7 +1378,7 @@ impl Analyzer<'_, '_> {
 
     /// Returns `Ok(true)` if this method know how to infer types.
     pub(super) fn infer_type_by_converting_to_type_lit(
-        &mut self,
+        &self,
         span: Span,
         inferred: &mut InferData,
         param: &Type,
@@ -1406,7 +1406,7 @@ impl Analyzer<'_, '_> {
     }
 
     fn infer_type_using_type_elements_and_type_elements(
-        &mut self,
+        &self,
         span: Span,
         inferred: &mut InferData,
         param: &[TypeElement],

--- a/crates/stc_ts_file_analyzer/src/analyzer/generic/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/generic/mod.rs
@@ -487,7 +487,7 @@ impl Analyzer<'_, '_> {
     /// arr([1, u]) // Ok
     /// arr([{}, u]) // Ok
     /// ```
-    fn infer_type(&mut self, span: Span, inferred: &mut InferData, param: &Type, arg: &Type, opts: InferTypeOpts) -> VResult<()> {
+    fn infer_type(&self, span: Span, inferred: &mut InferData, param: &Type, arg: &Type, opts: InferTypeOpts) -> VResult<()> {
         if self.config.is_builtin {
             return Ok(());
         }

--- a/crates/stc_ts_file_analyzer/src/analyzer/scope/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/scope/mod.rs
@@ -706,7 +706,7 @@ impl Analyzer<'_, '_> {
     ///  - `expand_union` should be true if you are going to use it in
     ///    assignment, and false if you are going to use it in user-visible
     ///    stuffs (e.g. type annotation for .d.ts file)
-    pub(super) fn expand(&mut self, span: Span, ty: Type, opts: ExpandOpts) -> VResult<Type> {
+    pub(super) fn expand(&self, span: Span, ty: Type, opts: ExpandOpts) -> VResult<Type> {
         let _tracing = dev_span!("expand");
 
         if !self.config.is_builtin {
@@ -2046,7 +2046,7 @@ impl ScopeKind {
 
 struct Expander<'a, 'b, 'c> {
     span: Span,
-    analyzer: &'a mut Analyzer<'b, 'c>,
+    analyzer: &'a Analyzer<'b, 'c>,
     dejavu: FxHashSet<Id>,
     full: bool,
     expand_union: bool,
@@ -2746,7 +2746,7 @@ impl Fold<TypeElement> for Expander<'_, '_, '_> {
 
 /// Calls [`Analyzer::normalize`] on top-level types
 pub struct ShallowNormalizer<'a, 'b, 'c> {
-    analyzer: &'a mut Analyzer<'b, 'c>,
+    analyzer: &'a Analyzer<'b, 'c>,
 }
 
 impl VisitMut<Type> for ShallowNormalizer<'_, '_, '_> {

--- a/crates/stc_ts_file_analyzer/src/analyzer/scope/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/scope/mod.rs
@@ -746,7 +746,7 @@ impl Analyzer<'_, '_> {
     }
 
     /// Expands the type if it's [Type::Ref].
-    pub(crate) fn expand_top_ref<'a>(&mut self, span: Span, ty: Cow<'a, Type>, opts: ExpandOpts) -> VResult<Cow<'a, Type>> {
+    pub(crate) fn expand_top_ref<'a>(&self, span: Span, ty: Cow<'a, Type>, opts: ExpandOpts) -> VResult<Cow<'a, Type>> {
         ty.assert_valid();
 
         if !ty.is_ref_type() {

--- a/crates/stc_ts_file_analyzer/src/analyzer/types/conditional.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/types/conditional.rs
@@ -202,7 +202,7 @@ impl Analyzer<'_, '_> {
         }
     }
 
-    pub(crate) fn overwrite_conditional(&mut self, span: Span, c: &Conditional) -> Type {
+    pub(crate) fn overwrite_conditional(&self, span: Span, c: &Conditional) -> Type {
         if Self::has_type_param_for_conditional(&c.check_type) {
             if c.check_type.type_eq(&c.true_type) {
                 Type::new_intersection(span, [*(c.check_type).clone(), *(c.extends_type).clone()]).freezed()

--- a/crates/stc_ts_file_analyzer/src/analyzer/types/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/types/mod.rs
@@ -797,7 +797,7 @@ impl Analyzer<'_, '_> {
         }
     }
 
-    pub(crate) fn normalize_intersection_types(&mut self, span: Span, types: &[Type], opts: NormalizeTypeOpts) -> VResult<Option<Type>> {
+    pub(crate) fn normalize_intersection_types(&self, span: Span, types: &[Type], opts: NormalizeTypeOpts) -> VResult<Option<Type>> {
         macro_rules! never {
             () => {{
                 Ok(Some(Type::Keyword(KeywordType {
@@ -2243,7 +2243,7 @@ impl Analyzer<'_, '_> {
     }
 
     pub(crate) fn report_error_for_unresolved_type(
-        &mut self,
+        &self,
         span: Span,
         type_name: &RExpr,
         type_args: Option<&TypeParamInstantiation>,

--- a/crates/stc_ts_file_analyzer/src/analyzer/types/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/types/mod.rs
@@ -1197,7 +1197,7 @@ impl Analyzer<'_, '_> {
     }
 
     fn normalize_intersection_of_type_elements(
-        &mut self,
+        &self,
         span: Span,
         elements: &[TypeElement],
         property_types: &mut Vec<TypeElement>,
@@ -1550,7 +1550,7 @@ impl Analyzer<'_, '_> {
     /// ## excluded
     ///
     /// Members of base class.
-    pub(crate) fn collect_class_members(&mut self, excluded: &[&ClassMember], ty: &Type) -> VResult<Option<Vec<ClassMember>>> {
+    pub(crate) fn collect_class_members(&self, excluded: &[&ClassMember], ty: &Type) -> VResult<Option<Vec<ClassMember>>> {
         if self.config.is_builtin {
             return Ok(None);
         }
@@ -1916,7 +1916,7 @@ impl Analyzer<'_, '_> {
         }))
     }
 
-    fn merge_type_elements(&mut self, span: Span, mut els: Vec<TypeElement>) -> VResult<Vec<TypeElement>> {
+    fn merge_type_elements(&self, span: Span, mut els: Vec<TypeElement>) -> VResult<Vec<TypeElement>> {
         run(|| {
             // As merging is not common, we optimize it by creating a new vector only if
             // there's a conflict

--- a/crates/stc_ts_file_analyzer/src/analyzer/types/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/types/mod.rs
@@ -1970,7 +1970,7 @@ impl Analyzer<'_, '_> {
         .with_context(|| "tried to merge type elements".to_string())
     }
 
-    fn merge_type_element(&mut self, span: Span, to: &mut TypeElement, from: TypeElement) -> VResult<()> {
+    fn merge_type_element(&self, span: Span, to: &mut TypeElement, from: TypeElement) -> VResult<()> {
         run(|| match (to, from) {
             (TypeElement::Property(to), TypeElement::Property(from)) => {
                 if let Some(to_type) = &to.type_ann {

--- a/crates/stc_ts_file_analyzer/src/analyzer/types/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/types/mod.rs
@@ -102,7 +102,7 @@ impl Analyzer<'_, '_> {
     ///
     /// If `span` is provided, it will be used for types **created** by the
     /// method. Otherwise the span of the original type is used.
-    pub(crate) fn normalize<'a>(&mut self, span: Option<Span>, mut ty: Cow<'a, Type>, opts: NormalizeTypeOpts) -> VResult<Cow<'a, Type>> {
+    pub(crate) fn normalize<'a>(&self, span: Option<Span>, mut ty: Cow<'a, Type>, opts: NormalizeTypeOpts) -> VResult<Cow<'a, Type>> {
         let _tracing = if cfg!(debug_assertions) {
             let ty = force_dump_type_as_string(&ty);
 

--- a/crates/stc_ts_file_analyzer/src/analyzer/types/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/types/mod.rs
@@ -1604,7 +1604,7 @@ impl Analyzer<'_, '_> {
     /// Note: `span` is only used while expanding type (to prevent
     /// panic) in the case of [Type::Ref].
     pub(crate) fn convert_type_to_type_lit<'a>(
-        &mut self,
+        &self,
         span: Span,
         ty: Cow<'a, Type>,
         opts: ConvertTypeToLitOpts,


### PR DESCRIPTION
**Description:**

This is required for #1042, which requires to recurse into self.

**Related issue (if exists):**
