### PR TITLE
fix stmt ordering

### DIFF
--- a/crates/stc_ts_ordering/src/calc.rs
+++ b/crates/stc_ts_ordering/src/calc.rs
@@ -49,7 +49,9 @@ where
             let deps = self.declared_by.get(used);
 
             if let Some(deps) = deps {
-                buf.extend(deps.iter());
+                if let Some(min) = deps.iter().min() {
+                    buf.push(*min)
+                }
             }
         }
 

--- a/crates/stc_ts_type_checker/tests/conformance/types/rest/objectRest.error-diff.json
+++ b/crates/stc_ts_type_checker/tests/conformance/types/rest/objectRest.error-diff.json
@@ -18,13 +18,6 @@
       45
     ]
   },
-  "extra_errors": {
-    "TS2304": 2
-  },
-  "extra_error_lines": {
-    "TS2304": [
-      44,
-      44
-    ]
-  }
+  "extra_errors": {},
+  "extra_error_lines": {}
 }

--- a/crates/stc_ts_type_checker/tests/conformance/types/rest/objectRest.stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/conformance/types/rest/objectRest.stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
     required_error: 6,
     matched_error: 0,
-    extra_error: 2,
+    extra_error: 0,
     panic: 0,
 }

--- a/crates/stc_ts_type_checker/tests/tsc-stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/tsc-stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
     required_error: 3518,
     matched_error: 6517,
-    extra_error: 771,
+    extra_error: 769,
     panic: 74,
 }


### PR DESCRIPTION
<!-- Note: CI script will automatically rebase your PR so please do not rebase unless required -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**
fix the ordering of statements when variables are erroneously declared multiple times

```javascript
var a = {}
var { } = a;

let b = 'a';
var {  [b]: soSo,  ...a } = a; // this errorneous re-declaration of var `a` hoists the line above the declaration of `b`

``` 

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**BREAKING CHANGE:**

<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG. Add description or remove entirely if not breaking.

You may need to update `MIGRATION.md` for the breaking changes.
-->

**Related issue (if exists):**
