### PR TITLE
fix: "false" | "true" when bool tpl

### DIFF
--- a/crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/assign/mod.rs
@@ -551,7 +551,6 @@ impl Analyzer<'_, '_> {
                         },
                     )?
                     .into_owned();
-
                 return Ok(Cow::Owned(ty));
             }
             _ => {}
@@ -580,7 +579,6 @@ impl Analyzer<'_, '_> {
         let _stack = stack::track(opts.span)?;
 
         data.dejavu.push((left.clone(), right.clone()));
-
         let res = self.assign_without_wrapping(data, left, right, opts).with_context(|| {
             //
             let l = force_dump_type_as_string(left);

--- a/crates/stc_ts_type_checker/tests/conformance/types/literal/templateLiteralTypesPatterns.error-diff.json
+++ b/crates/stc_ts_type_checker/tests/conformance/types/literal/templateLiteralTypesPatterns.error-diff.json
@@ -1,10 +1,9 @@
 {
   "required_errors": {
-    "TS2345": 2
+    "TS2345": 1
   },
   "required_error_lines": {
     "TS2345": [
-      37,
       105
     ]
   },

--- a/crates/stc_ts_type_checker/tests/conformance/types/literal/templateLiteralTypesPatterns.stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/conformance/types/literal/templateLiteralTypesPatterns.stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
-    required_error: 2,
-    matched_error: 55,
+    required_error: 1,
+    matched_error: 56,
     extra_error: 1,
     panic: 0,
 }

--- a/crates/stc_ts_type_checker/tests/tsc-stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/tsc-stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
-    required_error: 3535,
-    matched_error: 6500,
+    required_error: 3534,
+    matched_error: 6501,
     extra_error: 771,
     panic: 74,
 }


### PR DESCRIPTION
```ts
declare function nullishes(x: `${null | undefined}`): void;
nullishes("false"); // error should be reported
```
Adds error to above code. But if `boolean` is included in the union, no error

```ts
declare function nullishes(x: `${null | undefined | boolean}`): void;
nullishes("false"); // no error
```
