### PR TITLE
fix: numeric strings to tpl bigint type

### DIFF
--- a/crates/stc_ts_file_analyzer/src/analyzer/tsc_helper.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/tsc_helper.rs
@@ -72,7 +72,13 @@ impl Analyzer<'_, '_> {
         } else if s.starts_with("0b") || s.starts_with("0B") {
             BigInt::parse_bytes(s[2..].as_bytes(), 2)
         } else {
-            s.parse::<BigInt>().ok()
+            // BigInt strings only accepts numbers
+            // 1000n or 1_000n are both considered invalid
+            if s.parse::<i64>().is_ok() {
+                s.parse::<BigInt>().ok()
+            } else {
+                None
+            }
         };
         if let Some(v) = v {
             !round_trip_only || v.to_string() == s

--- a/crates/stc_ts_file_analyzer/src/analyzer/tsc_helper.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/tsc_helper.rs
@@ -72,9 +72,15 @@ impl Analyzer<'_, '_> {
         } else if s.starts_with("0b") || s.starts_with("0B") {
             BigInt::parse_bytes(s[2..].as_bytes(), 2)
         } else {
+            let unsigned_literal = s.strip_prefix('-').unwrap_or(s);
+
+            // numeric string starting with more than one 0 are incorrect
+            if unsigned_literal.starts_with("00") {
+                None
+            }
             // BigInt strings only accepts numbers
             // 1000n or 1_000n are both considered invalid
-            if s.parse::<i64>().is_ok() {
+            else if unsigned_literal.chars().all(|c| c.is_ascii_digit()) {
                 s.parse::<BigInt>().ok()
             } else {
                 None

--- a/crates/stc_ts_type_checker/tests/conformance/types/literal/templateLiteralTypesPatterns.error-diff.json
+++ b/crates/stc_ts_type_checker/tests/conformance/types/literal/templateLiteralTypesPatterns.error-diff.json
@@ -1,12 +1,6 @@
 {
-  "required_errors": {
-    "TS2345": 1
-  },
-  "required_error_lines": {
-    "TS2345": [
-      105
-    ]
-  },
+  "required_errors": {},
+  "required_error_lines": {},
   "extra_errors": {
     "TS2339": 1
   },

--- a/crates/stc_ts_type_checker/tests/conformance/types/literal/templateLiteralTypesPatterns.stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/conformance/types/literal/templateLiteralTypesPatterns.stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
-    required_error: 1,
-    matched_error: 56,
+    required_error: 0,
+    matched_error: 57,
     extra_error: 1,
     panic: 0,
 }

--- a/crates/stc_ts_type_checker/tests/tsc-stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/tsc-stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
-    required_error: 3519,
-    matched_error: 6516,
+    required_error: 3518,
+    matched_error: 6517,
     extra_error: 771,
     panic: 74,
 }


### PR DESCRIPTION
**Description:**

A `bigint` type of a tpl accepted values like `100_000` or `10e3` but that should not happen as it should only accept numeric strings (without separators or scientific notation)

```ts
declare function bigints(x: `${bigint}`): void;
bigints("100_000"); // should 2345
```