### PR TITLE
feat: Remove extra error at `interfaceExtendsObjectIntersectionErrors`

### DIFF
--- a/crates/stc_ts_file_analyzer/src/analyzer/convert/interface.rs
+++ b/crates/stc_ts_file_analyzer/src/analyzer/convert/interface.rs
@@ -62,6 +62,11 @@ impl Analyzer<'_, '_> {
             };
 
             if let Err(err) = res {
+                if err.code() == 2304 {
+                    // TypeNotFound
+                    return;
+                }
+
                 self.storage.report(
                     ErrorKind::InvalidInterfaceInheritance {
                         span,

--- a/crates/stc_ts_file_analyzer/tests/tsc/types/interface/interfaceDeclaration/1.ts
+++ b/crates/stc_ts_file_analyzer/tests/tsc/types/interface/interfaceDeclaration/1.ts
@@ -1,0 +1,3 @@
+// @strictNullChecks: true
+
+interface I31<T> extends T { x: string }

--- a/crates/stc_ts_file_analyzer/tests/tsc/types/interface/interfaceDeclaration/1.tsc-errors.json
+++ b/crates/stc_ts_file_analyzer/tests/tsc/types/interface/interfaceDeclaration/1.tsc-errors.json
@@ -1,0 +1,8 @@
+[
+  {
+    "file": "tests/tsc/types/interface/interfaceDeclaration/1.ts",
+    "line": 3,
+    "col": 26,
+    "code": 2312
+  }
+]

--- a/crates/stc_ts_type_checker/tests/conformance/interfaces/interfaceDeclarations/interfaceExtendsObjectIntersectionErrors.error-diff.json
+++ b/crates/stc_ts_type_checker/tests/conformance/interfaces/interfaceDeclarations/interfaceExtendsObjectIntersectionErrors.error-diff.json
@@ -32,12 +32,6 @@
       48
     ]
   },
-  "extra_errors": {
-    "TS2430": 1
-  },
-  "extra_error_lines": {
-    "TS2430": [
-      49
-    ]
-  }
+  "extra_errors": {},
+  "extra_error_lines": {}
 }

--- a/crates/stc_ts_type_checker/tests/conformance/interfaces/interfaceDeclarations/interfaceExtendsObjectIntersectionErrors.stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/conformance/interfaces/interfaceDeclarations/interfaceExtendsObjectIntersectionErrors.stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
     required_error: 14,
     matched_error: 9,
-    extra_error: 1,
+    extra_error: 0,
     panic: 0,
 }

--- a/crates/stc_ts_type_checker/tests/tsc-stats.rust-debug
+++ b/crates/stc_ts_type_checker/tests/tsc-stats.rust-debug
@@ -1,6 +1,6 @@
 Stats {
     required_error: 2861,
     matched_error: 7174,
-    extra_error: 1086,
+    extra_error: 1085,
     panic: 3,
 }


### PR DESCRIPTION
<!-- Note: CI script will automatically rebase your PR so please do not rebase unless required -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

```ts
interface I31<T> extends T { x: string }
```

I have a concern.

The following functions cause duplicate error handling due to duplicate function calls.

```rs
#[validator]
impl Analyzer<'_, '_> {
    fn validate(&mut self, d: &RTsInterfaceDecl) -> VResult<Type> {
        let ty = self.with_child(ScopeKind::Flow, Default::default(), |child: &mut Analyzer| -> VResult<_> {
            match &*d.id.sym {
                "any" | "void" | "never" | "unknown" | "string" | "number" | "bigint" | "boolean" | "null" | "undefined" | "symbol" => {
                    child.storage.report(ErrorKind::InvalidInterfaceName { span: d.id.span }.into());
                }
                _ => {}
            }

            let mut ty = Interface {
                span: d.span,
                name: d.id.clone().into(),
                type_params: try_opt!(d.type_params.validate_with(&mut *child).map(|v| v.map(Box::new))),
                extends: d.extends.validate_with(child)?.freezed(),
                body: d.body.validate_with(child)?,
                metadata: Default::default(),
                tracker: Default::default(),
            };
            child.prevent_expansion(&mut ty.body);
            ty.body.freeze();

            child.resolve_parent_interfaces(&d.extends, true);
            child.report_error_for_conflicting_parents(d.id.span, &ty.extends);
            child.report_error_for_wrong_interface_inheritance(d.id.span, &ty.body, &ty.extends);

            let ty = Type::Interface(ty).freezed();

            Ok(ty)
        })?;

        // TODO(kdy1): Recover
        self.register_type(d.id.clone().into(), ty.clone());

        Ok(ty)
    }
}
```

`child.resolve_parent_interfaces` and `child.report_error_for_wrong_interface_inheritance` call `report_error_for_unresolved_type`
this fn cause `ErrorKind::TypeNotFound`

This PR only clogs the hole.

If there seems to be a need for fundamental improvement, please open up the issue

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**BREAKING CHANGE:**

<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG. Add description or remove entirely if not breaking.

You may need to update `MIGRATION.md` for the breaking changes.
-->

**Related issue (if exists):**
