### PR TITLE
fix: consider tpl with no types as string

### DIFF
--- a/crates/stc_ts_file_analyzer/src/analyzer/assign/tpl.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/assign/tpl.rs
@@ -134,9 +134,21 @@ impl Analyzer<'_, '_> {
             }
 
             Type::Tpl(source) => {
+                if source.quasis.len() == 1 && source.types.is_empty() {
+                    let ty = Type::Lit(LitType {
+                        span,
+                        lit: RTsLit::Str(source.quasis[0].clone().value.into()),
+                        metadata: Default::default(),
+                        tracker: Default::default(),
+                    });
+
+                    return self.is_valid_type_for_tpl_lit_placeholder(span, &ty, target);
+                }
+
                 if source.quasis.len() == 2 && source.quasis[0].value == "" && source.quasis[1].value == "" {
                     // TODO(kdy1): Return `Ok(self.is_type_assignable_to(span, &source.types[0],
                     // target))` instead
+
                     if self.is_type_assignable_to(span, &source.types[0], target) {
                         return Ok(true);
                     }

--- a/crates/stc_ts_file_analyzer/tests/pass-only/assign/tpl/1.ts
+++ b/crates/stc_ts_file_analyzer/tests/pass-only/assign/tpl/1.ts
@@ -1,0 +1,12 @@
+function f1(a: `100`) {
+  let x: `${number}`;
+  x = `${a}`;
+}
+function f2(a: `true`) {
+  let x: `${boolean}`;
+  x = `${a}`;
+}
+function f3(a: `false`) {
+  let x: `${boolean}`;
+  x = `${a}`;
+}


### PR DESCRIPTION
**Description:**

The following all failed

```ts
function f1(a: `100`) {
  let x: `${number}`;
  x = `${a}`; // incorrect 2322
}
function f2(a: `true`) {
  let x: `${boolean}`;
  x = `${a}`; // incorrect 2322
}
function f3(a: `false`) {
  let x: `${boolean}`;
  x = `${a}`; // incorrect 2322
}
```

This happened because the case of a `tpl` having 0 types was not handled.

No test case covered this so I added new ones in `pass-only`

