### PR TITLE
fix: Fix panic from `parse().unwrap()` at generic inference

### DIFF
--- a/crates/stc_ts_file_analyzer/src/analyzer/generic/inference.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/generic/inference.rs
@@ -533,6 +533,7 @@ impl Analyzer<'_, '_> {
                 // variable whose constraint includes one of the
                 // allowed template literal placeholder types, infer from a
                 // literal type corresponding to the constraint.
+                // ref: https://github.com/microsoft/TypeScript/blob/b5557271a51704e0469dd86974335a4775a68ffd/src/compiler/checker.ts#L25342
                 if source.is_str_lit() && (target.is_type_param() || target.is_infer()) {
                     if let Type::Infer(InferType {
                         type_param:

--- a/crates/stc_ts_file_analyzer/src/analyzer/generic/inference.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/generic/inference.rs
@@ -624,16 +624,24 @@ impl Analyzer<'_, '_> {
                                         }
 
                                         if r.is_num() {
-                                            return Type::Lit(LitType {
-                                                span,
-                                                lit: RTsLit::Number(RNumber {
-                                                    span,
-                                                    value: src.parse().unwrap(),
-                                                    raw: None,
-                                                }),
-                                                metadata: Default::default(),
-                                                tracker: Default::default(),
-                                            });
+                                            match src.parse() {
+                                                Ok(v) => {
+                                                    return Type::Lit(LitType {
+                                                        span,
+                                                        lit: RTsLit::Number(RNumber { span, value: v, raw: None }),
+                                                        metadata: Default::default(),
+                                                        tracker: Default::default(),
+                                                    })
+                                                }
+                                                Err(..) => {
+                                                    return Type::Keyword(KeywordType {
+                                                        span,
+                                                        kind: TsKeywordTypeKind::TsNumberKeyword,
+                                                        metadata: Default::default(),
+                                                        tracker: Default::default(),
+                                                    })
+                                                }
+                                            }
                                         }
 
                                         if l.is_enum_type() || l.is_enum_variant() {


### PR DESCRIPTION
<!-- Note: CI script will automatically rebase your PR so please do not rebase unless required -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

```rs
 if r.is_num() {
      match src.parse() {
          Ok(v) => {
              return Type::Lit(LitType {
                  span,
                  lit: RTsLit::Number(RNumber { span, value: v, raw: None }),
                  metadata: Default::default(),
                  tracker: Default::default(),
              })
          }
          Err(..) => {
              return Type::Keyword(KeywordType {
                  span,
                  kind: TsKeywordTypeKind::TsNumberKeyword,
                  metadata: Default::default(),
                  tracker: Default::default(),
              })
          }
      }
  }
```
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**BREAKING CHANGE:**

<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG. Add description or remove entirely if not breaking.

You may need to update `MIGRATION.md` for the breaking changes.
-->

**Related issue (if exists):**
